### PR TITLE
Fixing example configs

### DIFF
--- a/examples/config/camino-messenger-bot-distributor-camino.yaml
+++ b/examples/config/camino-messenger-bot-distributor-camino.yaml
@@ -18,7 +18,7 @@ developer_mode: true
 matrix_key: YOUR_PRIVATE_KEY_HEX
 
 # Hostname of the Matrix Server
-matrix_host: dev.messenger.chain4travel.com
+matrix_host: messenger.chain4travel.com
 
 # Local DB file to store Matrix data
 matrix_store: distributor-matrix.db

--- a/examples/config/camino-messenger-bot-supplier-camino.yaml
+++ b/examples/config/camino-messenger-bot-supplier-camino.yaml
@@ -18,7 +18,7 @@ developer_mode: true
 matrix_key: YOUR_PRIVATE_KEY_HEX
 
 # Hostname of the Matrix Server
-matrix_host: dev.messenger.chain4travel.com
+matrix_host: messenger.chain4travel.com
 
 # Local DB file to store Matrix data
 matrix_store: supplier-matrix.db


### PR DESCRIPTION
Changed host for camino also to messenger.chain4travel.com in example configs.