### PR TITLE
Config rpc enable flags, fixed logger setup

### DIFF
--- a/cmd/camino_messenger_bot.go
+++ b/cmd/camino_messenger_bot.go
@@ -49,7 +49,7 @@ func rootFunc(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("failed to read config: %w", err)
 	}
 
-	sugaredConfigReaderLogger.Sync()
+	_ = sugaredConfigReaderLogger.Sync()
 
 	var zapLogger *zap.Logger
 	if configReader.IsDevelopmentMode() {

--- a/cmd/camino_messenger_bot.go
+++ b/cmd/camino_messenger_bot.go
@@ -28,9 +28,29 @@ var rootCmd = &cobra.Command{
 }
 
 func rootFunc(cmd *cobra.Command, _ []string) error {
-	configReader := config.NewConfigReader(cmd.Flags())
+	configReaderLogger, err := zap.NewProduction()
+	if err != nil {
+		return fmt.Errorf("failed to create config-reader logger: %w", err)
+	}
 
-	var err error
+	sugaredConfigReaderLogger := configReaderLogger.Sugar()
+	defer func() { _ = sugaredConfigReaderLogger.Sync() }()
+
+	configReader, err := config.NewConfigReader(cmd.Flags(), sugaredConfigReaderLogger)
+	if err != nil {
+		return fmt.Errorf("failed to create config reader: %w", err)
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	cfg, err := configReader.ReadConfig()
+	if err != nil {
+		return fmt.Errorf("failed to read config: %w", err)
+	}
+
+	sugaredConfigReaderLogger.Sync()
+
 	var zapLogger *zap.Logger
 	if configReader.IsDevelopmentMode() {
 		zapLogger, err = zap.NewDevelopment()
@@ -45,15 +65,6 @@ func rootFunc(cmd *cobra.Command, _ []string) error {
 	defer func() { _ = logger.Sync() }()
 
 	logger.Infof("App version: %s (git: %s)", Version, GitCommit)
-
-	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
-	defer stop()
-
-	cfg, err := configReader.ReadConfig(logger)
-	if err != nil {
-		logger.Error(err)
-		return err
-	}
 
 	app, err := app.NewApp(ctx, cfg, logger)
 	if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -49,6 +49,7 @@ type TracingConfig struct {
 }
 
 type PartnerPluginConfig struct {
+	Enabled     bool
 	HostURL     url.URL
 	Unencrypted bool
 	CACertFile  string
@@ -70,6 +71,7 @@ type DBConfig struct {
 }
 
 type RPCServerConfig struct {
+	Enabled        bool   `mapstructure:"enabled"`
 	Port           uint64 `mapstructure:"port"`
 	Unencrypted    bool   `mapstructure:"unencrypted"`
 	ServerCertFile string `mapstructure:"cert_file"`
@@ -115,6 +117,7 @@ type UnparsedTracingConfig struct {
 }
 
 type UnparsedPartnerPluginConfig struct {
+	Enabled     bool   `mapstructure:"enabled"`
 	Host        string `mapstructure:"host"`
 	Unencrypted bool   `mapstructure:"unencrypted"`
 	CACertFile  string `mapstructure:"ca_file"`
@@ -137,6 +140,7 @@ func (cfg *Config) unparse() *UnparsedConfig {
 			KeyFile:  cfg.Tracing.KeyFile,
 		},
 		PartnerPlugin: UnparsedPartnerPluginConfig{
+			Enabled:     cfg.PartnerPlugin.Enabled,
 			Host:        cfg.PartnerPlugin.HostURL.String(),
 			Unencrypted: cfg.PartnerPlugin.Unencrypted,
 			CACertFile:  cfg.PartnerPlugin.CACertFile,

--- a/config/config_reader.go
+++ b/config/config_reader.go
@@ -26,15 +26,16 @@ var (
 
 type Reader interface {
 	IsDevelopmentMode() bool
-	ReadConfig(logger *zap.SugaredLogger) (*Config, error)
+	ReadConfig() (*Config, error)
 }
 
 // Returns a new config reader.
-func NewConfigReader(flags *pflag.FlagSet) Reader {
+func NewConfigReader(flags *pflag.FlagSet, logger *zap.SugaredLogger) (Reader, error) {
 	return &reader{
-		viper: viper.New(),
-		flags: flags,
-	}
+		viper:  viper.New(),
+		flags:  flags,
+		logger: logger,
+	}, nil
 }
 
 type reader struct {
@@ -47,9 +48,7 @@ func (cr *reader) IsDevelopmentMode() bool {
 	return cr.viper.GetBool(flagKeyDeveloperMode)
 }
 
-func (cr *reader) ReadConfig(logger *zap.SugaredLogger) (*Config, error) {
-	cr.logger = logger
-
+func (cr *reader) ReadConfig() (*Config, error) {
 	cr.viper.SetEnvPrefix(envPrefix)
 	cr.viper.AutomaticEnv()
 	cr.viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))

--- a/config/config_reader.go
+++ b/config/config_reader.go
@@ -131,6 +131,7 @@ func (cr *reader) parseConfig(cfg *UnparsedConfig) (*Config, error) {
 			KeyFile:  cfg.Tracing.KeyFile,
 		},
 		PartnerPlugin: PartnerPluginConfig{
+			Enabled:     cfg.PartnerPlugin.Enabled,
 			HostURL:     *partnerPluginHost,
 			Unencrypted: cfg.PartnerPlugin.Unencrypted,
 			CACertFile:  cfg.PartnerPlugin.CACertFile,

--- a/config/config_reader_test.go
+++ b/config/config_reader_test.go
@@ -62,10 +62,11 @@ func TestReadConfig(t *testing.T) {
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			cr := NewConfigReader(tt.flags)
+			cr, err := NewConfigReader(tt.flags, zap.NewNop().Sugar())
+			require.NoError(t, err)
 			tt.prepare(t, cr.(*reader))
 
-			config, err := cr.ReadConfig(zap.NewNop().Sugar())
+			config, err := cr.ReadConfig()
 			require.ErrorIs(t, err, tt.expectedErr)
 
 			require.NoError(t, unsetEnvFromMap(envPrefix, rawMap))

--- a/config/flags.go
+++ b/config/flags.go
@@ -41,13 +41,13 @@ func Flags() *pflag.FlagSet {
 	flags.String("tracing.key_file", "", "The tracing key file.")
 
 	// Partner plugin config flags
-	flags.Bool("partner_plugin.enabled", false, "Whether the RPC client is enabled or not.")
+	flags.Bool("partner_plugin.enabled", false, "Enable or disable the partner plugin rpc client. It must be enabled if bot's cm account supports at least one service.")
 	flags.String("partner_plugin.host", "localhost:50051", "partner plugin RPC server host.")
 	flags.Bool("partner_plugin.unencrypted", false, "Whether the RPC client should initiate an unencrypted connection with the server.")
 	flags.String("partner_plugin.ca_file", "", "The partner plugin RPC server CA certificate file.")
 
 	// RPC server config flags
-	flags.Bool("rpc_server.enabled", false, "Whether the RPC server is enabled or not.")
+	flags.Bool("rpc_server.enabled", false, "Enable or disable RPC server. It must be enabled if bot is expecting to receive RPC requests (e.g. its distributor bot).")
 	flags.Uint64("rpc_server.port", 9090, "The RPC server port.")
 	flags.Bool("rpc_server.unencrypted", false, "Whether the RPC server should be unencrypted.")
 	flags.String("rpc_server.cert_file", "", "The server certificate file.")

--- a/config/flags.go
+++ b/config/flags.go
@@ -41,11 +41,13 @@ func Flags() *pflag.FlagSet {
 	flags.String("tracing.key_file", "", "The tracing key file.")
 
 	// Partner plugin config flags
+	flags.Bool("partner_plugin.enabled", false, "Whether the RPC client is enabled or not.")
 	flags.String("partner_plugin.host", "localhost:50051", "partner plugin RPC server host.")
 	flags.Bool("partner_plugin.unencrypted", false, "Whether the RPC client should initiate an unencrypted connection with the server.")
 	flags.String("partner_plugin.ca_file", "", "The partner plugin RPC server CA certificate file.")
 
 	// RPC server config flags
+	flags.Bool("rpc_server.enabled", false, "Whether the RPC server is enabled or not.")
 	flags.Uint64("rpc_server.port", 9090, "The RPC server port.")
 	flags.Bool("rpc_server.unencrypted", false, "Whether the RPC server should be unencrypted.")
 	flags.String("rpc_server.cert_file", "", "The server certificate file.")

--- a/config/test_config.yaml
+++ b/config/test_config.yaml
@@ -17,11 +17,13 @@ network_fee_recipient_bot_address: 0xff6BAC3d972680515cbB59fCB6Db6deB13Eb0E91
 network_fee_recipient_cm_account: 0xF6bA5c68A505559c170dC7a30448Ed64D8b9Bc3B
 partner_plugin:
     ca_file: ca-cert.pem
+    enabled: true
     host: localhost:50051
     unencrypted: true
 response_timeout: 10000
 rpc_server:
     cert_file: server-cert.pem
+    enabled: true
     key_file: server-key.pem
     port: 9090
     unencrypted: true

--- a/examples/config/camino-messenger-bot-distributor-camino.yaml
+++ b/examples/config/camino-messenger-bot-distributor-camino.yaml
@@ -71,6 +71,7 @@ matrix:
 
 ### Partner Plugin (NOT USED FOR DISTRIBUTOR BOT)
 # partner_plugin:
+#     # Enable or disable the partner plugin rpc client. It must be enabled if bot's cm account supports at least one service.
 #     enabled: false
 
 #     # Partner Plugin hostname and port, should be reachable from this machine.
@@ -88,6 +89,7 @@ matrix:
 
 ### RPC server
 rpc_server:
+    # Enable or disable RPC server. It must be enabled if bot is expecting to receive RPC requests (e.g. its distributor bot).
     enabled: true
     
     # Listen on this port for incoming RPC requests

--- a/examples/config/camino-messenger-bot-distributor-camino.yaml
+++ b/examples/config/camino-messenger-bot-distributor-camino.yaml
@@ -71,6 +71,8 @@ matrix:
 
 ### Partner Plugin (NOT USED FOR DISTRIBUTOR BOT)
 # partner_plugin:
+#     enabled: false
+
 #     # Partner Plugin hostname and port, should be reachable from this machine.
 #     # Bot tries to connect to this host and port to relay messages that it receives from
 #     # the distributors through Matrix Server
@@ -86,6 +88,8 @@ matrix:
 
 ### RPC server
 rpc_server:
+    enabled: true
+    
     # Listen on this port for incoming RPC requests
     port: 9090
 

--- a/examples/config/camino-messenger-bot-distributor-columbus.yaml
+++ b/examples/config/camino-messenger-bot-distributor-columbus.yaml
@@ -71,6 +71,7 @@ matrix:
 
 ### Partner Plugin (NOT USED FOR DISTRIBUTOR BOT)
 # partner_plugin:
+#     # Enable or disable the partner plugin rpc client. It must be enabled if bot's cm account supports at least one service.
 #     enabled: false
 
 #     # Partner Plugin hostname and port, should be reachable from this machine.
@@ -88,6 +89,7 @@ matrix:
 
 ### RPC server
 rpc_server:
+    # Enable or disable RPC server. It must be enabled if bot is expecting to receive RPC requests (e.g. its distributor bot).
     enabled: true
     
     # Listen on this port for incoming RPC requests

--- a/examples/config/camino-messenger-bot-distributor-columbus.yaml
+++ b/examples/config/camino-messenger-bot-distributor-columbus.yaml
@@ -71,6 +71,8 @@ matrix:
 
 ### Partner Plugin (NOT USED FOR DISTRIBUTOR BOT)
 # partner_plugin:
+#     enabled: false
+
 #     # Partner Plugin hostname and port, should be reachable from this machine.
 #     # Bot tries to connect to this host and port to relay messages that it receives from
 #     # the distributors through Matrix Server
@@ -86,6 +88,8 @@ matrix:
 
 ### RPC server
 rpc_server:
+    enabled: true
+    
     # Listen on this port for incoming RPC requests
     port: 9090
 

--- a/examples/config/camino-messenger-bot-supplier-camino.yaml
+++ b/examples/config/camino-messenger-bot-supplier-camino.yaml
@@ -86,7 +86,7 @@ partner_plugin:
 
 
 
-### RPC server (NOT USED FOR SUPPLIER BOT)
+### RPC server (NOT USED FOR SUPPLIER BOT IN THIS VERSION)
 # rpc_server:
 #     enabled: false
 

--- a/examples/config/camino-messenger-bot-supplier-camino.yaml
+++ b/examples/config/camino-messenger-bot-supplier-camino.yaml
@@ -71,6 +71,7 @@ matrix:
 
 ### Partner Plugin
 partner_plugin:
+    # Enable or disable the partner plugin rpc client. It must be enabled if bot's cm account supports at least one service.
     enabled: true
     
     # Partner Plugin hostname and port, should be reachable from this machine.
@@ -88,6 +89,7 @@ partner_plugin:
 
 ### RPC server (NOT USED FOR SUPPLIER BOT IN THIS VERSION)
 # rpc_server:
+#     # Enable or disable RPC server. It must be enabled if bot is expecting to receive RPC requests (e.g. its distributor bot).
 #     enabled: false
 
 #     # Listen on this port for incoming RPC requests

--- a/examples/config/camino-messenger-bot-supplier-camino.yaml
+++ b/examples/config/camino-messenger-bot-supplier-camino.yaml
@@ -71,6 +71,8 @@ matrix:
 
 ### Partner Plugin
 partner_plugin:
+    enabled: true
+    
     # Partner Plugin hostname and port, should be reachable from this machine.
     # Bot tries to connect to this host and port to relay messages that it receives from
     # the distributors through Matrix Server
@@ -84,16 +86,18 @@ partner_plugin:
 
 
 
-### RPC server
-rpc_server:
-    # Listen on this port for incoming RPC requests
-    port: 9090
+### RPC server (NOT USED FOR SUPPLIER BOT)
+# rpc_server:
+#     enabled: false
 
-    # TLS configuration
-    unencrypted: true
+#     # Listen on this port for incoming RPC requests
+#     port: 9090
 
-    cert_file: server-cert.pem
-    key_file: server-key.pem
+#     # TLS configuration
+#     unencrypted: true
+
+#     cert_file: server-cert.pem
+#     key_file: server-key.pem
 
 
 

--- a/examples/config/camino-messenger-bot-supplier-columbus.yaml
+++ b/examples/config/camino-messenger-bot-supplier-columbus.yaml
@@ -71,6 +71,7 @@ matrix:
 
 ### Partner Plugin
 partner_plugin:
+    # Enable or disable the partner plugin rpc client. It must be enabled if bot's cm account supports at least one service.
     enabled: true
 
     # Partner Plugin hostname and port, should be reachable from this machine.
@@ -88,6 +89,7 @@ partner_plugin:
 
 ### RPC server (NOT USED FOR SUPPLIER BOT IN THIS VERSION)
 # rpc_server:
+#     # Enable or disable RPC server. It must be enabled if bot is expecting to receive RPC requests (e.g. its distributor bot).
 #     enabled: false
 
 #     # Listen on this port for incoming RPC requests

--- a/examples/config/camino-messenger-bot-supplier-columbus.yaml
+++ b/examples/config/camino-messenger-bot-supplier-columbus.yaml
@@ -86,7 +86,7 @@ partner_plugin:
 
 
 
-### RPC server (NOT USED FOR SUPPLIER BOT)
+### RPC server (NOT USED FOR SUPPLIER BOT IN THIS VERSION)
 # rpc_server:
 #     enabled: false
 

--- a/examples/config/camino-messenger-bot-supplier-columbus.yaml
+++ b/examples/config/camino-messenger-bot-supplier-columbus.yaml
@@ -71,6 +71,8 @@ matrix:
 
 ### Partner Plugin
 partner_plugin:
+    enabled: true
+
     # Partner Plugin hostname and port, should be reachable from this machine.
     # Bot tries to connect to this host and port to relay messages that it receives from
     # the distributors through Matrix Server
@@ -84,16 +86,18 @@ partner_plugin:
 
 
 
-### RPC server
-rpc_server:
-    # Listen on this port for incoming RPC requests
-    port: 9090
+### RPC server (NOT USED FOR SUPPLIER BOT)
+# rpc_server:
+#     enabled: false
 
-    # TLS configuration
-    unencrypted: true
+#     # Listen on this port for incoming RPC requests
+#     port: 9090
 
-    cert_file: server-cert.pem
-    key_file: server-key.pem
+#     # TLS configuration
+#     unencrypted: true
+
+#     cert_file: server-cert.pem
+#     key_file: server-key.pem
 
 
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -70,7 +70,7 @@ func NewApp(ctx context.Context, cfg *config.Config, logger *zap.SugaredLogger) 
 	}
 
 	// register supported services, check if they actually supported by bot
-	serviceRegistry, hasSupportedServices, err := messaging.NewServiceRegistry(
+	serviceRegistry, err := messaging.NewServiceRegistry(
 		cfg.CMAccountAddress,
 		evmClient,
 		logger,
@@ -79,10 +79,6 @@ func NewApp(ctx context.Context, cfg *config.Config, logger *zap.SugaredLogger) 
 	if err != nil {
 		logger.Errorf("Failed to create service registry: %v", err)
 		return nil, err
-	}
-
-	if !hasSupportedServices && cfg.PartnerPlugin.Enabled {
-		logger.Warn("Bot doesn't support any services, but has partner plugin rpc client enabled")
 	}
 
 	// messaging components

--- a/internal/messaging/service_registry.go
+++ b/internal/messaging/service_registry.go
@@ -63,6 +63,8 @@ func NewServiceRegistry(
 			servicesNames[serviceName] = struct{}{}
 		}
 
+		services = generated.RegisterClientServices(rpcClient.ClientConn, servicesNames)
+
 		logStr += "\n"
 		logger.Info(logStr)
 
@@ -78,8 +80,6 @@ func NewServiceRegistry(
 
 			return nil, errUnsupportedService
 		}
-
-		services = generated.RegisterClientServices(rpcClient.ClientConn, servicesNames)
 	}
 
 	return &serviceRegistry{

--- a/internal/rpc/client/client.go
+++ b/internal/rpc/client/client.go
@@ -20,6 +20,10 @@ type RPCClient struct {
 }
 
 func NewClient(cfg config.PartnerPluginConfig, logger *zap.SugaredLogger) (*RPCClient, error) {
+	if !cfg.Enabled {
+		return nil, nil
+	}
+
 	var opts []grpc.DialOption
 	if cfg.Unencrypted {
 		opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))

--- a/internal/rpc/server/server.go
+++ b/internal/rpc/server/server.go
@@ -38,6 +38,10 @@ func NewServer(
 	processor messaging.Processor,
 	serviceRegistry messaging.ServiceRegistry,
 ) (Server, error) {
+	if !cfg.Enabled {
+		return nil, nil
+	}
+
 	var opts []grpc.ServerOption
 	if cfg.Unencrypted {
 		logger.Warn("Running gRPC server without TLS!")


### PR DESCRIPTION
1) Adds partner_plugin.enabled and rpc_server.enabled config fields/flags. Those bool fields will control if partner plugin rpc client or bot rpc server are started.

2) Fixes logger setup. Now it will correctly create zap production/development logger according to config developer_mode. Previously it was reading this field before reading config file, so it would use default value in case if it wasn't given as env or flag. 