### PR TITLE
update year to 2025

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,4 @@
-# Copyright (C) 2024, Chain4Travel AG. All rights reserved.
+# Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 # See the file LICENSE for licensing terms.
 
 # https://golangci-lint.run/usage/configuration/

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (C) 2025, Chain4Travel AG.
+Copyright (C) 2022-2025, Chain4Travel AG.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (C) 2024, Chain4Travel AG.
+Copyright (C) 2025, Chain4Travel AG.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated copyright year range from 2024 to 2022-2025 in configuration and license files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->