### PR TITLE
license headers

### DIFF
--- a/LICENSE.header
+++ b/LICENSE.header
@@ -1,2 +1,0 @@
-Copyright (C) 2024, Chain4Travel AG. All rights reserved.
-See the file LICENSE for licensing terms.

--- a/cmd/camino_messenger_bot.go
+++ b/cmd/camino_messenger_bot.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package cmd
 
 import (

--- a/config/config.go
+++ b/config/config.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package config
 
 import (

--- a/config/config_reader.go
+++ b/config/config_reader.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package config
 
 import (

--- a/config/config_reader_test.go
+++ b/config/config_reader_test.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package config
 
 import (

--- a/config/flags.go
+++ b/config/flags.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package config
 
 import (

--- a/examples/booking/mintnbuy.go
+++ b/examples/booking/mintnbuy.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package main
 
 import (

--- a/examples/events/listen.go
+++ b/examples/events/listen.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package main
 
 import (

--- a/examples/rpc/client.go
+++ b/examples/rpc/client.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package main
 
 import (

--- a/examples/rpc/partner-plugin/handlers/mint_v1.go
+++ b/examples/rpc/partner-plugin/handlers/mint_v1.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package handlers
 
 import (

--- a/examples/rpc/partner-plugin/handlers/mint_v2.go
+++ b/examples/rpc/partner-plugin/handlers/mint_v2.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package handlers
 
 import (

--- a/examples/rpc/partner-plugin/server.go
+++ b/examples/rpc/partner-plugin/server.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package main
 
 import (

--- a/header.yaml
+++ b/header.yaml
@@ -1,0 +1,10 @@
+default-headers: 
+  - name: c4t
+    header: |
+      // Copyright (C) 2022-{YEAR}, Chain4Travel AG. All rights reserved.
+      // See the file LICENSE for licensing terms.
+
+headers-excluded-paths:
+  - "./camino-matrix-go/**/*.go"
+  - "./**/mock_*.go"
+  - "./internal/rpc/generated/**/*.go"

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package app
 
 import (

--- a/internal/compression/compress.go
+++ b/internal/compression/compress.go
@@ -1,7 +1,5 @@
-/*
- * Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
- * See the file LICENSE for licensing terms.
- */
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
 
 package compression
 

--- a/internal/compression/decompress.go
+++ b/internal/compression/decompress.go
@@ -1,7 +1,5 @@
-/*
- * Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
- * See the file LICENSE for licensing terms.
- */
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
 
 package compression
 

--- a/internal/matrix/matrix_messenger.go
+++ b/internal/matrix/matrix_messenger.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package matrix
 
 import (

--- a/internal/matrix/msg_assembler.go
+++ b/internal/matrix/msg_assembler.go
@@ -1,7 +1,5 @@
-/*
- * Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
- * See the file LICENSE for licensing terms.
- */
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
 
 package matrix
 

--- a/internal/matrix/msg_assembler_test.go
+++ b/internal/matrix/msg_assembler_test.go
@@ -1,7 +1,5 @@
-/*
- * Copyright (C) 2024, Chain4Travel AG. All rights reserved.
- * See the file LICENSE for licensing terms.
- */
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
 
 package matrix
 

--- a/internal/matrix/room_handler.go
+++ b/internal/matrix/room_handler.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package matrix
 
 import (

--- a/internal/matrix/room_handler_test.go
+++ b/internal/matrix/room_handler_test.go
@@ -1,7 +1,5 @@
-/*
- * Copyright (C) 2024, Chain4Travel AG. All rights reserved.
- * See the file LICENSE for licensing terms.
- */
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
 
 package matrix
 

--- a/internal/messaging/compressor.go
+++ b/internal/messaging/compressor.go
@@ -1,7 +1,5 @@
-/*
- * Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
- * See the file LICENSE for licensing terms.
- */
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
 
 package messaging
 

--- a/internal/messaging/compressor_test.go
+++ b/internal/messaging/compressor_test.go
@@ -1,7 +1,5 @@
-/*
- * Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
- * See the file LICENSE for licensing terms.
- */
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
 
 package messaging
 

--- a/internal/messaging/messenger.go
+++ b/internal/messaging/messenger.go
@@ -1,7 +1,5 @@
-/*
- * Copyright (C) 2024, Chain4Travel AG. All rights reserved.
- * See the file LICENSE for licensing terms.
- */
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
 
 package messaging
 

--- a/internal/messaging/mint.go
+++ b/internal/messaging/mint.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package messaging
 
 import (

--- a/internal/messaging/mint_v1.go
+++ b/internal/messaging/mint_v1.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package messaging
 
 import (

--- a/internal/messaging/mint_v2.go
+++ b/internal/messaging/mint_v2.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package messaging
 
 import (

--- a/internal/messaging/noop_response_handler.go
+++ b/internal/messaging/noop_response_handler.go
@@ -1,7 +1,5 @@
-/*
- * Copyright (C) 2024, Chain4Travel AG. All rights reserved.
- * See the file LICENSE for licensing terms.
- */
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
 
 package messaging
 

--- a/internal/messaging/processor.go
+++ b/internal/messaging/processor.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package messaging
 
 import (

--- a/internal/messaging/processor_test.go
+++ b/internal/messaging/processor_test.go
@@ -1,7 +1,5 @@
-/*
- * Copyright (C) 2024, Chain4Travel AG. All rights reserved.
- * See the file LICENSE for licensing terms.
- */
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
 
 package messaging
 

--- a/internal/messaging/response_handler.go
+++ b/internal/messaging/response_handler.go
@@ -1,5 +1,5 @@
-//  Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
-//  See the file LICENSE for licensing terms.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
 
 package messaging
 

--- a/internal/messaging/service_registry.go
+++ b/internal/messaging/service_registry.go
@@ -1,7 +1,6 @@
-/*
- * Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
- * See the file LICENSE for licensing terms.
- */
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package messaging
 
 import (

--- a/internal/messaging/types/types.go
+++ b/internal/messaging/types/types.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package types
 
 import (

--- a/internal/messaging/types/types_test.go
+++ b/internal/messaging/types/types_test.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package types
 
 import (

--- a/internal/metadata/checkpoint.go
+++ b/internal/metadata/checkpoint.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package metadata
 
 type Checkpoint interface {

--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package metadata
 
 import (

--- a/internal/rpc/client/client.go
+++ b/internal/rpc/client/client.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package client
 
 import (

--- a/internal/rpc/rpc.go
+++ b/internal/rpc/rpc.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package rpc
 
 import (

--- a/internal/rpc/server/server.go
+++ b/internal/rpc/server/server.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package server
 
 import (

--- a/internal/tracing/exporter.go
+++ b/internal/tracing/exporter.go
@@ -1,7 +1,5 @@
-/*
- * Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
- * See the file LICENSE for licensing terms.
- */
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
 
 package tracing
 

--- a/internal/tracing/nooptracer.go
+++ b/internal/tracing/nooptracer.go
@@ -1,7 +1,5 @@
-/*
- * Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
- * See the file LICENSE for licensing terms.
- */
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
 
 package tracing
 

--- a/internal/tracing/nooptracer_test.go
+++ b/internal/tracing/nooptracer_test.go
@@ -1,7 +1,5 @@
-/*
- * Copyright (C) 2024, Chain4Travel AG. All rights reserved.
- * See the file LICENSE for licensing terms.
- */
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
 
 package tracing
 

--- a/internal/tracing/tracer.go
+++ b/internal/tracing/tracer.go
@@ -1,7 +1,5 @@
-/*
- * Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
- * See the file LICENSE for licensing terms.
- */
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
 
 package tracing
 

--- a/internal/tracing/tracer_test.go
+++ b/internal/tracing/tracer_test.go
@@ -1,7 +1,5 @@
-/*
- * Copyright (C) 2024, Chain4Travel AG. All rights reserved.
- * See the file LICENSE for licensing terms.
- */
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
 
 package tracing
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package version
 
 import (

--- a/main.go
+++ b/main.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package main
 
 import (

--- a/pkg/booking/booking.go
+++ b/pkg/booking/booking.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package booking
 
 import (

--- a/pkg/chequehandler/cheque_handler.go
+++ b/pkg/chequehandler/cheque_handler.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package chequehandler
 
 import (

--- a/pkg/chequehandler/cheque_record.go
+++ b/pkg/chequehandler/cheque_record.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package chequehandler
 
 import (

--- a/pkg/chequehandler/issued_cheque_record.go
+++ b/pkg/chequehandler/issued_cheque_record.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package chequehandler
 
 import (

--- a/pkg/chequehandler/storage/sqlite/cheque_records.go
+++ b/pkg/chequehandler/storage/sqlite/cheque_records.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package sqlite
 
 import (

--- a/pkg/chequehandler/storage/sqlite/issued_cheque_records.go
+++ b/pkg/chequehandler/storage/sqlite/issued_cheque_records.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package sqlite
 
 import (

--- a/pkg/chequehandler/storage/sqlite/storage.go
+++ b/pkg/chequehandler/storage/sqlite/storage.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package sqlite
 
 import (

--- a/pkg/cheques/cheques.go
+++ b/pkg/cheques/cheques.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package cheques
 
 import (

--- a/pkg/cheques/eth_typed_data.go
+++ b/pkg/cheques/eth_typed_data.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package cheques
 
 import (

--- a/pkg/cheques/signer.go
+++ b/pkg/cheques/signer.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package cheques
 
 import (

--- a/pkg/cheques/signer_test.go
+++ b/pkg/cheques/signer_test.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package cheques
 
 import (

--- a/pkg/cm_accounts/cm_accounts.go
+++ b/pkg/cm_accounts/cm_accounts.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package cmaccounts
 
 import (

--- a/pkg/database/sqlite/session.go
+++ b/pkg/database/sqlite/session.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package sqlite
 
 import (

--- a/pkg/database/sqlite/storage.go
+++ b/pkg/database/sqlite/storage.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package sqlite
 
 import (

--- a/pkg/erc20/erc20.go
+++ b/pkg/erc20/erc20.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package erc20
 
 import (

--- a/pkg/events/listener.go
+++ b/pkg/events/listener.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package events
 
 import (

--- a/pkg/matrix/types.go
+++ b/pkg/matrix/types.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package matrix
 
 import (

--- a/pkg/scheduler/job.go
+++ b/pkg/scheduler/job.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package scheduler
 
 import "time"

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package scheduler
 
 import (

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package scheduler
 
 import (

--- a/pkg/scheduler/storage/sqlite/jobs.go
+++ b/pkg/scheduler/storage/sqlite/jobs.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package sqlite
 
 import (

--- a/pkg/scheduler/storage/sqlite/storage.go
+++ b/pkg/scheduler/storage/sqlite/storage.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package sqlite
 
 import (

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -23,7 +23,7 @@ install_golangci_lint() {
 
 # Function to check license headers in go files
 check_license_header() {
-  go install -v github.com/chain4travel/camino-license@228ce5f90b99b1f9b20554ac207bef4c623594c5
+  go install -v github.com/chain4travel/camino-license@v0.1.0
   CAMINOBOT_PATH=$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd .. && pwd)
   echo "camino-license check --config=./header.yaml '${CAMINOBOT_PATH}'"
   camino-license check --config=./header.yaml "${CAMINOBOT_PATH}"

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -21,6 +21,14 @@ install_golangci_lint() {
     go install -v github.com/golangci/golangci-lint/cmd/golangci-lint@v$EXPECTED_VERSION
 }
 
+# Function to check license headers in go files
+check_license_header() {
+  go install -v github.com/chain4travel/camino-license@228ce5f90b99b1f9b20554ac207bef4c623594c5
+  CAMINOBOT_PATH=$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd .. && pwd)
+  echo "camino-license check --config=./header.yaml '${CAMINOBOT_PATH}'"
+  camino-license check --config=./header.yaml "${CAMINOBOT_PATH}"
+}
+
 # Check if golangci-lint is installed
 if golangci_lint_installed; then
     echo "golangci-lint is already installed."
@@ -32,3 +40,8 @@ fi
 # Run golangci-lint
 echo "Running golangci-lint..."
 golangci-lint run --config .golangci.yml
+
+
+# Run camino-license
+echo "Running camino-license"
+check_license_header

--- a/utils/tls/tls.go
+++ b/utils/tls/tls.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package utils
 
 import (


### PR DESCRIPTION
* Adding license headers to all go files
* excluded mock files, generated files and camino-matrix-go (please review the header.yaml)