### PR TITLE
Update example config files and docker compose

### DIFF
--- a/camino-messenger-bot-distributor.yaml.example
+++ b/camino-messenger-bot-distributor.yaml.example
@@ -71,3 +71,10 @@ booking_token_abi_file: abi/BookingTokenV0.abi
 # Supplier name to be used for registering to the BookingToken smart contract.
 # Should be a short name, it will be saved on-chain. Not used with distributor bot.
 #supplier_name: SUPPLIER_NAME
+
+# Default expiration time (in seconds) for BookingToken mints.
+#
+# The supplier bot creates booking tokens and sets an expiration timestamp on each token.
+# Once this time has passed, the token is no longer available for purchase by the distributor.
+# The default value is 600 seconds.
+#buyable_until_default: 600

--- a/camino-messenger-bot-supplier.yaml.example
+++ b/camino-messenger-bot-supplier.yaml.example
@@ -80,3 +80,10 @@ booking_token_abi_file: abi/BookingTokenV0.abi
 # Supplier name to be used for registering to the BookingToken smart contract.
 # Should be a short name, it will be saved on-chain.
 supplier_name: SUPPLIER_NAME
+
+# Default expiration time (in seconds) for BookingToken mints.
+#
+# The supplier bot creates booking tokens and sets an expiration timestamp on each token.
+# Once this time has passed, the token is no longer available for purchase by the distributor.
+# The default value is 600 seconds.
+buyable_until_default: 600

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 version: "3"
 services:
-  provider-bot:
+  supplier-bot:
     image: c4tplatform/camino-messenger-bot
     build:
       context: .
@@ -9,13 +9,13 @@ services:
       CMB_DEVELOPER_MODE: "true"
       CMB_MATRIX_KEY: "PrivateKey-THE_REST_OF_THE_KEY"
       CMB_MATRIX_HOST: "matrix.camino.network"
-      CMB_MATRIX_STORE: "mautrix-localhost.db"
+      CMB_MATRIX_STORE: "supplier-matrix.db"
       CMB_RPC_SERVER_PORT: "9090"
       CMB_RPC_UNENCRYPTED: "true"
       CMB_PARTNER_PLUGIN_HOST: "localhost"
       CMB_PARTNER_PLUGIN_PORT: "50051"
       CMB_PARTNER_PLUGIN_UNENCRYPTED: "true"
-      CMB_RESPONSE_TIMEOUT: "6000"
+      CMB_RESPONSE_TIMEOUT: "10000"
       CMB_SUPPORTED_REQUEST_TYPES: "ActivitySearchRequest,AccommodationSearchRequest,GetNetworkFeeRequest,GetPartnerConfigurationRequest,PingRequest,TransportSearchRequest,MintRequest,ValidationRequest"
       CMB_RPC_URL: "https://columbus.camino.network/ext/bc/C/rpc"
       CMB_BOOKING_TOKEN_ABI_FILE: abi/BookingTokenV0.abi
@@ -33,14 +33,11 @@ services:
       CMB_DEVELOPER_MODE: "true"
       CMB_MATRIX_KEY: "PrivateKey-THE_REST_OF_THE_KEY"
       CMB_MATRIX_HOST: "matrix.camino.network"
-      CMB_MATRIX_STORE: "mautrix-localhost.db"
+      CMB_MATRIX_STORE: "distributor-matrix.db"
       CMB_RPC_SERVER_PORT: "9090"
       CMB_RPC_UNENCRYPTED: "true"
-      CMB_PARTNER_PLUGIN_HOST: "localhost"
-      CMB_PARTNER_PLUGIN_PORT: "50052"
-      CMB_PARTNER_PLUGIN_UNENCRYPTED: "true"
-      CMB_RESPONSE_TIMEOUT: "6000"
-      CMB_SUPPORTED_REQUEST_TYPES: "ActivitySearchRequest,AccommodationSearchRequest,GetNetworkFeeRequest,GetPartnerConfigurationRequest,PingRequest,TransportSearchRequest,MintRequest,ValidationRequest"
+      CMB_RESPONSE_TIMEOUT: "10000"
+      CMB_SUPPORTED_REQUEST_TYPES: "GetNetworkFeeRequest,GetPartnerConfigurationRequest,PingRequest"
       CMB_RPC_URL: "https://columbus.camino.network/ext/bc/C/rpc"
       CMB_BOOKING_TOKEN_ABI_FILE: "abi/BookingTokenV0.abi"
       CMB_EVM_PRIVATE_KEY: "PrivateKey-THE_REST_OF_THE_KEY"


### PR DESCRIPTION
This PR adds the new `buyable_until_default` config file into the example configuration files and Docker Compose file.

Also updates provider --> supplier in Docker Compose file and db file names.