### PR TITLE
TEMPORARY FIX: add check if header is missing in inAddErrorToResponse + Check if Mint Response Failed

### DIFF
--- a/internal/messaging/mint_v1.go
+++ b/internal/messaging/mint_v1.go
@@ -26,7 +26,7 @@ func (h *evmResponseHandler) handleMintResponseV1(ctx context.Context, response 
 		mintResp.Header = &typesv1.ResponseHeader{}
 	}
 
-	if mintResp.Header != nil && mintResp.Header.Status == typesv1.StatusType_STATUS_TYPE_FAILURE {
+	if mintResp.Header.Status == typesv1.StatusType_STATUS_TYPE_FAILURE {
 		return false
 	}
 

--- a/internal/messaging/mint_v1.go
+++ b/internal/messaging/mint_v1.go
@@ -26,6 +26,10 @@ func (h *evmResponseHandler) handleMintResponseV1(ctx context.Context, response 
 		mintResp.Header = &typesv1.ResponseHeader{}
 	}
 
+	if mintResp.Header != nil && mintResp.Header.Status == typesv1.StatusType_STATUS_TYPE_FAILURE {
+		return false
+	}
+
 	// TODO @evlekht ensure that mintReq.BuyerAddress is c-chain address format,
 	// TODO not x/p/t chain or anything else. Currently it will not error
 	// TODO if address is invalid and will just get zero addr

--- a/internal/messaging/mint_v2.go
+++ b/internal/messaging/mint_v2.go
@@ -28,6 +28,10 @@ func (h *evmResponseHandler) handleMintResponseV2(ctx context.Context, response 
 		mintResp.Header = &typesv1.ResponseHeader{}
 	}
 
+	// Check if the response from plugin is sucessfull before minting
+	if mintResp.Header != nil && mintResp.Header.Status == typesv1.StatusType_STATUS_TYPE_FAILURE {
+		return false
+	}
 	// TODO: @VjeraTurk check if CMAccount exists
 
 	// TODO @evlekht ensure that mintReq.BuyerAddress is c-chain address format,

--- a/internal/messaging/mint_v2.go
+++ b/internal/messaging/mint_v2.go
@@ -28,7 +28,7 @@ func (h *evmResponseHandler) handleMintResponseV2(ctx context.Context, response 
 		mintResp.Header = &typesv1.ResponseHeader{}
 	}
 
-	// Check if the response from plugin is sucessful before minting
+	// Check if the response from plugin is successful before minting
 	if mintResp.Header != nil && mintResp.Header.Status == typesv1.StatusType_STATUS_TYPE_FAILURE {
 		return false
 	}

--- a/internal/messaging/mint_v2.go
+++ b/internal/messaging/mint_v2.go
@@ -28,7 +28,7 @@ func (h *evmResponseHandler) handleMintResponseV2(ctx context.Context, response 
 		mintResp.Header = &typesv1.ResponseHeader{}
 	}
 
-	// Check if the response from plugin is sucessfull before minting
+	// Check if the response from plugin is sucessful before minting
 	if mintResp.Header != nil && mintResp.Header.Status == typesv1.StatusType_STATUS_TYPE_FAILURE {
 		return false
 	}

--- a/internal/messaging/mint_v2.go
+++ b/internal/messaging/mint_v2.go
@@ -29,7 +29,7 @@ func (h *evmResponseHandler) handleMintResponseV2(ctx context.Context, response 
 	}
 
 	// Check if the response from plugin is successful before minting
-	if mintResp.Header != nil && mintResp.Header.Status == typesv1.StatusType_STATUS_TYPE_FAILURE {
+	if mintResp.Header.Status == typesv1.StatusType_STATUS_TYPE_FAILURE {
 		return false
 	}
 	// TODO: @VjeraTurk check if CMAccount exists

--- a/internal/messaging/response_handler.go
+++ b/internal/messaging/response_handler.go
@@ -140,6 +140,16 @@ func (h *evmResponseHandler) HandleRequest(_ context.Context, msgType types.Mess
 func (h *evmResponseHandler) AddErrorToResponseHeader(response protoreflect.ProtoMessage, errMessage string) {
 	headerFieldDescriptor := response.ProtoReflect().Descriptor().Fields().ByName("header")
 	headerReflectValue := response.ProtoReflect().Get(headerFieldDescriptor)
+
+	if !headerReflectValue.IsValid() || !headerReflectValue.Message().IsValid() {
+		// TODO: @VjeraTurk support more than 1 version! Or ensure header is not nil elsewhere
+		// Initialize the header if it is not set
+		header := &typesv1.ResponseHeader{}
+		response.ProtoReflect().Set(headerFieldDescriptor, protoreflect.ValueOfMessage(header.ProtoReflect()))
+		addErrorToResponseHeaderV1(header, errMessage)
+		return
+	}
+
 	switch header := headerReflectValue.Message().Interface().(type) {
 	case *typesv1.ResponseHeader:
 		addErrorToResponseHeaderV1(header, errMessage)


### PR DESCRIPTION
## Problem 1
Quick fix to prevent fatal error, when no header is present.

This fix is temporary and should be replaced by a permanent solution.
Allows for _new error_ to trigger with marshaling content during compression (`compressor.go msg.MarshalContent()`):

```
2024-11-13T20:43:30.119+0100	ERROR	messaging/processor.go:309	error compressing/chunking response: compression produced no chunks
github.com/chain4travel/camino-messenger-bot/internal/messaging.(*processor).Respond
	/home/vjera/Repos/camino-messenger-bot/internal/messaging/processor.go:309
github.com/chain4travel/camino-messenger-bot/internal/messaging.(*processor).ProcessInbound
	/home/vjera/Repos/camino-messenger-bot/internal/messaging/processor.go:140
github.com/chain4travel/camino-messenger-bot/internal/messaging.(*processor).Start.func1
	/home/vjera/Repos/camino-messenger-bot/internal/messaging/processor.go:124
```

Mock handlers should never respond with `nil` in place of an empty Type/Array or `HeaderResponse` ?

Fixes on `partner_plugin_mock` branch:
https://github.com/chain4travel/camino-messenger-bot/commit/8e6c7d01a695316ef3495f205afb4ad8f7979e82
https://github.com/chain4travel/camino-messenger-bot/commit/7d36d24ef60f18ad7830930de120c436faaf2c43


## Problem 2

Mint always assumes a successful response from partner plugin -> introduce a case where the plugin response has failed