### PR TITLE
Fix dbs path, fix db errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ __debug*
 ./camino-messenger-bot-supplier.yaml
 ./camino-messenger-bot-distributor.yaml
 
-distributor-matrix.db
-supplier-matrix.db
+distributor-bot-db
+supplier-bot-db
 
 coverage.out

--- a/config/config.go
+++ b/config/config.go
@@ -124,8 +124,7 @@ type UnparsedPartnerPluginConfig struct {
 }
 
 type UnparsedMatrixConfig struct {
-	Host  string `mapstructure:"host"`
-	Store string `mapstructure:"store"`
+	Host string `mapstructure:"host"`
 }
 
 type UnparsedSQLiteDBConfig struct {
@@ -151,8 +150,7 @@ func (cfg *Config) unparse() *UnparsedConfig {
 			CACertFile:  cfg.PartnerPlugin.CACertFile,
 		},
 		Matrix: UnparsedMatrixConfig{
-			Host:  cfg.Matrix.HostURL.String(),
-			Store: cfg.Matrix.Store,
+			Host: cfg.Matrix.HostURL.String(),
 		},
 		DeveloperMode:                       cfg.DeveloperMode,
 		BotKey:                              hex.EncodeToString(crypto.FromECDSA(cfg.BotKey)),

--- a/config/config_reader.go
+++ b/config/config_reader.go
@@ -147,7 +147,7 @@ func (cr *reader) parseConfig(cfg *UnparsedConfig) (*Config, error) {
 		},
 		Matrix: MatrixConfig{
 			HostURL: *matrixHost,
-			Store:   cfg.Matrix.Store,
+			Store:   cfg.DB.DBPath + "/matrix",
 		},
 		DeveloperMode:                       cfg.DeveloperMode,
 		BotKey:                              botKey,

--- a/config/flags.go
+++ b/config/flags.go
@@ -54,7 +54,6 @@ func Flags() *pflag.FlagSet {
 
 	// Matrix config flags
 	flags.String("matrix.host", "", "Sets the matrix host.")
-	flags.String("matrix.store", "cmb_matrix.db", "Sets the matrix store (sqlite3 db path).")
 
 	return flags
 }

--- a/config/test_config.yaml
+++ b/config/test_config.yaml
@@ -10,7 +10,6 @@ db:
 developer_mode: true
 matrix:
     host: messenger.chain4travel.com
-    store: supplier-matrix.db
 min_cheque_duration_until_expiration: 15552000
 network_fee_recipient_bot_address: 0xff6BAC3d972680515cbB59fCB6Db6deB13Eb0E91
 network_fee_recipient_cm_account: 0xF6bA5c68A505559c170dC7a30448Ed64D8b9Bc3B

--- a/examples/config/camino-messenger-bot-distributor-camino.yaml
+++ b/examples/config/camino-messenger-bot-distributor-camino.yaml
@@ -61,9 +61,6 @@ matrix:
     # Hostname of the Matrix server
     host: messenger.chain4travel.com
 
-    # Local DB file to store Matrix data
-    store: distributor-matrix.db
-
 
 
 ### Partner Plugin (NOT USED FOR DISTRIBUTOR BOT)

--- a/examples/config/camino-messenger-bot-distributor-columbus.yaml
+++ b/examples/config/camino-messenger-bot-distributor-columbus.yaml
@@ -61,9 +61,6 @@ matrix:
     # Hostname of the Matrix server
     host: messenger.chain4travel.com
 
-    # Local DB file to store Matrix data
-    store: distributor-matrix.db
-
 
 
 ### Partner Plugin (NOT USED FOR DISTRIBUTOR BOT)

--- a/examples/config/camino-messenger-bot-supplier-camino.yaml
+++ b/examples/config/camino-messenger-bot-supplier-camino.yaml
@@ -61,9 +61,6 @@ matrix:
     # Hostname of the Matrix server
     host: messenger.chain4travel.com
 
-    # Local DB file to store Matrix data
-    store: supplier-matrix.db
-
 
 
 ### Partner Plugin

--- a/examples/config/camino-messenger-bot-supplier-columbus.yaml
+++ b/examples/config/camino-messenger-bot-supplier-columbus.yaml
@@ -59,9 +59,6 @@ matrix:
     # Hostname of the Matrix server
     host: messenger.chain4travel.com
 
-    # Local DB file to store Matrix data
-    store: supplier-matrix.db
-
 
 
 ### Partner Plugin

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -136,7 +136,11 @@ func NewApp(ctx context.Context, cfg *config.Config, logger *zap.SugaredLogger) 
 		return nil, err
 	}
 
-	matrixMessenger := matrix.NewMessenger(cfg.Matrix, cfg.BotKey, logger)
+	matrixMessenger, err := matrix.NewMessenger(cfg.Matrix, cfg.BotKey, logger)
+	if err != nil {
+		logger.Errorf("Failed to create matrix messenger: %v", err)
+		return nil, err
+	}
 
 	botAddress := crypto.PubkeyToAddress(cfg.BotKey.PublicKey)
 	botUserID := messaging.UserIDFromAddress(botAddress, cfg.Matrix.HostURL.String())

--- a/internal/matrix/matrix_messenger.go
+++ b/internal/matrix/matrix_messenger.go
@@ -31,10 +31,11 @@ import (
 
 var _ messaging.Messenger = (*messenger)(nil)
 
-func NewMessenger(cfg config.MatrixConfig, botKey *ecdsa.PrivateKey, logger *zap.SugaredLogger) messaging.Messenger {
+func NewMessenger(cfg config.MatrixConfig, botKey *ecdsa.PrivateKey, logger *zap.SugaredLogger) (messaging.Messenger, error) {
 	c, err := mautrix.NewClient(cfg.HostURL.String(), "", "")
 	if err != nil {
-		panic(err)
+		logger.Errorf("failed to create matrix client: %v", err)
+		return nil, err
 	}
 	return &messenger{
 		msgChannel:   make(chan types.Message),
@@ -45,7 +46,7 @@ func NewMessenger(cfg config.MatrixConfig, botKey *ecdsa.PrivateKey, logger *zap
 		msgAssembler: NewMessageAssembler(),
 		botKey:       botKey,
 		dbPath:       cfg.Store,
-	}
+	}, nil
 }
 
 type messenger struct {

--- a/pkg/chequehandler/storage/sqlite/storage.go
+++ b/pkg/chequehandler/storage/sqlite/storage.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 
 	"github.com/chain4travel/camino-messenger-bot/pkg/chequehandler"
-	"github.com/chain4travel/camino-messenger-bot/pkg/database"
 	"github.com/chain4travel/camino-messenger-bot/pkg/database/sqlite"
 	_ "github.com/golang-migrate/migrate/v4/source/file" // required by migrate
 	"github.com/jmoiron/sqlx"
@@ -83,7 +82,7 @@ func getSQLXTx(session chequehandler.Session) (*sqlx.Tx, error) {
 
 func upgradeError(err error) error {
 	if errors.Is(err, sql.ErrNoRows) {
-		return database.ErrNotFound
+		return chequehandler.ErrNotFound
 	}
 	return err
 }

--- a/pkg/database/common.go
+++ b/pkg/database/common.go
@@ -1,5 +1,0 @@
-package database
-
-import "errors"
-
-var ErrNotFound = errors.New("not found")

--- a/pkg/database/sqlite/storage.go
+++ b/pkg/database/sqlite/storage.go
@@ -2,6 +2,8 @@ package sqlite
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 
 	"github.com/golang-migrate/migrate/v4"
 	"github.com/golang-migrate/migrate/v4/database/sqlite3"
@@ -17,7 +19,12 @@ type DBConfig struct {
 }
 
 func New(logger *zap.SugaredLogger, cfg DBConfig, dbName string) (*DB, error) {
-	db, err := sqlx.Open("sqlite3", cfg.DBPath)
+	if err := os.MkdirAll(filepath.Dir(cfg.DBPath), os.ModePerm); err != nil {
+		logger.Error(err)
+		return nil, err
+	}
+
+	db, err := sqlx.Open("sqlite3", cfg.DBPath+".sqlite")
 	if err != nil {
 		logger.Error(err)
 		return nil, err

--- a/pkg/scheduler/storage/sqlite/storage.go
+++ b/pkg/scheduler/storage/sqlite/storage.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"errors"
 
-	"github.com/chain4travel/camino-messenger-bot/pkg/database"
 	"github.com/chain4travel/camino-messenger-bot/pkg/database/sqlite"
 	"github.com/chain4travel/camino-messenger-bot/pkg/scheduler"
 	_ "github.com/golang-migrate/migrate/v4/source/file" // required by migrate
@@ -79,7 +78,7 @@ func getSQLXTx(session scheduler.Session) (*sqlx.Tx, error) {
 
 func upgradeError(err error) error {
 	if errors.Is(err, sql.ErrNoRows) {
-		return database.ErrNotFound
+		return scheduler.ErrNotFound
 	}
 	return err
 }


### PR DESCRIPTION
#60 introduced some bugs with db config and db errors, this PR fixes that.
- Storage should use its "user" package errors, because it depends on its interface. User-package expects certain errors defined by it, because it doesn't know about storage implementation.
 - DB pkg should ensure database path, otherwise it would fail if path is missing some folders along the way.
 - `matrix.storage` config field could be removed in favor of general `db.path` that defines database root directory