### PR TITLE
Add CMP release to version outputs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,9 @@ RUN apk add olm-dev
 
 # build
 COPY . .
-RUN apk --no-cache add git
+RUN apk --no-cache add git bash
 RUN git submodule update --init
-RUN CAMINOBOT_PATH=$(pwd) sh scripts/build.sh
+RUN CAMINOBOT_PATH=$(pwd) bash ./scripts/build.sh
 
 
 #runtime stage

--- a/cmd/camino_messenger_bot.go
+++ b/cmd/camino_messenger_bot.go
@@ -16,7 +16,7 @@ import (
 var rootCmd = &cobra.Command{
 	Use:        "camino-messenger-bot",
 	Short:      "starts camino messenger bot",
-	Version:    version.AppVersion,
+	Version:    version.FullVersion,
 	SuggestFor: []string{"camino-messenger", "camino-messenger-bot", "camino-bot", "cmb"},
 	RunE:       rootFunc,
 }
@@ -59,9 +59,8 @@ func rootFunc(cmd *cobra.Command, _ []string) error {
 	defer func() { _ = logger.Sync() }()
 
 	logger.Infof("App version: %s (git: %s)", version.AppVersion, version.AppGitCommit)
-	logger.Infof("Protocol version: %s", version.ProtocolVersion)
-	logger.Infof("buf.build protocolbuffers version: %s", version.BufBuildPBCommit)
-	logger.Infof("buf.build grpc version: %s", version.BufBuildGRPCCommit)
+	logger.Infof("buf.build protocolbuffers version: %s (CMP %s)", version.BufBuildPBCommit, version.BufBuildPBCMPRelease)
+	logger.Infof("buf.build grpc version: %s (CMP %s)", version.BufBuildGRPCCommit, version.BufBuildGRPCCMPRelease)
 	logger.Infof("camino-messenger-contracts version: %s", version.ContractsGitCommit)
 
 	app, err := app.NewApp(ctx, cfg, logger)

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -6,18 +6,29 @@ import (
 )
 
 var (
-	// set by go build -ldflags
-	AppVersion   = "Unspecified"
+	// AppVersion set by go build -ldflags
+	AppVersion = "Unspecified"
+
+	// AppGitCommi set by go build -ldflags
 	AppGitCommit = "Unspecified"
 
-	BufBuildPBCMPRelease   = "Unspecified"
+	// BufBuildPBCMPRelease is set by go build -ldflags
+	BufBuildPBCMPRelease = "Unspecified"
+
+	// BufBuildGRPCCMPRelease is set by go build -ldflags
 	BufBuildGRPCCMPRelease = "Unspecified"
 
-	// set during init
-	BufBuildPBCommit   = "Unspecified"
+	// BufBuildPBCommit set during init from pkg dependency version
+	BufBuildPBCommit = "Unspecified"
+
+	// BufBuildGRPCCommit set during init from pkg dependency version
 	BufBuildGRPCCommit = "Unspecified"
+
+	// ContractsGitCommit set during init from pkg dependency version
 	ContractsGitCommit = "Unspecified"
-	FullVersion        = "Unspecified"
+
+	// FullVersion is set during init by combining all version info
+	FullVersion = "Unspecified"
 )
 
 func init() {

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -6,10 +6,10 @@ import (
 )
 
 var (
-	// AppVersion set by go build -ldflags
+	// AppVersion is set by go build -ldflags
 	AppVersion = "Unspecified"
 
-	// AppGitCommi set by go build -ldflags
+	// AppGitCommit is set by go build -ldflags
 	AppGitCommit = "Unspecified"
 
 	// BufBuildPBCMPRelease is set by go build -ldflags

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -36,7 +36,7 @@ func init() {
 	FullVersion = fmt.Sprintf("%s (git: %s)\n\nlibs:\n  %s: %s (%s)\n  %s: %s (%s)\n  %s: %s",
 		AppVersion,
 		AppGitCommit,
-		"buf.build protocolbuffers ",
+		"buf.build protocolbuffers  ",
 		BufBuildPBCommit,
 		BufBuildPBCMPRelease,
 		"buf.build grpc            ",

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -36,7 +36,7 @@ func init() {
 	FullVersion = fmt.Sprintf("%s (git: %s)\n\nlibs:\n  %s: %s (%s)\n  %s: %s (%s)\n  %s: %s",
 		AppVersion,
 		AppGitCommit,
-		"buf.build protocolbuffers  ",
+		"buf.build protocolbuffers ",
 		BufBuildPBCommit,
 		BufBuildPBCMPRelease,
 		"buf.build grpc            ",

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,19 +1,23 @@
 package version
 
-import "runtime/debug"
-
-const ProtocolVersion = "v10.0.0"
+import (
+	"fmt"
+	"runtime/debug"
+)
 
 var (
-	// AppVersion is set by go build -ldflags
-	AppVersion = "Unspecified"
-
-	// AppGitCommit is set by go build -ldflags
+	// set by go build -ldflags
+	AppVersion   = "Unspecified"
 	AppGitCommit = "Unspecified"
 
+	BufBuildPBCMPRelease   = "Unspecified"
+	BufBuildGRPCCMPRelease = "Unspecified"
+
+	// set during init
 	BufBuildPBCommit   = "Unspecified"
 	BufBuildGRPCCommit = "Unspecified"
 	ContractsGitCommit = "Unspecified"
+	FullVersion        = "Unspecified"
 )
 
 func init() {
@@ -28,4 +32,17 @@ func init() {
 			ContractsGitCommit = dependency.Version
 		}
 	}
+
+	FullVersion = fmt.Sprintf("%s (git: %s)\n\nlibs:\n  %s: %s (%s)\n  %s: %s (%s)\n  %s: %s",
+		AppVersion,
+		AppGitCommit,
+		"buf.build protocolbuffers ",
+		BufBuildPBCommit,
+		BufBuildPBCMPRelease,
+		"buf.build grpc            ",
+		BufBuildGRPCCommit,
+		BufBuildGRPCCMPRelease,
+		"camino-messenger-contracts",
+		ContractsGitCommit,
+	)
 }

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -24,6 +24,8 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+echo "Starting build process..."
+
 if [ -z "${CAMINOBOT_PATH}" ]; then
     # camino-messenger-bot root folder
     CAMINOBOT_PATH=$(
@@ -31,6 +33,9 @@ if [ -z "${CAMINOBOT_PATH}" ]; then
         cd .. && pwd
     )
 fi
+echo "cd $CAMINOBOT_PATH"
+cd "$CAMINOBOT_PATH"
+
 # Load the constants
 echo "Preparing constants..."
 source "$CAMINOBOT_PATH"/scripts/constants.sh
@@ -58,8 +63,8 @@ echo "$BUILD_CMD"
 eval "$BUILD_CMD"
 
 if [ $? -eq 0 ]; then
+    echo "Output binary: ${CAMINOBOT_PATH}/${OUTPUT_BINARY}"
     echo "Build successful!"
-    echo "Output binary: ${OUTPUT_BINARY}"
 else
     echo "Build failed."
     exit 1

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -13,37 +13,53 @@ DEBUG=false
 while [[ $# -gt 0 ]]; do
     key="$1"
     case $key in
-        -d|--debug)
-            DEBUG=true
-            shift
-            ;;
-        *)
-            echo "Unknown option: $1" 
-            exit 1
-            ;;
+    -d | --debug)
+        DEBUG=true
+        shift
+        ;;
+    *)
+        echo "Unknown option: $1"
+        exit 1
+        ;;
     esac
 done
 
 if [ -z "${CAMINOBOT_PATH}" ]; then
-    # Camino-messenger-bot root folder
-    CAMINOBOT_PATH=$( cd "$( dirname "${BASH_SOURCE[0]}" )"; cd .. && pwd )
+    # camino-messenger-bot root folder
+    CAMINOBOT_PATH=$(
+        cd "$(dirname "${BASH_SOURCE[0]}")"
+        cd .. && pwd
+    )
 fi
 # Load the constants
+echo "Preparing constants..."
 source "$CAMINOBOT_PATH"/scripts/constants.sh
+
+echo "  DEBUG                  : $DEBUG"
+echo "  git_tag                : $git_tag"
+echo "  git_commit             : $git_commit"
+echo "  protocolbuffers_release: $protocolbuffers_release"
+echo "  grpc_release           : $grpc_release"
 
 LDFLAGS="-X github.com/chain4travel/camino-messenger-bot/internal/version.AppGitCommit=$git_commit"
 LDFLAGS="$LDFLAGS -X github.com/chain4travel/camino-messenger-bot/internal/version.AppVersion=$git_tag"
+LDFLAGS="$LDFLAGS -X github.com/chain4travel/camino-messenger-bot/internal/version.BufBuildPBCMPRelease=$protocolbuffers_release"
+LDFLAGS="$LDFLAGS -X github.com/chain4travel/camino-messenger-bot/internal/version.BufBuildGRPCCMPRelease=$grpc_release"
 
 # Build the Go application
 echo "Building camino-messenger-bot..."
 if [ "$DEBUG" = true ]; then
-    go build -o ${OUTPUT_BINARY} -ldflags "$LDFLAGS" -gcflags "all=-N -l" ${MAIN_SOURCE}
+    BUILD_CMD="go build -o ${OUTPUT_BINARY} -ldflags \"$LDFLAGS\" -gcflags \"all=-N -l\" ${MAIN_SOURCE}"
 else
-    go build -o ${OUTPUT_BINARY} -ldflags "$LDFLAGS" ${MAIN_SOURCE}
+    BUILD_CMD="go build -o ${OUTPUT_BINARY} -ldflags \"$LDFLAGS\" ${MAIN_SOURCE}"
 fi
+
+echo "$BUILD_CMD"
+eval "$BUILD_CMD"
 
 if [ $? -eq 0 ]; then
     echo "Build successful!"
+    echo "Output binary: ${OUTPUT_BINARY}"
 else
     echo "Build failed."
     exit 1

--- a/scripts/constants.sh
+++ b/scripts/constants.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+
 # Current branch
 current_branch_temp=$(git symbolic-ref -q --short HEAD || git describe --tags --always || echo unknown)
 # replace / with - to be a docker tag compatible
@@ -11,5 +13,5 @@ git_commit=${CAMINO_BOT_COMMIT:-$(git rev-parse --short HEAD)}
 git_tag=${CAMINO_BOT_TAG:-$(git describe --tags --always --dirty || echo unknown)}
 
 # get protocol releases from buf.build
-grpc_release=$(scripts/resolve_protocol_release.sh buf.build/gen/go/chain4travel/camino-messenger-protocol/grpc/go)
-protocolbuffers_release=$(scripts/resolve_protocol_release.sh buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go)
+grpc_release=$(${SCRIPT_DIR}/resolve_protocol_release.sh buf.build/gen/go/chain4travel/camino-messenger-protocol/grpc/go)
+protocolbuffers_release=$(${SCRIPT_DIR}/resolve_protocol_release.sh buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go)

--- a/scripts/constants.sh
+++ b/scripts/constants.sh
@@ -8,7 +8,7 @@ current_branch=${current_branch_temp////-}
 
 # camino-messenger-bot and caminoethvm git tag and sha
 git_commit=${CAMINO_BOT_COMMIT:-$(git rev-parse --short HEAD)}
-git_tag=${CAMINO_BOT_TAG:-$(git describe --tags --abbrev=0 --always || echo unknown)}
+git_tag=${CAMINO_BOT_TAG:-$(git describe --tags --always --dirty || echo unknown)}
 
 # get protocol releases from buf.build
 grpc_release=$(scripts/resolve_protocol_release.sh buf.build/gen/go/chain4travel/camino-messenger-protocol/grpc/go)

--- a/scripts/constants.sh
+++ b/scripts/constants.sh
@@ -9,3 +9,7 @@ current_branch=${current_branch_temp////-}
 # camino-messenger-bot and caminoethvm git tag and sha
 git_commit=${CAMINO_BOT_COMMIT:-$(git rev-parse --short HEAD)}
 git_tag=${CAMINO_BOT_TAG:-$(git describe --tags --abbrev=0 --always || echo unknown)}
+
+# get protocol releases from buf.build
+grpc_release=$(scripts/resolve_protocol_release.sh buf.build/gen/go/chain4travel/camino-messenger-protocol/grpc/go)
+protocolbuffers_release=$(scripts/resolve_protocol_release.sh buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go)

--- a/scripts/resolve_protocol_release.sh
+++ b/scripts/resolve_protocol_release.sh
@@ -29,7 +29,7 @@ if [ -z "$short_hash" ]; then
     exit 0
 fi
 
-label=$(curl -s -X POST "https://buf.build/buf.registry.module.v1beta1.LabelService/ListLabels" \
+label=$(curl -s -f --max-time 10 -X POST "https://buf.build/buf.registry.module.v1beta1.LabelService/ListLabels" \
     -H "Content-Type: application/json" \
     --data '{
        "pageSize": 25,

--- a/scripts/resolve_protocol_release.sh
+++ b/scripts/resolve_protocol_release.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+#
+# Resolve the label from buf.build for a given dependency uri from the go.mod file
+#
+# This script tries to resolve the label for the protocol release from buf.build. It
+# does not error out if the label is not found. Just returns "UnknownBufLabel".
+
+if [ $# -eq 0 ]; then
+    echo "Usage: $0 <buf-dependency-path>"
+    echo "Example: $0 buf.build/gen/go/chain4travel/camino-messenger-protocol/grpc/go"
+    exit 0
+fi
+
+dep_path=$1
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+go_mod_path="$SCRIPT_DIR/../go.mod"
+
+UNKNOWN_LABEL="UnknownBufLabel"
+
+if [ -z "$go_mod_path" ]; then
+    echo "$UNKNOWN_LABEL"
+    exit 0
+fi
+
+short_hash=$(grep -E "$dep_path" "$go_mod_path" | grep -oP '(\w{12})(?=\.)' || echo "")
+
+if [ -z "$short_hash" ]; then
+    echo "$UNKNOWN_LABEL"
+    exit 0
+fi
+
+label=$(curl -s -X POST "https://buf.build/buf.registry.module.v1beta1.LabelService/ListLabels" \
+    -H "Content-Type: application/json" \
+    --data '{
+       "pageSize": 25,
+       "resourceRef": {
+           "name": {
+               "owner": "chain4travel",
+               "module": "camino-messenger-protocol"
+           }
+       },
+       "order": "ORDER_UPDATE_TIME_DESC",
+       "archiveFilter": "ARCHIVE_FILTER_UNARCHIVED_ONLY"
+   }' | jq -r --arg hash "$short_hash" '
+   .labels[] | select(.commitId | startswith($hash)) | .name' | (
+    release_label=$(grep "^release-" || true)
+    if [ -n "$release_label" ]; then
+        echo "$release_label"
+    else
+        head -n 1
+    fi
+))
+
+if [ -z "$label" ]; then
+    echo "$UNKNOWN_LABEL"
+else
+    echo "$label"
+fi


### PR DESCRIPTION
This PR adds protocol release label from buf.build to the compiled binary. It also makes the build process more explicit by providing information about the build to the stdout.

I've also updated how the `git_tag` is build with `git describe`, explanation below.

Example `-v` output:

```
❯ ./build/camino-messenger-bot -v
camino-messenger-bot version v10.1.0-22-g8a20f6e-dirty (git: 8a20f6e)

libs:
  buf.build protocolbuffers : v1.34.2-20240924170438-a97744087df6.2 (release-10)
  buf.build grpc            : v1.5.1-20240924170438-a97744087df6.1 (release-10)
  camino-messenger-contracts: v0.0.0-20241024152339-d7c3c6e5c377
```

Here we see the version is `v10.1.0-22-g8a20f6e-dirty (git: 8a20f6e)`, which means:
- the last tag that exists before the current HEAD is `v10.1.0`
- 22 commits happened after that tag, the `-22` part (this is only added if the current HEAD does not have a tag)
- now it's SHA `8a20f6e` which comes from git (the `-g` part before the SHA) (only if there is no tag for current HEAD)
- at compilation time the working directory was dirty (had uncommitted changes) (the `-dirty` part)
- `(git: 8a20f6e)` this part is always added, even if current HEAD has a specific tag, in which case the version would be only the tag (if no dirty), ie: `v10.1.0`

This process ensures that we can identify for pretty much all the cases that can affect the binary. Previously it was always setting the version to tag name even if you had commits after that and the dirty workdir was not used at all.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced versioning information displayed in the application, now showing more comprehensive version details.
  - Introduced a new script to resolve protocol release labels from dependencies, improving version tracking.

- **Improvements**
  - Build script now provides clearer feedback during the build process, enhancing user experience.
  - Updated methods for retrieving git tags to ensure accuracy even with uncommitted changes.
  - Enhanced logging for protocol versions, providing additional context in log entries.

- **Chores**
  - Updated Dockerfile to use `bash` for script execution, improving compatibility with script constructs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->