### PR TITLE
update year in .golangci.yml and LICENSE

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,4 @@
-# Copyright (C) 2024, Chain4Travel AG. All rights reserved.
+# Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 # See the file LICENSE for licensing terms.
 
 # https://golangci-lint.run/usage/configuration/

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (C) 2024, Chain4Travel AG.
+Copyright (C) 2025, Chain4Travel AG.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/cmd/camino_messenger_bot.go
+++ b/cmd/camino_messenger_bot.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package cmd

--- a/config/config.go
+++ b/config/config.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package config

--- a/config/config_reader.go
+++ b/config/config_reader.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package config

--- a/config/config_reader_test.go
+++ b/config/config_reader_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package config

--- a/config/flags.go
+++ b/config/flags.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package config

--- a/examples/booking/mintnbuy.go
+++ b/examples/booking/mintnbuy.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package main

--- a/examples/events/listen.go
+++ b/examples/events/listen.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package main

--- a/examples/rpc/client.go
+++ b/examples/rpc/client.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package main

--- a/examples/rpc/partner-plugin/handlers/mint_v1.go
+++ b/examples/rpc/partner-plugin/handlers/mint_v1.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package handlers

--- a/examples/rpc/partner-plugin/handlers/mint_v2.go
+++ b/examples/rpc/partner-plugin/handlers/mint_v2.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package handlers

--- a/examples/rpc/partner-plugin/server.go
+++ b/examples/rpc/partner-plugin/server.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package main

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package app

--- a/internal/compression/compress.go
+++ b/internal/compression/compress.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package compression

--- a/internal/compression/decompress.go
+++ b/internal/compression/decompress.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package compression

--- a/internal/matrix/matrix_messenger.go
+++ b/internal/matrix/matrix_messenger.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package matrix

--- a/internal/matrix/msg_assembler.go
+++ b/internal/matrix/msg_assembler.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package matrix

--- a/internal/matrix/msg_assembler_test.go
+++ b/internal/matrix/msg_assembler_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package matrix

--- a/internal/matrix/room_handler.go
+++ b/internal/matrix/room_handler.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package matrix

--- a/internal/matrix/room_handler_test.go
+++ b/internal/matrix/room_handler_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package matrix

--- a/internal/messaging/compressor.go
+++ b/internal/messaging/compressor.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package messaging

--- a/internal/messaging/compressor_test.go
+++ b/internal/messaging/compressor_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package messaging

--- a/internal/messaging/messenger.go
+++ b/internal/messaging/messenger.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package messaging

--- a/internal/messaging/mint.go
+++ b/internal/messaging/mint.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package messaging

--- a/internal/messaging/mint_v1.go
+++ b/internal/messaging/mint_v1.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package messaging

--- a/internal/messaging/mint_v2.go
+++ b/internal/messaging/mint_v2.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package messaging

--- a/internal/messaging/noop_response_handler.go
+++ b/internal/messaging/noop_response_handler.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package messaging

--- a/internal/messaging/processor.go
+++ b/internal/messaging/processor.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package messaging

--- a/internal/messaging/processor_test.go
+++ b/internal/messaging/processor_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package messaging

--- a/internal/messaging/response_handler.go
+++ b/internal/messaging/response_handler.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package messaging

--- a/internal/messaging/service_registry.go
+++ b/internal/messaging/service_registry.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package messaging

--- a/internal/messaging/types/types.go
+++ b/internal/messaging/types/types.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package types

--- a/internal/messaging/types/types_test.go
+++ b/internal/messaging/types/types_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package types

--- a/internal/metadata/checkpoint.go
+++ b/internal/metadata/checkpoint.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package metadata

--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package metadata

--- a/internal/rpc/client/client.go
+++ b/internal/rpc/client/client.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package client

--- a/internal/rpc/rpc.go
+++ b/internal/rpc/rpc.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package rpc

--- a/internal/rpc/server/server.go
+++ b/internal/rpc/server/server.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package server

--- a/internal/tracing/exporter.go
+++ b/internal/tracing/exporter.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package tracing

--- a/internal/tracing/nooptracer.go
+++ b/internal/tracing/nooptracer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package tracing

--- a/internal/tracing/nooptracer_test.go
+++ b/internal/tracing/nooptracer_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package tracing

--- a/internal/tracing/tracer.go
+++ b/internal/tracing/tracer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package tracing

--- a/internal/tracing/tracer_test.go
+++ b/internal/tracing/tracer_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package tracing

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package version

--- a/main.go
+++ b/main.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package main

--- a/pkg/booking/booking.go
+++ b/pkg/booking/booking.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package booking

--- a/pkg/chequehandler/cheque_handler.go
+++ b/pkg/chequehandler/cheque_handler.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package chequehandler

--- a/pkg/chequehandler/cheque_record.go
+++ b/pkg/chequehandler/cheque_record.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package chequehandler

--- a/pkg/chequehandler/issued_cheque_record.go
+++ b/pkg/chequehandler/issued_cheque_record.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package chequehandler

--- a/pkg/chequehandler/storage/sqlite/cheque_records.go
+++ b/pkg/chequehandler/storage/sqlite/cheque_records.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package sqlite

--- a/pkg/chequehandler/storage/sqlite/issued_cheque_records.go
+++ b/pkg/chequehandler/storage/sqlite/issued_cheque_records.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package sqlite

--- a/pkg/chequehandler/storage/sqlite/storage.go
+++ b/pkg/chequehandler/storage/sqlite/storage.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package sqlite

--- a/pkg/cheques/cheques.go
+++ b/pkg/cheques/cheques.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package cheques

--- a/pkg/cheques/eth_typed_data.go
+++ b/pkg/cheques/eth_typed_data.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package cheques

--- a/pkg/cheques/signer.go
+++ b/pkg/cheques/signer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package cheques

--- a/pkg/cheques/signer_test.go
+++ b/pkg/cheques/signer_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package cheques

--- a/pkg/cm_accounts/cm_accounts.go
+++ b/pkg/cm_accounts/cm_accounts.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package cmaccounts

--- a/pkg/database/sqlite/session.go
+++ b/pkg/database/sqlite/session.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package sqlite

--- a/pkg/database/sqlite/storage.go
+++ b/pkg/database/sqlite/storage.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package sqlite

--- a/pkg/erc20/erc20.go
+++ b/pkg/erc20/erc20.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package erc20

--- a/pkg/events/listener.go
+++ b/pkg/events/listener.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package events

--- a/pkg/matrix/types.go
+++ b/pkg/matrix/types.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package matrix

--- a/pkg/scheduler/job.go
+++ b/pkg/scheduler/job.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package scheduler

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package scheduler

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package scheduler

--- a/pkg/scheduler/storage/sqlite/jobs.go
+++ b/pkg/scheduler/storage/sqlite/jobs.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package sqlite

--- a/pkg/scheduler/storage/sqlite/storage.go
+++ b/pkg/scheduler/storage/sqlite/storage.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package sqlite

--- a/pp-mock/handlers/accommodation/v1/accommodation_product_info.go
+++ b/pp-mock/handlers/accommodation/v1/accommodation_product_info.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package handlers

--- a/pp-mock/handlers/accommodation/v1/accommodation_product_list.go
+++ b/pp-mock/handlers/accommodation/v1/accommodation_product_list.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package handlers

--- a/pp-mock/handlers/accommodation/v1/accommodation_search.go
+++ b/pp-mock/handlers/accommodation/v1/accommodation_search.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package handlers

--- a/pp-mock/handlers/accommodation/v2/accommodation_product_info.go
+++ b/pp-mock/handlers/accommodation/v2/accommodation_product_info.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package handlers

--- a/pp-mock/handlers/accommodation/v2/accommodation_product_list.go
+++ b/pp-mock/handlers/accommodation/v2/accommodation_product_list.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package handlers

--- a/pp-mock/handlers/accommodation/v2/accommodation_search.go
+++ b/pp-mock/handlers/accommodation/v2/accommodation_search.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package handlers

--- a/pp-mock/handlers/book/mint/v1/mint_v1.go
+++ b/pp-mock/handlers/book/mint/v1/mint_v1.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package handlers

--- a/pp-mock/handlers/book/mint/v2/mint_v2.go
+++ b/pp-mock/handlers/book/mint/v2/mint_v2.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package handlers

--- a/pp-mock/handlers/book/validation/v1/validation_v1.go
+++ b/pp-mock/handlers/book/validation/v1/validation_v1.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package handlers

--- a/pp-mock/handlers/book/validation/v2/validation_v2.go
+++ b/pp-mock/handlers/book/validation/v2/validation_v2.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package handlers

--- a/pp-mock/handlers/common.go
+++ b/pp-mock/handlers/common.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package common

--- a/pp-mock/handlers/ping/v1/ping_handler.go
+++ b/pp-mock/handlers/ping/v1/ping_handler.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package handlers

--- a/pp-mock/server.go
+++ b/pp-mock/server.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package main

--- a/utils/tls/tls.go
+++ b/utils/tls/tls.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package utils


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

- **Documentation**
    - Updated copyright notices from 2024 to 2025 across multiple files in the project
    - Updated allowed time period in `pp-mock/handlers/common.go` from June 1, 2024 to June 30, 2024, to June 1, 2025 to June 30, 2025

- **Chores**
    - Routine maintenance of copyright information
    - No functional changes to code logic or structure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->