### PR TITLE
Add Gitpod config file

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "camino-matrix-go"]
 	path = camino-matrix-go
-	url = ../camino-matrix-go.git
+	url = https://github.com/chain4travel/camino-matrix-go.git
 	

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,10 @@
+tasks:
+  - name: Main
+    before: echo -e "\e[93mBot is compiling in the terminal on the right...\e[0m"
+    init: echo -e "\e[96mFor more info https://docs.camino.network/camino-messenger/bot/\e[0m"
+    command: echo -e '\e[92mTry "./bot --help" when compilation is finished!\e[0m'
+  - name: Compile Bot
+    before: sudo apt install -y libolm-dev
+    init: echo "Installing Go modules..." && git submodule update --init && go mod download
+    command: echo "Compiling bot..." && go build -o bot cmd/camino-messenger-bot/main.go
+    openMode: split-right


### PR DESCRIPTION
This PR adds a config file gor gitpod.io. Config file, upon the start of a workspace, installs the dependencies, initializes the submodule and then compiles the bot. Also updated the submodule to an absolute path.

For testing:
* Go to https://gitpod.io/workspaces
* Login with your github account
* Click "New Workspace"
* Provide URL of the fork: https://github.com/havan/camino-messenger-bot 
* Click "Continue". Workspace will be created and the compilation will start automatically. After finished, leaving you with a ready development environment.

![Screenshot from 2024-04-18 02-30-18](https://github.com/chain4travel/camino-messenger-bot/assets/18965/89d78cce-fb90-449b-b978-746161a262fd)

![Screenshot from 2024-04-18 02-31-05](https://github.com/chain4travel/camino-messenger-bot/assets/18965/c5cae94f-dcab-4a14-8832-2ac81f21e815)

