### PR TITLE
Prevent minting if response status is not success

### DIFF
--- a/internal/messaging/mint_v1.go
+++ b/internal/messaging/mint_v1.go
@@ -17,7 +17,7 @@ func (h *evmResponseHandler) prepareMintResponseV1(
 	response *bookv1.MintResponse,
 	request *bookv1.MintRequest,
 ) {
-	if response.Header.Status == typesv1.StatusType_STATUS_TYPE_FAILURE {
+	if response.Header.Status != typesv1.StatusType_STATUS_TYPE_SUCCESS {
 		return
 	}
 

--- a/internal/messaging/mint_v2.go
+++ b/internal/messaging/mint_v2.go
@@ -18,7 +18,7 @@ func (h *evmResponseHandler) prepareMintResponseV2(
 	response *bookv2.MintResponse,
 	request *bookv2.MintRequest,
 ) {
-	if response.Header.Status == typesv1.StatusType_STATUS_TYPE_FAILURE {
+	if response.Header.Status != typesv1.StatusType_STATUS_TYPE_SUCCESS {
 		return
 	}
 	// TODO: @VjeraTurk check if CMAccount exists


### PR DESCRIPTION
Current implementation checks if status is failure and than returns. If not failure, it continues, even if status is unknown, not success.
This PR changes check to "not success => failure"