### PR TITLE
Add cm-account setup instructions to README.MD

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -32,13 +32,13 @@ Currently [release-10](https://github.com/chain4travel/camino-messenger-protocol
 To run the camino-bot-messenger as intended you will need a **CM Account** with a **bot** added to it and **registered services**.
 
 ### Creating the CM account
-If you don't already have a **CM account**, for development purposes a CM Account can be created via [camino messenger contracts](https://github.com/chain4travel/camino-messenger-contracts) `hardhat` tool or via [suite](https://suite.camino.network/create) as explained [here](https://docs.camino.network/partners/partner-config/#step-by-step-configuration-guide).
+If you don't already have a **CM account**, for development purposes, a CM Account can be created via [camino messenger contracts](https://github.com/chain4travel/camino-messenger-contracts) `hardhat` tool or via [suite](https://suite.camino.network/create) as explained [here](https://docs.camino.network/partners/partner-config/#step-by-step-configuration-guide).
 
-To create a **CM account** and add the bot to it - you will need **two KYC verified** (test) **wallets** - one for the **CM Account**, and one for the **bot**.
+To create a **CM account** and add the bot to it - you will need **two** (test) **wallets** - one for the **CM Account**, and one for the **bot**. The CM Account wallet has to be **KYC verified**.
 Creating and KYC verifying the test wallets can be done via [suite](https://suite.camino.network/create) as explained [here](https://docs.camino.network/guides/how-to-create-a-wallet) and [here](https://docs.camino.network/guides/kyc#kyc-verification-process).
 
-### Creating the CM acocunt via hardhat
-After you have your two KYC verified wallets ready, clone the contracts repo, position inside the repo, and run:
+### Creating the CM account via hardhat
+After you have your two wallets ready, clone the contracts repo, position inside the repo, and run:
 ```
 yarn hardhat account --help
 yarn hardhat account create --help
@@ -52,13 +52,13 @@ To see how to use the tool.
 ```
 yarn hardhat account create --private-key <0xstatic-private-key-of-the-cm-account-wallet> --network columbus
 ```
-The command will output an **address of your new CM Account** in format 0x<\...\>. Store it and add it to your .yml configuration under `cm_account_addess`.
+The command will **output** your new **CMAccount Address** in format 0x<\...\>. Store it and add it to your `.yml` configuration under `cm_account_addess`.
 
 2. To **add the bot** to the CM Account run:
 ```
 yarn hardhat account add:bot --bot <0xc-chain-address-of-the-bot-wallet> --cm-account  <0xCMAccount-address> --private-key <0xstatic-private-key-of-the-cm-account-wallet> --network columbus
 ```
-Add this bot's private key to your .yml configuration under `bot_key`.
+Add this bot's private key to your `.yml` configuration under `bot_key`.
 
 3. To **register a service** supported by your CM Account e.g.
 ```

--- a/README.MD
+++ b/README.MD
@@ -32,7 +32,7 @@ Currently [release-10](https://github.com/chain4travel/camino-messenger-protocol
 To run the camino-bot-messenger as intended you will need a **CM Account** with a **bot** added to it and **registered services**.
 
 ### Creating the CM Account
-If you don't already have a **CM Account**, for development purposes, a CM Account can be created via [camino messenger contracts](https://github.com/chain4travel/camino-messenger-contracts) `hardhat` tool or via [suite](https://suite.camino.network/create) as explained [here](https://docs.camino.network/partners/partner-config/#step-by-step-configuration-guide).
+If you don't already have a **CM Account**, for development purposes, a CM Account can be created via [camino messenger contracts](https://github.com/chain4travel/camino-messenger-contracts) `hardhat` tool or via [suite](https://suite.camino.network) as explained [here](https://docs.camino.network/partners/partner-config/#step-by-step-configuration-guide).
 
 To create a **CM Account** and add the bot to it - you will need **two** (test) **wallets** - one for the **CM Account**, and one for the **bot**. The CM Account wallet has to be **KYC verified**. Creating and KYC verifying the test wallets can be done via [suite](https://suite.camino.network/create) as explained [here](https://docs.camino.network/guides/how-to-create-a-wallet) and [here](https://docs.camino.network/guides/kyc#kyc-verification-process).
 

--- a/README.MD
+++ b/README.MD
@@ -32,7 +32,7 @@ Currently [release-10](https://github.com/chain4travel/camino-messenger-protocol
 To run the camino-bot-messenger as intended you will need a **CM Account** with a **bot** added to it and **registered services**.
 
 ### Creating the CM account
-If you don't already have a **CM account**, for development purposes a CM Account can be created via [camino messenger contracts](https://github.com/chain4travel/camino-messenger-contracts) `hardhat` tool or via [suite](https://dev.suite.camino.network/create) as explained [here](https://docs.camino.network/partners/partner-config/#step-by-step-configuration-guide).
+If you don't already have a **CM account**, for development purposes a CM Account can be created via [camino messenger contracts](https://github.com/chain4travel/camino-messenger-contracts) `hardhat` tool or via [suite](https://suite.camino.network/create) as explained [here](https://docs.camino.network/partners/partner-config/#step-by-step-configuration-guide).
 
 To create a **CM account** and add the bot to it - you will need **two KYC verified** (test) **wallets** - one for the **CM Account**, and one for the **bot**.
 Creating and KYC verifying the test wallets can be done via [suite](https://dev.suite.camino.network/create) as explained [here](https://docs.camino.network/guides/how-to-create-a-wallet) and [here](https://docs.camino.network/guides/kyc#kyc-verification-process).

--- a/README.MD
+++ b/README.MD
@@ -42,6 +42,10 @@ To create a **CM Account** and add the bot to it - you will need **two** (test) 
 ### Creating the CM Account via hardhat
 After you have your two wallets ready, clone the contracts repo, position inside the repo, and run:
 ```
+yarn install
+```
+And then
+```
 yarn hardhat account --help
 yarn hardhat account create --help
 yarn hardhat account bot:add --help

--- a/README.MD
+++ b/README.MD
@@ -31,13 +31,12 @@ Currently [release-10](https://github.com/chain4travel/camino-messenger-protocol
 
 To run the camino-bot-messenger as intended you will need a **CM Account** with a **bot** added to it and **registered services**.
 
-### Creating the CM account
-If you don't already have a **CM account**, for development purposes, a CM Account can be created via [camino messenger contracts](https://github.com/chain4travel/camino-messenger-contracts) `hardhat` tool or via [suite](https://suite.camino.network/create) as explained [here](https://docs.camino.network/partners/partner-config/#step-by-step-configuration-guide).
+### Creating the CM Account
+If you don't already have a **CM Account**, for development purposes, a CM Account can be created via [camino messenger contracts](https://github.com/chain4travel/camino-messenger-contracts) `hardhat` tool or via [suite](https://suite.camino.network/create) as explained [here](https://docs.camino.network/partners/partner-config/#step-by-step-configuration-guide).
 
-To create a **CM account** and add the bot to it - you will need **two** (test) **wallets** - one for the **CM Account**, and one for the **bot**. The CM Account wallet has to be **KYC verified**.
-Creating and KYC verifying the test wallets can be done via [suite](https://suite.camino.network/create) as explained [here](https://docs.camino.network/guides/how-to-create-a-wallet) and [here](https://docs.camino.network/guides/kyc#kyc-verification-process).
+To create a **CM Account** and add the bot to it - you will need **two** (test) **wallets** - one for the **CM Account**, and one for the **bot**. The CM Account wallet has to be **KYC verified**. Creating and KYC verifying the test wallets can be done via [suite](https://suite.camino.network/create) as explained [here](https://docs.camino.network/guides/how-to-create-a-wallet) and [here](https://docs.camino.network/guides/kyc#kyc-verification-process).
 
-### Creating the CM account via hardhat
+### Creating the CM Account via hardhat
 After you have your two wallets ready, clone the contracts repo, position inside the repo, and run:
 ```
 yarn hardhat account --help
@@ -52,7 +51,7 @@ To see how to use the tool.
 ```
 yarn hardhat account create --private-key <0xstatic-private-key-of-the-cm-account-wallet> --network columbus
 ```
-The command will **output** your new **CMAccount Address** in format 0x<\...\>. Store it and add it to your `.yml` configuration under `cm_account_addess`.
+The command will output your new **CM Account Address** in format 0x<\...\>. Store it and add it to your `.yml` configuration under `cm_account_addess`.
 
 2. To **add the bot** to the CM Account run:
 ```

--- a/README.MD
+++ b/README.MD
@@ -36,6 +36,9 @@ If you don't already have a **CM Account**, for development purposes, a CM Accou
 
 To create a **CM Account** and add the bot to it - you will need **two** (test) **wallets** - one for the **CM Account**, and one for the **bot**. The CM Account wallet has to be **KYC verified**. Creating and KYC verifying the test wallets can be done via [suite](https://suite.camino.network/create) as explained [here](https://docs.camino.network/guides/how-to-create-a-wallet) and [here](https://docs.camino.network/guides/kyc#kyc-verification-process).
 
+> [!IMPORTANT]
+> Remember to ensure the suite is connected to testnet Columbus if you are doing this for development purposes. 
+
 ### Creating the CM Account via hardhat
 After you have your two wallets ready, clone the contracts repo, position inside the repo, and run:
 ```

--- a/README.MD
+++ b/README.MD
@@ -35,7 +35,7 @@ To run the camino-bot-messenger as intended you will need a **CM Account** with 
 If you don't already have a **CM account**, for development purposes a CM Account can be created via [camino messenger contracts](https://github.com/chain4travel/camino-messenger-contracts) `hardhat` tool or via [suite](https://suite.camino.network/create) as explained [here](https://docs.camino.network/partners/partner-config/#step-by-step-configuration-guide).
 
 To create a **CM account** and add the bot to it - you will need **two KYC verified** (test) **wallets** - one for the **CM Account**, and one for the **bot**.
-Creating and KYC verifying the test wallets can be done via [suite](https://dev.suite.camino.network/create) as explained [here](https://docs.camino.network/guides/how-to-create-a-wallet) and [here](https://docs.camino.network/guides/kyc#kyc-verification-process).
+Creating and KYC verifying the test wallets can be done via [suite](https://suite.camino.network/create) as explained [here](https://docs.camino.network/guides/how-to-create-a-wallet) and [here](https://docs.camino.network/guides/kyc#kyc-verification-process).
 
 ### Creating the CM acocunt via hardhat
 After you have your two KYC verified wallets ready, clone the contracts repo, position inside the repo, and run:

--- a/README.MD
+++ b/README.MD
@@ -55,7 +55,8 @@ To see how to use the tool.
 yarn hardhat account create --private-key <0xstatic-private-key-of-the-cm-account-wallet> --network columbus
 ```
 The command will output your new **CM Account Address** in format 0x<\...\>. Store it and add it to your `.yml` configuration under `cm_account_addess`.
-To retrieve your bot wallet static private key, follow the instructions [here](https://docs.camino.network/guides/how-to-login-to-your-wallet#how-to-retrieve-your-private-key).
+To retrieve your bot wallet static private key, follow the instructions [here](https://docs.camino.network/guides/how-to-login-to-your-wallet#how-to-retrieve-your-private-key).  
+
 2. To **add the bot** to the CM Account run:
 ```
 yarn hardhat account add:bot --bot <0xc-chain-address-of-the-bot-wallet> --cm-account  <0xCMAccount-address> --private-key <0xstatic-private-key-of-the-cm-account-wallet> --network columbus

--- a/README.MD
+++ b/README.MD
@@ -25,7 +25,7 @@ Camino-Messenger-Bot is designed to facilitate communication through various mes
 
 This application depends on the [camino-messenger-protocol](https://github.com/chain4travel/camino-messenger-protocol), which is a separate repository. The protocol defines the protobuf messages and services used for communication between the gRPC server and client.
 
-Currently [release-11](https://github.com/chain4travel/camino-messenger-protocol/releases/tag/release-11) of Camino Messenger Protocol is used.
+Currently [release-10](https://github.com/chain4travel/camino-messenger-protocol/releases/tag/release-10) of Camino Messenger Protocol is used.
 
 ## Camino Messenger Account (CM Account)
 

--- a/README.MD
+++ b/README.MD
@@ -55,7 +55,7 @@ To see how to use the tool.
 yarn hardhat account create --private-key <0xstatic-private-key-of-the-cm-account-wallet> --network columbus
 ```
 The command will output your new **CM Account Address** in format 0x<\...\>. Store it and add it to your `.yml` configuration under `cm_account_addess`.
-
+To retrieve your bot wallet static private key, follow the instructions [here](https://docs.camino.network/guides/how-to-login-to-your-wallet#how-to-retrieve-your-private-key).
 2. To **add the bot** to the CM Account run:
 ```
 yarn hardhat account add:bot --bot <0xc-chain-address-of-the-bot-wallet> --cm-account  <0xCMAccount-address> --private-key <0xstatic-private-key-of-the-cm-account-wallet> --network columbus

--- a/README.MD
+++ b/README.MD
@@ -25,7 +25,44 @@ Camino-Messenger-Bot is designed to facilitate communication through various mes
 
 This application depends on the [camino-messenger-protocol](https://github.com/chain4travel/camino-messenger-protocol), which is a separate repository. The protocol defines the protobuf messages and services used for communication between the gRPC server and client.
 
-Currently [release-9](https://github.com/chain4travel/camino-messenger-protocol/releases/tag/release-9) of Camino Messenger Protocol is used.
+Currently [release-11](https://github.com/chain4travel/camino-messenger-protocol/releases/tag/release-11) of Camino Messenger Protocol is used.
+
+## Camino Messenger Account (CM Account)
+
+To run the camino-bot-messenger as intended you will need a **CM Account** with a **bot** added to it and **registered services**.
+
+### Creating the CM account
+If you don't already have a **CM account**, for development purposes a CM Account can be created via [camino messenger contract](https://github.com/chain4travel/camino-messenger-contracts) `hardhat` tool or via [suite](https://dev.suite.camino.network/create) as explained [here](https://docs.camino.network/partners/partner-config/#step-by-step-configuration-guide).
+
+To create a **CM account** and add the bot to it - you will need **two KYC verified** (test) **wallets** - one for the **CM Account**, and one for the **bot**.
+Creating and KYC verifying the test wallets can be done via [suite](https://dev.suite.camino.network/create) as explained [here](https://docs.camino.network/guides/how-to-create-a-wallet) and [here](https://docs.camino.network/guides/kyc#kyc-verification-process).
+
+### Creating the CM acocunt via hardhat
+After you have your two KYC verified wallets ready, clone the contracts repo, position inside the repo, and run:
+```
+yarn hardhat account --help
+yarn hardhat account create --help
+yarn hardhat account bot:add --help
+yarn hardhat account service:add --help  
+```
+
+To see how to use the tool.
+
+1. To create the CM Account run:
+```
+yarn hardhat account create --private-key <0xstatic-private-key-of-the-cm-account-wallet> --network columbus
+```
+The command will output an **address of your new CM Account** in format 0x<\...\>.
+
+2. To add the bot to the CM Account run:
+```
+yarn hardhat account add:bot --bot <0xc-chain-address-of-the-bot-wallet> --cm-account  <0xCMAccount-address> --private-key <0xstatic-private-key-of-the-cm-account-wallet> --network columbus
+```
+3. To register a service supported by your CM Account e.g.
+```
+yarn hardhat account service:add --cm-account <0xCMAccount-address> --private-key <0xstatic-private-key-of-the-cm-account-wallet>  --service-name cmp.services.transport.v3.TransportSearchService --fee 3 --network columbus
+```
+
 
 ## Examples and Docker Support
 

--- a/README.MD
+++ b/README.MD
@@ -32,7 +32,7 @@ Currently [release-10](https://github.com/chain4travel/camino-messenger-protocol
 To run the camino-bot-messenger as intended you will need a **CM Account** with a **bot** added to it and **registered services**.
 
 ### Creating the CM account
-If you don't already have a **CM account**, for development purposes a CM Account can be created via [camino messenger contract](https://github.com/chain4travel/camino-messenger-contracts) `hardhat` tool or via [suite](https://dev.suite.camino.network/create) as explained [here](https://docs.camino.network/partners/partner-config/#step-by-step-configuration-guide).
+If you don't already have a **CM account**, for development purposes a CM Account can be created via [camino messenger contracts](https://github.com/chain4travel/camino-messenger-contracts) `hardhat` tool or via [suite](https://dev.suite.camino.network/create) as explained [here](https://docs.camino.network/partners/partner-config/#step-by-step-configuration-guide).
 
 To create a **CM account** and add the bot to it - you will need **two KYC verified** (test) **wallets** - one for the **CM Account**, and one for the **bot**.
 Creating and KYC verifying the test wallets can be done via [suite](https://dev.suite.camino.network/create) as explained [here](https://docs.camino.network/guides/how-to-create-a-wallet) and [here](https://docs.camino.network/guides/kyc#kyc-verification-process).
@@ -48,21 +48,22 @@ yarn hardhat account service:add --help
 
 To see how to use the tool.
 
-1. To create the CM Account run:
+1. To **create the CM Account** run:
 ```
 yarn hardhat account create --private-key <0xstatic-private-key-of-the-cm-account-wallet> --network columbus
 ```
-The command will output an **address of your new CM Account** in format 0x<\...\>.
+The command will output an **address of your new CM Account** in format 0x<\...\>. Store it and add it to your .yml configuration under `cm_account_addess`.
 
-2. To add the bot to the CM Account run:
+2. To **add the bot** to the CM Account run:
 ```
 yarn hardhat account add:bot --bot <0xc-chain-address-of-the-bot-wallet> --cm-account  <0xCMAccount-address> --private-key <0xstatic-private-key-of-the-cm-account-wallet> --network columbus
 ```
-3. To register a service supported by your CM Account e.g.
+Add this bot's private key to your .yml configuration under `bot_key`.
+
+3. To **register a service** supported by your CM Account e.g.
 ```
 yarn hardhat account service:add --cm-account <0xCMAccount-address> --private-key <0xstatic-private-key-of-the-cm-account-wallet>  --service-name cmp.services.transport.v3.TransportSearchService --fee 3 --network columbus
 ```
-
 
 ## Examples and Docker Support
 

--- a/README.MD
+++ b/README.MD
@@ -69,7 +69,11 @@ Add this bot's private key to your `.yml` configuration under `bot_key`.
 
 3. To **register a service** supported by your CM Account e.g.
 ```
-yarn hardhat account service:add --cm-account <0xCMAccount-address> --private-key <0xstatic-private-key-of-the-cm-account-wallet>  --service-name cmp.services.transport.v3.TransportSearchService --fee 3 --network columbus
+yarn hardhat account service:add --cm-account <0xCMAccount-address> --private-key <0xstatic-private-key-of-the-cm-account-wallet>  --service-name cmp.services.transport.v3.TransportSearchService --fee 3 --network Columbus
+```
+To see all the services you can support, run:
+```
+yarn hardhat manager services:list --network columbus
 ```
 
 ## Examples and Docker Support


### PR DESCRIPTION
## Camino Messenger Account (CM Account)

To run the camino-bot-messenger as intended you will need a **CM Account** with a **bot** added to it and **registered services**.

### Creating the CM Account
If you don't already have a **CM Account**, for development purposes, a CM Account can be created via [camino messenger contracts](https://github.com/chain4travel/camino-messenger-contracts) `hardhat` tool or via [suite](https://suite.camino.network) as explained [here](https://docs.camino.network/partners/partner-config/#step-by-step-configuration-guide).

To create a **CM Account** and add the bot to it - you will need **two** (test) **wallets** - one for the **CM Account**, and one for the **bot**. The CM Account wallet has to be **KYC verified**. Creating and KYC verifying the test wallets can be done via [suite](https://suite.camino.network/create) as explained [here](https://docs.camino.network/guides/how-to-create-a-wallet) and [here](https://docs.camino.network/guides/kyc#kyc-verification-process).

> [!IMPORTANT]
> Remember to ensure the suite is connected to testnet Columbus if you are doing this for development purposes. 

### Creating the CM Account via hardhat
After you have your two wallets ready, clone the contracts repo, position inside the repo, and run:
```
yarn install
```
And then
```
yarn hardhat account --help
yarn hardhat account create --help
yarn hardhat account bot:add --help
yarn hardhat account service:add --help  
```

To see how to use the tool.

1. To **create the CM Account** run:
```
yarn hardhat account create --private-key <0xstatic-private-key-of-the-cm-account-wallet> --network columbus
```
The command will output your new **CM Account Address** in format 0x<\...\>. Store it and add it to your `.yml` configuration under `cm_account_addess`.
To retrieve your bot wallet static private key, follow the instructions [here](https://docs.camino.network/guides/how-to-login-to-your-wallet#how-to-retrieve-your-private-key).  

2. To **add the bot** to the CM Account run:
```
yarn hardhat account add:bot --bot <0xc-chain-address-of-the-bot-wallet> --cm-account  <0xCMAccount-address> --private-key <0xstatic-private-key-of-the-cm-account-wallet> --network columbus
```
Add this bot's private key to your `.yml` configuration under `bot_key`.

3. To **register a service** supported by your CM Account e.g.
```
yarn hardhat account service:add --cm-account <0xCMAccount-address> --private-key <0xstatic-private-key-of-the-cm-account-wallet>  --service-name cmp.services.transport.v3.TransportSearchService --fee 3 --network Columbus
```
To see all the services you can support, run:
```
yarn hardhat manager services:list --network columbus
```