### PR TITLE
Implement TransportProductList message - TransportProductList, TransportSearch Mock examples

### DIFF
--- a/examples/rpc/partner-plugin/server.go
+++ b/examples/rpc/partner-plugin/server.go
@@ -25,7 +25,7 @@ import (
 	"buf.build/gen/go/chain4travel/camino-messenger-protocol/grpc/go/cmp/services/ping/v1/pingv1grpc"
 	"buf.build/gen/go/chain4travel/camino-messenger-protocol/grpc/go/cmp/services/seat_map/v2/seat_mapv2grpc"
 	"buf.build/gen/go/chain4travel/camino-messenger-protocol/grpc/go/cmp/services/seat_map/v3/seat_mapv3grpc"
-	"buf.build/gen/go/chain4travel/camino-messenger-protocol/grpc/go/cmp/services/transport/v2/transportv2grpc"
+	"buf.build/gen/go/chain4travel/camino-messenger-protocol/grpc/go/cmp/services/transport/v3/transportv3grpc"
 	accommodationv3 "buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go/cmp/services/accommodation/v3"
 	activityv2 "buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go/cmp/services/activity/v2"
 	activityv3 "buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go/cmp/services/activity/v3"
@@ -37,7 +37,7 @@ import (
 	partnerv2 "buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go/cmp/services/partner/v2"
 	pingv1 "buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go/cmp/services/ping/v1"
 	seat_mapv3 "buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go/cmp/services/seat_map/v3"
-	transportv2 "buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go/cmp/services/transport/v2"
+	transportv3 "buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go/cmp/services/transport/v3"
 	typesv1 "buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go/cmp/types/v1"
 	typesv2 "buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go/cmp/types/v2"
 	typesv3 "buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go/cmp/types/v3"
@@ -61,7 +61,8 @@ type partnerPlugin struct {
 	accommodationv3grpc.AccommodationProductListServiceServer
 	accommodationv3grpc.AccommodationSearchServiceServer
 	partnerv2grpc.GetPartnerConfigurationServiceServer
-	transportv2grpc.TransportSearchServiceServer
+	transportv3grpc.TransportSearchServiceServer
+	transportv3grpc.TransportProductListServiceServer
 	seat_mapv2grpc.SeatMapServiceServer
 	seat_mapv2grpc.SeatMapAvailabilityServiceServer
 	infov2grpc.CountryEntryRequirementsServiceServer
@@ -461,18 +462,410 @@ func (p *partnerPlugin) Ping(ctx context.Context, request *pingv1.PingRequest) (
 	}, nil
 }
 
-func (p *partnerPlugin) TransportSearch(ctx context.Context, _ *transportv2.TransportSearchRequest) (*transportv2.TransportSearchResponse, error) {
+func (p *partnerPlugin) TransportSearch(ctx context.Context, _ *transportv3.TransportSearchRequest) (*transportv3.TransportSearchResponse, error) {
 	md := metadata.Metadata{}
 	err := md.ExtractMetadata(ctx)
 	if err != nil {
 		log.Print("error extracting metadata")
 	}
 	md.Stamp(fmt.Sprintf("%s-%s", "ext-system", "response"))
-	log.Printf("Responding to request: %s (TransportSearch)", md.RequestID)
+	log.Printf("Responding to request: %s (TransportSearch) v3", md.RequestID)
 
-	response := transportv2.TransportSearchResponse{
-		Header:   nil,
-		Metadata: &typesv2.SearchResponseMetadata{SearchId: &typesv1.UUID{Value: md.RequestID}},
+	response := transportv3.TransportSearchResponse{
+		Header: &typesv1.ResponseHeader{
+			Status: typesv1.StatusType_STATUS_TYPE_SUCCESS,
+		},
+		Metadata: &typesv3.SearchResponseMetadata{
+			SearchId: &typesv1.UUID{Value: md.RequestID},
+		},
+		ContentSourceTypes: []typesv1.ContentSourceType{
+			typesv1.ContentSourceType_CONTENT_SOURCE_TYPE_GDS,
+			typesv1.ContentSourceType_CONTENT_SOURCE_TYPE_NDC,
+		},
+		Results: []*transportv3.TransportSearchResult{{
+			ResultId:     0,
+			QueryId:      0,
+			OfferId:      "123456",
+			TravellerIds: []int32{123, 456},
+			TravellingTrips: []*transportv3.TripExtended{{
+				SupplierCode: &typesv2.SupplierProductCode{
+					SupplierCode:   "XY",
+					SupplierNumber: 123,
+				},
+				Baggage: &typesv1.Baggage{
+					MaxCount: 5,
+					MaxWeight: &typesv1.Weight{
+						Value: 20,
+						Unit:  typesv1.WeightUnit_WEIGHT_UNIT_KILOGRAM,
+					},
+					MaxDimension: &typesv1.Dimension{
+						Length: 45,
+						Width:  90,
+						Height: 75,
+						Unit:   typesv1.LengthUnit_LENGTH_UNIT_CENTIMETER,
+					},
+				},
+				Price: &typesv3.Price{
+					Value:    "180",
+					Decimals: 2,
+					Currency: &typesv3.Currency{
+						Currency: &typesv3.Currency_IsoCurrency{
+							IsoCurrency: typesv3.IsoCurrency_ISO_CURRENCY_EUR,
+						},
+					},
+				},
+				Segments: []*transportv3.SegmentExtended{{
+					Info: &transportv3.Segment{
+						SegmentId:    "SEG123",
+						ProviderCode: "BAW", // British Airways
+						ProductCode: &typesv2.ProductCode{
+							Code:   "BA",
+							Number: 123,
+							Type:   typesv2.ProductCodeType_PRODUCT_CODE_TYPE_SUPPLIER,
+						},
+						SupplierCode: &typesv2.SupplierProductCode{
+							SupplierCode:   "BAW",
+							SupplierNumber: 123,
+						},
+						Departure: &transportv3.TransitEvent{
+							DateTime: timestamppb.New(time.Date(2024, 9, 20, 9, 0, 0, 0, time.UTC)),
+							LocationCode: &typesv2.LocationCode{
+								Code: "LHR",
+								Type: typesv2.LocationCodeType_LOCATION_CODE_TYPE_ICAO_CODE,
+							},
+						},
+						Arrival: &transportv3.TransitEvent{
+							DateTime: timestamppb.New(time.Date(2024, 9, 20, 11, 55, 0, 0, time.UTC)),
+							LocationCode: &typesv2.LocationCode{
+								Code: "JFK",
+								Type: typesv2.LocationCodeType_LOCATION_CODE_TYPE_ICAO_CODE,
+							},
+						},
+						SegmentDuration: &typesv1.Duration{
+							Minutes: 475,
+						},
+						SegmentDistance: &typesv1.Length{
+							Value: 5539,
+							Unit:  typesv1.LengthUnit_LENGTH_UNIT_KILOMETER,
+						},
+					},
+					ServiceTypeCode:        "Y",
+					ServiceTypeDescription: "Economy Class",
+					Services: []*typesv3.ServiceFact{{
+						Code:        "EC",
+						Description: "Early Check-in with Priority Boarding",
+						PriceDetail: &typesv3.PriceDetail{
+							Price: &typesv3.Price{
+								Value:    "10",
+								Decimals: 2,
+								Currency: &typesv3.Currency{
+									Currency: &typesv3.Currency_IsoCurrency{
+										IsoCurrency: typesv3.IsoCurrency_ISO_CURRENCY_EUR,
+									},
+								},
+							},
+							Binding:        false,
+							Description:    "Early Check-in with Priority Boarding",
+							LocallyPayable: true,
+						},
+						AvailabilityType: typesv3.ServiceAvailabilityType_SERVICE_AVAILABILITY_TYPE_OPTIONAL,
+						ChargeBasis:      typesv3.ChargeBasisType_CHARGE_BASIS_TYPE_PER_PAX,
+						Quantity:         1,
+						Details: []*typesv3.ServiceFact{
+							{
+								Code:             "PB",
+								Description:      "Priority Boarding",
+								AvailabilityType: typesv3.ServiceAvailabilityType_SERVICE_AVAILABILITY_TYPE_INCLUDED,
+								ChargeBasis:      typesv3.ChargeBasisType_CHARGE_BASIS_TYPE_PER_PAX,
+							}, {
+								Code:             "HB",
+								Description:      "Hand Baggage 10kg",
+								AvailabilityType: typesv3.ServiceAvailabilityType_SERVICE_AVAILABILITY_TYPE_INCLUDED,
+								ChargeBasis:      typesv3.ChargeBasisType_CHARGE_BASIS_TYPE_PER_PAX,
+								Quantity:         1,
+							},
+						},
+					}},
+					MinPax: 1,
+					MaxPax: 3,
+				}},
+			}},
+			TotalPrice: &typesv3.PriceDetail{
+				Price: &typesv3.Price{
+					Value:    "180",
+					Decimals: 2,
+					Currency: &typesv3.Currency{
+						Currency: &typesv3.Currency_IsoCurrency{
+							IsoCurrency: typesv3.IsoCurrency_ISO_CURRENCY_EUR,
+						},
+					},
+				},
+				Binding:     true,
+				Description: "Total price including all taxes and fees",
+				Breakdowns: []*typesv3.PriceDetail{
+					{
+						Price: &typesv3.Price{
+							Value:    "150",
+							Decimals: 2,
+							Currency: &typesv3.Currency{
+								Currency: &typesv3.Currency_IsoCurrency{
+									IsoCurrency: typesv3.IsoCurrency_ISO_CURRENCY_EUR,
+								},
+							},
+						},
+						Description: "Base price",
+						Type: &typesv1.PriceBreakdownType{
+							Code: "BASE",
+							Type: &typesv1.PriceBreakdownType_PriceType{
+								PriceType: typesv1.PriceType_PRICE_TYPE_BASE_RATE,
+							},
+						},
+					}, {
+						Price: &typesv3.Price{
+							Value:    "30",
+							Decimals: 2,
+							Currency: &typesv3.Currency{
+								Currency: &typesv3.Currency_IsoCurrency{
+									IsoCurrency: typesv3.IsoCurrency_ISO_CURRENCY_EUR,
+								},
+							},
+						},
+						Description: "VAT",
+						Type: &typesv1.PriceBreakdownType{
+							Code: "VAT",
+							Type: &typesv1.PriceBreakdownType_TaxCode{
+								TaxCode: typesv1.TaxCode_TAX_CODE_VALUE_ADDED_TAX,
+							},
+						},
+					},
+				},
+			},
+			RateRules: []*typesv1.RateRule{{
+				RateType:        typesv1.RateRuleType_RATE_RULE_TYPE_NON_REFUNDABLE,
+				RateDescription: "Non-refundable fare",
+			}},
+			Links: []*typesv1.Link{{
+				Type:        typesv1.LinkType_LINK_TYPE_BOOKING,
+				Description: "Booking link",
+				Ref:         "https://api.example.com/bookings/123456",
+			}},
+			Bookability: &typesv1.Bookability{
+				Type: typesv1.BookabilityType_BOOKABILITY_TYPE_AVAILABLE,
+				ConfirmationTime: &typesv1.Time{
+					Hours:   1,
+					Minutes: 0,
+				},
+			},
+			Validity: &typesv1.DateTimeRange{
+				StartDatetime: &timestamppb.Timestamp{
+					Seconds: time.Now().Unix(),
+				},
+				EndDatetime: &timestamppb.Timestamp{
+					Seconds: time.Now().Add(24 * time.Hour).Unix(),
+				},
+			},
+			CancelPolicy: &typesv3.CancelPolicy{
+				Refundable: true,
+				FreeCancellationUpto: &timestamppb.Timestamp{
+					Seconds: time.Now().Add(48 * time.Hour).Unix(),
+				},
+				CancelPenalties: []*typesv3.CancelPenalty{{
+					DatetimeRange: &typesv1.DateTimeRange{
+						StartDatetime: &timestamppb.Timestamp{
+							Seconds: time.Now().Add(48 * time.Hour).Unix(),
+						},
+						EndDatetime: &timestamppb.Timestamp{
+							Seconds: time.Now().Add(72 * time.Hour).Unix(),
+						},
+					},
+					Value: &typesv3.Price{
+						Value:    "50",
+						Decimals: 2,
+						Currency: &typesv3.Currency{
+							Currency: &typesv3.Currency_IsoCurrency{
+								IsoCurrency: typesv3.IsoCurrency_ISO_CURRENCY_EUR,
+							},
+						},
+					},
+					Description: "Late cancellation fee",
+				}},
+			},
+			ChangePolicy: &typesv3.ChangePolicy{
+				ChangeAllowed: true,
+				FreeChangeUpto: &timestamppb.Timestamp{
+					Seconds: time.Now().Add(48 * time.Hour).Unix(),
+				},
+				ChangeTypes: []*typesv3.ChangeType{{
+					Code: "CHANGE",
+					DatetimeRange: &typesv1.DateTimeRange{
+						StartDatetime: &timestamppb.Timestamp{
+							Seconds: time.Now().Add(48 * time.Hour).Unix(),
+						},
+						EndDatetime: &timestamppb.Timestamp{
+							Seconds: time.Now().Add(72 * time.Hour).Unix(),
+						},
+					},
+					Value: &typesv3.Price{
+						Value:    "30",
+						Decimals: 2,
+						Currency: &typesv3.Currency{
+							Currency: &typesv3.Currency_IsoCurrency{
+								IsoCurrency: typesv3.IsoCurrency_ISO_CURRENCY_EUR,
+							},
+						},
+					},
+					Description: "Late change fee",
+				}},
+			},
+			Observations: "Example transport search result with all fields populated",
+		}},
+		Travellers: []*typesv3.BasicTraveller{
+			{
+				TravellerId: 123,
+				Type:        typesv3.TravellerType_TRAVELLER_TYPE_ADULT,
+			}, {
+				TravellerId: 456,
+				Type:        typesv3.TravellerType_TRAVELLER_TYPE_CHILD,
+			},
+		},
+	}
+	log.Printf("CMAccount %s received request from CMAccount %s", md.Recipient, md.Sender)
+
+	grpc.SendHeader(ctx, md.ToGrpcMD())
+	return &response, nil
+}
+
+func (p *partnerPlugin) TransportProductList(ctx context.Context, _ *transportv3.TransportProductListRequest) (*transportv3.TransportProductListResponse, error) {
+	md := metadata.Metadata{}
+	err := md.ExtractMetadata(ctx)
+	if err != nil {
+		log.Print("error extracting metadata")
+	}
+	md.Stamp(fmt.Sprintf("%s-%s", "ext-system", "response"))
+	log.Printf("Responding to request: %s (TransportProductList)", md.RequestID)
+
+	response := transportv3.TransportProductListResponse{
+		Header: &typesv1.ResponseHeader{
+			Status: typesv1.StatusType_STATUS_TYPE_SUCCESS,
+		},
+		Trips: []*transportv3.TripBasic{{
+			SupplierCode: &typesv2.SupplierProductCode{
+				SupplierCode:   "XY",
+				SupplierNumber: 123,
+			},
+			Segments: []*transportv3.Segment{{
+				SegmentId:    "SEG123",
+				ProviderCode: "I2",
+				ProductCode: &typesv2.ProductCode{
+					Code:   "XY",
+					Number: 123,
+					Type:   typesv2.ProductCodeType_PRODUCT_CODE_TYPE_SUPPLIER,
+				},
+				SupplierCode: &typesv2.SupplierProductCode{
+					SupplierCode:   "XY",
+					SupplierNumber: 123,
+				},
+				Departure: &transportv3.TransitEvent{
+					DateTime: timestamppb.New(time.Date(2024, 9, 20, 9, 0, 0, 0, time.UTC)),
+					LocationCode: &typesv2.LocationCode{
+						Code: "LHR",
+						Type: typesv2.LocationCodeType_LOCATION_CODE_TYPE_ICAO_CODE,
+					},
+				},
+				Arrival: &transportv3.TransitEvent{
+					DateTime: timestamppb.New(time.Date(2024, 9, 20, 11, 55, 0, 0, time.UTC)),
+					LocationCode: &typesv2.LocationCode{
+						Code: "JFK",
+						Type: typesv2.LocationCodeType_LOCATION_CODE_TYPE_ICAO_CODE,
+					},
+				},
+				SegmentDuration: &typesv1.Duration{
+					Minutes: 475,
+				},
+				SegmentDistance: &typesv1.Length{
+					Value: 5539,
+					Unit:  typesv1.LengthUnit_LENGTH_UNIT_KILOMETER,
+				},
+			}},
+		}, {
+			SupplierCode: &typesv2.SupplierProductCode{
+				SupplierCode:   "XY",
+				SupplierNumber: 456,
+			},
+			Segments: []*transportv3.Segment{{
+				SegmentId:    "SEG456",
+				ProviderCode: "I2",
+				ProductCode: &typesv2.ProductCode{
+					Code:   "XY",
+					Number: 456,
+					Type:   typesv2.ProductCodeType_PRODUCT_CODE_TYPE_SUPPLIER,
+				},
+				SupplierCode: &typesv2.SupplierProductCode{
+					SupplierCode:   "XY",
+					SupplierNumber: 456,
+				},
+				Departure: &transportv3.TransitEvent{
+					DateTime: timestamppb.New(time.Date(2024, 9, 27, 23, 55, 0, 0, time.UTC)),
+					LocationCode: &typesv2.LocationCode{
+						Code: "SIN",
+						Type: typesv2.LocationCodeType_LOCATION_CODE_TYPE_ICAO_CODE,
+					},
+				},
+				Arrival: &transportv3.TransitEvent{
+					DateTime: timestamppb.New(time.Date(2024, 9, 28, 9, 30, 0, 0, time.UTC)),
+					LocationCode: &typesv2.LocationCode{
+						Code: "MEL",
+						Type: typesv2.LocationCodeType_LOCATION_CODE_TYPE_ICAO_CODE,
+					},
+				},
+				SegmentDuration: &typesv1.Duration{
+					Minutes: 455,
+				},
+				SegmentDistance: &typesv1.Length{
+					Value: 6024,
+					Unit:  typesv1.LengthUnit_LENGTH_UNIT_KILOMETER,
+				},
+			}},
+		}, {
+			SupplierCode: &typesv2.SupplierProductCode{
+				SupplierCode:   "XY",
+				SupplierNumber: 789,
+			},
+			Segments: []*transportv3.Segment{{
+				SegmentId:    "SEG789",
+				ProviderCode: "DB",
+				ProductCode: &typesv2.ProductCode{
+					Code:   "XY",
+					Number: 789,
+					Type:   typesv2.ProductCodeType_PRODUCT_CODE_TYPE_SUPPLIER,
+				},
+				SupplierCode: &typesv2.SupplierProductCode{
+					SupplierCode:   "XY",
+					SupplierNumber: 789,
+				},
+				Departure: &transportv3.TransitEvent{
+					DateTime: timestamppb.New(time.Date(2024, 9, 27, 15, 30, 0, 0, time.UTC)),
+					LocationCode: &typesv2.LocationCode{
+						Code: "PAR",
+						Type: typesv2.LocationCodeType_LOCATION_CODE_TYPE_UNSPECIFIED,
+					},
+				},
+				Arrival: &transportv3.TransitEvent{
+					DateTime: timestamppb.New(time.Date(2024, 9, 28, 16, 47, 0, 0, time.UTC)),
+					LocationCode: &typesv2.LocationCode{
+						Code: "LON",
+						Type: typesv2.LocationCodeType_LOCATION_CODE_TYPE_UNSPECIFIED,
+					},
+				},
+				SegmentDuration: &typesv1.Duration{
+					Minutes: 137,
+				},
+				SegmentDistance: &typesv1.Length{
+					Value: 495,
+					Unit:  typesv1.LengthUnit_LENGTH_UNIT_KILOMETER,
+				},
+			}},
+		}},
 	}
 	log.Printf("CMAccount %s received request from CMAccount %s", md.Recipient, md.Sender)
 
@@ -527,15 +920,13 @@ func (p *partnerPlugin) SeatMap(ctx context.Context, _ *seat_mapv3.SeatMapReques
 											},
 										},
 									},
-									Restrictions: []*typesv3.LocalizedSeatAttributeSet{
-										{
-											Language: typesv1.Language_LANGUAGE_EN,
-											SeatAttributes: []*typesv3.SeatAttribute{{
-												Name:        "Restricted Vision",
-												Description: "Seat behind a column",
-											}},
-										},
-									},
+									Restrictions: []*typesv3.LocalizedSeatAttributeSet{{
+										Language: typesv1.Language_LANGUAGE_EN,
+										SeatAttributes: []*typesv3.SeatAttribute{{
+											Name:        "Restricted Vision",
+											Description: "Seat behind a column",
+										}},
+									}},
 									Features: []*typesv3.LocalizedSeatAttributeSet{
 										{
 											Language: typesv1.Language_LANGUAGE_EN,
@@ -857,7 +1248,8 @@ func main() {
 	accommodationv3grpc.RegisterAccommodationSearchServiceServer(grpcServer, &partnerPlugin{})
 	partnerv2grpc.RegisterGetPartnerConfigurationServiceServer(grpcServer, &partnerPlugin{})
 	bookv2grpc.RegisterValidationServiceServer(grpcServer, &partnerPlugin{})
-	transportv2grpc.RegisterTransportSearchServiceServer(grpcServer, &partnerPlugin{})
+	transportv3grpc.RegisterTransportProductListServiceServer(grpcServer, &partnerPlugin{})
+	transportv3grpc.RegisterTransportSearchServiceServer(grpcServer, &partnerPlugin{})
 	seat_mapv3grpc.RegisterSeatMapServiceServer(grpcServer, &partnerPlugin{})
 	seat_mapv3grpc.RegisterSeatMapAvailabilityServiceServer(grpcServer, &partnerPlugin{})
 	infov2grpc.RegisterCountryEntryRequirementsServiceServer(grpcServer, &partnerPlugin{})

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/chain4travel/camino-messenger-bot
 go 1.23.5
 
 require (
-	buf.build/gen/go/chain4travel/camino-messenger-protocol/grpc/go v1.5.1-00000000000000-a57016294956.1
-	buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go v1.36.4-00000000000000-66f585c173ec.1
+	buf.build/gen/go/chain4travel/camino-messenger-protocol/grpc/go v1.5.1-00000000000000-dfcc02fb40a1.2
+	buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go v1.36.5-00000000000000-dfcc02fb40a1.1
 	github.com/chain4travel/camino-messenger-contracts/go/contracts v0.0.0-20250129104547-90f8b12cd935
 	github.com/chain4travel/caminogoeth-compat v1.1.0-rc1
 	github.com/ethereum/go-ethereum v1.14.12
@@ -102,7 +102,7 @@ require (
 	golang.org/x/net v0.32.0 // indirect
 	golang.org/x/sys v0.28.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20241202173237-19429a94021a // indirect
-	google.golang.org/protobuf v1.36.4
+	google.golang.org/protobuf v1.36.5
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1
 	maunium.net/go/mautrix v0.15.1

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,5 @@
-buf.build/gen/go/chain4travel/camino-messenger-protocol/grpc/go v1.5.1-00000000000000-a57016294956.1 h1:rY4qUmMNZIJmAZUFmYIO5rHexSkVe13K58Qv7LUDww8=
-buf.build/gen/go/chain4travel/camino-messenger-protocol/grpc/go v1.5.1-00000000000000-a57016294956.1/go.mod h1:0YOjagkIW9UdhVmCGHDk4gG0pcDfp5LOtqdPR5xICcM=
 buf.build/gen/go/chain4travel/camino-messenger-protocol/grpc/go v1.5.1-00000000000000-dfcc02fb40a1.2 h1:AGQLM9oKlnRRTwYl8/hEca0LiL/xFFds1frtzYpIq3o=
 buf.build/gen/go/chain4travel/camino-messenger-protocol/grpc/go v1.5.1-00000000000000-dfcc02fb40a1.2/go.mod h1:CqAODm+b53bn1beSnm+S2rL1BNAD7e7VT8bk4dLhQsI=
-buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go v1.36.4-00000000000000-66f585c173ec.1 h1:j643037Upza4vzAQNs+bNfZk49xpP2dDPv5rj0yu+vw=
-buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go v1.36.4-00000000000000-66f585c173ec.1/go.mod h1:9d+BFo/9Ahuwf3KvEO2sjQ0oX3Bd+Bw+GgFIbv+ZkGc=
 buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go v1.36.5-00000000000000-dfcc02fb40a1.1 h1:LBXr578JzajKZxx7Z35eWSsnBtujtP+ONwgAoORd67M=
 buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go v1.36.5-00000000000000-dfcc02fb40a1.1/go.mod h1:C1b9bYCxJU3E5amzEKULbY6cVs0TT7YrrmzqgIqbQFg=
 filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
@@ -448,8 +444,6 @@ google.golang.org/protobuf v1.21.0/go.mod h1:47Nbq4nVaFHyn7ilMalzfO3qCViNmqZ2kzi
 google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
-google.golang.org/protobuf v1.36.4 h1:6A3ZDJHn/eNqc1i+IdefRzy/9PokBTPvcqMySR7NNIM=
-google.golang.org/protobuf v1.36.4/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojtC/QF5bRE=
 google.golang.org/protobuf v1.36.5 h1:tPhr+woSbjfYvY6/GPufUoYizxw1cF/yFoxJ2fmpwlM=
 google.golang.org/protobuf v1.36.5/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojtC/QF5bRE=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,11 @@
 buf.build/gen/go/chain4travel/camino-messenger-protocol/grpc/go v1.5.1-00000000000000-a57016294956.1 h1:rY4qUmMNZIJmAZUFmYIO5rHexSkVe13K58Qv7LUDww8=
 buf.build/gen/go/chain4travel/camino-messenger-protocol/grpc/go v1.5.1-00000000000000-a57016294956.1/go.mod h1:0YOjagkIW9UdhVmCGHDk4gG0pcDfp5LOtqdPR5xICcM=
+buf.build/gen/go/chain4travel/camino-messenger-protocol/grpc/go v1.5.1-00000000000000-dfcc02fb40a1.2 h1:AGQLM9oKlnRRTwYl8/hEca0LiL/xFFds1frtzYpIq3o=
+buf.build/gen/go/chain4travel/camino-messenger-protocol/grpc/go v1.5.1-00000000000000-dfcc02fb40a1.2/go.mod h1:CqAODm+b53bn1beSnm+S2rL1BNAD7e7VT8bk4dLhQsI=
 buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go v1.36.4-00000000000000-66f585c173ec.1 h1:j643037Upza4vzAQNs+bNfZk49xpP2dDPv5rj0yu+vw=
 buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go v1.36.4-00000000000000-66f585c173ec.1/go.mod h1:9d+BFo/9Ahuwf3KvEO2sjQ0oX3Bd+Bw+GgFIbv+ZkGc=
+buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go v1.36.5-00000000000000-dfcc02fb40a1.1 h1:LBXr578JzajKZxx7Z35eWSsnBtujtP+ONwgAoORd67M=
+buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go v1.36.5-00000000000000-dfcc02fb40a1.1/go.mod h1:C1b9bYCxJU3E5amzEKULbY6cVs0TT7YrrmzqgIqbQFg=
 filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
 filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
 github.com/DATA-DOG/go-sqlmock v1.5.1 h1:FK6RCIUSfmbnI/imIICmboyQBkOckutaa6R5YYlLZyo=
@@ -446,6 +450,8 @@ google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp0
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.36.4 h1:6A3ZDJHn/eNqc1i+IdefRzy/9PokBTPvcqMySR7NNIM=
 google.golang.org/protobuf v1.36.4/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojtC/QF5bRE=
+google.golang.org/protobuf v1.36.5 h1:tPhr+woSbjfYvY6/GPufUoYizxw1cF/yFoxJ2fmpwlM=
+google.golang.org/protobuf v1.36.5/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojtC/QF5bRE=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=

--- a/pp-mock/docs/example-messages/transport_product_list.json
+++ b/pp-mock/docs/example-messages/transport_product_list.json
@@ -1,0 +1,6 @@
+{
+    "modified_after": {
+        "nanos": 0,
+        "seconds": "1710489050"
+    }
+}

--- a/pp-mock/docs/example-messages/transport_search.json
+++ b/pp-mock/docs/example-messages/transport_search.json
@@ -1,0 +1,140 @@
+{
+    "queries": [
+        {
+            "query_id": 1,
+            "travellers": [
+                {
+                    "traveller_id": 1,
+                    "type": 0,
+                    "birthdate": {
+                        "year": 1990,
+                        "month": 1,
+                        "day": 15
+                    },
+                    "nationality": "COUNTRY_MH"
+                }
+            ],
+            "trips": [
+                {
+                    "arrival": {
+                        "date": {
+                            "year": 2025,
+                            "month": 4,
+                            "day": 9
+                        }
+                    },
+                    "departure": {
+                        "date": {
+                            "year": 2025,
+                            "month": 4,
+                            "day": 8
+                        }
+                    },
+                    "search_parameters_transport": {
+                        "product_codes": [
+                            {
+                                "code": "IATA4589",
+                                "type": 3
+                            },
+                            {
+                                "code": "IATA1234",
+                                "type": 3
+                            },
+                            {
+                                "code": "IATA5678",
+                                "type": 3
+                            }
+                        ],
+                        "max_price": {
+                            "value": "150000",
+                            "decimals": 2,
+                            "currency": {
+                                "iso_currency": "ISO_CURRENCY_EUR"
+                            }
+                        },
+                        "max_segments": 3
+                    }
+                }
+            ]
+        },
+        {
+            "query_id": 2,
+            "travellers": [],
+            "trips": [
+                {
+                    "arrival": {
+                        "date": {
+                            "year": 2025,
+                            "month": 4,
+                            "day": 3
+                        }
+                    },
+                    "departure": {
+                        "date": {
+                            "year": 2025,
+                            "month": 4,
+                            "day": 1
+                        }
+                    },
+                    "search_parameters_transport": {
+                        "product_codes": [
+                            {
+                                "code": "IATA1234",
+                                "type": 3
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        {
+            "query_id": 3,
+            "travellers": [
+                {
+                    "traveller_id": 1,
+                    "type": 0,
+                    "birthdate": {
+                        "year": 1990,
+                        "month": 4,
+                        "day": 15
+                    },
+                    "nationality": "COUNTRY_MH"
+                }
+            ],
+            "trips": [
+                {
+                    "arrival": {
+                        "date": {
+                            "year": 2025,
+                            "month": 4,
+                            "day": 9
+                        }
+                    },
+                    "departure": {
+                        "date": {
+                            "year": 2025,
+                            "month": 4,
+                            "day": 8
+                        }
+                    },
+                    "search_parameters_transport": {
+                        "product_codes": [
+                            {
+                                "code": "IATA1234",
+                                "type": 3
+                            }
+                        ],
+                        "max_price": {
+                            "value": "150000",
+                            "decimals": 2,
+                            "currency": {
+                                "iso_currency": "ISO_CURRENCY_EUR"
+                            }
+                        },
+                        "max_segments": 1
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/pp-mock/handlers/accommodation/v1/filters.go
+++ b/pp-mock/handlers/accommodation/v1/filters.go
@@ -134,12 +134,10 @@ func filterPropertiesByLastModified(
 ) []*accommodationv1.Property {
 	filtered := []*accommodationv1.Property{}
 	for _, property := range properties {
-		if property.Property.LastModified.AsTime().Before(lastModified) {
-			continue
+		if !property.Property.LastModified.AsTime().Before(lastModified) {
+			filtered = append(filtered, common.CloneProto(property.Property))
 		}
-		filtered = append(filtered, common.CloneProto(property.Property))
 	}
-
 	return filtered
 }
 

--- a/pp-mock/handlers/accommodation/v2/filters.go
+++ b/pp-mock/handlers/accommodation/v2/filters.go
@@ -135,12 +135,10 @@ func filterPropertiesByLastModified(
 ) []*accommodationv2.Property {
 	filtered := []*accommodationv2.Property{}
 	for _, property := range properties {
-		if property.Property.LastModified.AsTime().Before(lastModified) {
-			continue
+		if !property.Property.LastModified.AsTime().Before(lastModified) {
+			filtered = append(filtered, common.CloneProto(property.Property))
 		}
-		filtered = append(filtered, common.CloneProto(property.Property))
 	}
-
 	return filtered
 }
 

--- a/pp-mock/handlers/accommodation/v3/filters.go
+++ b/pp-mock/handlers/accommodation/v3/filters.go
@@ -135,12 +135,10 @@ func filterPropertiesByLastModified(
 ) []*accommodationv3.Property {
 	filtered := []*accommodationv3.Property{}
 	for _, property := range properties {
-		if property.Property.LastModified.AsTime().Before(lastModified) {
-			continue
+		if !property.Property.LastModified.AsTime().Before(lastModified) {
+			filtered = append(filtered, common.CloneProto(property.Property))
 		}
-		filtered = append(filtered, common.CloneProto(property.Property))
 	}
-
 	return filtered
 }
 

--- a/pp-mock/handlers/common.go
+++ b/pp-mock/handlers/common.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	typesv1 "buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go/cmp/types/v1"
+	typesv2 "buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go/cmp/types/v2"
+	typesv3 "buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go/cmp/types/v3"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -22,6 +24,48 @@ func IsTravelPeriodAllowed(travelPeriod *typesv1.TravelPeriod) bool {
 	endDate := time.Now().Add(time.Hour * 24 * 60) // 60 days from now
 
 	return DateV1ToTime(travelPeriod.StartDate).After(startDate) && DateV1ToTime(travelPeriod.EndDate).Before(endDate) && DateV1ToTime(travelPeriod.StartDate).Before(DateV1ToTime(travelPeriod.EndDate))
+}
+
+func AreTravelDatesValid(departureDate, arrivalDate *typesv1.Date) bool {
+	// Convert to time.Time or perform checks directly based on your logic
+	if departureDate == nil || arrivalDate == nil {
+		return false
+	}
+
+	// Fail if departure is in the past
+	if time.Now().After(DateV1ToTime(departureDate)) {
+		return false
+	}
+
+	// Fail if departure is after arrival
+	return !DateV1ToTime(departureDate).After(DateV1ToTime(arrivalDate))
+}
+
+// GetTravellerIDsV1 extracts traveller IDs from []*typesv1.BasicTraveller
+func GetTravellerIDsV1(travellers []*typesv1.BasicTraveller) []int32 {
+	ids := make([]int32, len(travellers))
+	for i, traveller := range travellers {
+		ids[i] = traveller.TravellerId
+	}
+	return ids
+}
+
+// GetTravellerIDsV2 extracts traveller IDs from []*typesv2.BasicTraveller
+func GetTravellerIDsV2(travellers []*typesv2.BasicTraveller) []int32 {
+	ids := make([]int32, len(travellers))
+	for i, traveller := range travellers {
+		ids[i] = traveller.TravellerId
+	}
+	return ids
+}
+
+// GetTravellerIDsV3 extracts traveller IDs from []*typesv3.BasicTraveller
+func GetTravellerIDsV3(travellers []*typesv3.BasicTraveller) []int32 {
+	ids := make([]int32, len(travellers))
+	for i, traveller := range travellers {
+		ids[i] = traveller.TravellerId
+	}
+	return ids
 }
 
 func CloneProtoSlice[T proto.Message](source []T) []T {

--- a/pp-mock/handlers/transport/v1/filters.go
+++ b/pp-mock/handlers/transport/v1/filters.go
@@ -1,0 +1,41 @@
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package handlers
+
+import (
+	transportv1 "buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go/cmp/services/transport/v1"
+	typesv1 "buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go/cmp/types/v1"
+	common "github.com/chain4travel/camino-messenger-bot/pp-mock/handlers"
+	"google.golang.org/protobuf/proto"
+)
+
+func filterTripsByProductCodes(trips []*transportv1.Trip, productCodes []*typesv1.ProductCode) []*transportv1.Trip {
+	if len(productCodes) == 0 {
+		return common.CloneProtoSlice(trips)
+	}
+
+	filtered := []*transportv1.Trip{}
+	for _, trip := range trips {
+	segmentsLoop:
+		for _, segment := range trip.Segments {
+			for _, code := range productCodes {
+				if proto.Equal(segment.GetProductCode(), code) {
+					filtered = append(filtered, common.CloneProto(trip))
+					break segmentsLoop
+				}
+			}
+		}
+	}
+	return filtered
+}
+
+func filterTripsByMaxSegments(trips []*transportv1.Trip, maxSegments int32) []*transportv1.Trip {
+	filtered := []*transportv1.Trip{}
+	for _, trip := range trips {
+		if len(trip.Segments) <= int(maxSegments) {
+			filtered = append(filtered, common.CloneProto(trip))
+		}
+	}
+	return filtered
+}

--- a/pp-mock/handlers/transport/v1/transport_search.go
+++ b/pp-mock/handlers/transport/v1/transport_search.go
@@ -128,18 +128,14 @@ func (*TransportSearchV1Server) TransportSearch(ctx context.Context, req *transp
 	for _, query := range req.Queries {
 		filteredTrips := mockdata.TripsV1
 		for _, queryTrip := range query.GetTrips() {
-			if queryTrip == nil {
-				continue
-			}
-			searchParametersTransport := queryTrip.GetSearchParametersTransport()
-			if searchParametersTransport == nil {
+			if queryTrip.SearchParametersTransport == nil { // its optional
 				continue
 			}
 
 			// This is just an example, not real business logic:
-			filteredTrips = filterTripsByProductCodes(filteredTrips, searchParametersTransport.GetProductCodes())
-			if searchParametersTransport.GetMaxSegments() != 0 {
-				filteredTrips = filterTripsByMaxSegments(filteredTrips, searchParametersTransport.GetMaxSegments())
+			filteredTrips = filterTripsByProductCodes(filteredTrips, queryTrip.SearchParametersTransport.ProductCodes)
+			if queryTrip.SearchParametersTransport.MaxSegments != 0 {
+				filteredTrips = filterTripsByMaxSegments(filteredTrips, queryTrip.SearchParametersTransport.MaxSegments)
 			}
 		}
 
@@ -184,29 +180,24 @@ func (*TransportSearchV1Server) TransportSearch(ctx context.Context, req *transp
 		resultIDnum++
 	}
 
-	if len(searchResults) == 0 {
-		return &transportv1.TransportSearchResponse{
-			Header: &typesv1.ResponseHeader{
-				Status: typesv1.StatusType_STATUS_TYPE_SUCCESS,
-				Alerts: []*typesv1.Alert{{
-					Message: fmt.Sprintf("No results found for search %v", req.Queries),
-					Type:    typesv1.AlertType_ALERT_TYPE_INFO,
-				}},
-			},
-		}, nil
-	}
-
-	searchID := uuid.New().String()
-
 	response := &transportv1.TransportSearchResponse{
 		Header: &typesv1.ResponseHeader{
 			Status: typesv1.StatusType_STATUS_TYPE_SUCCESS,
 		},
-		Metadata: &typesv1.SearchResponseMetadata{
-			SearchId: &typesv1.UUID{Value: searchID},
-		},
 		Results: searchResults,
 	}
+
+	if len(searchResults) == 0 {
+		response.Header.Alerts = []*typesv1.Alert{{
+			Message: fmt.Sprintf("No results found for search %v", req.Queries),
+			Type:    typesv1.AlertType_ALERT_TYPE_INFO,
+		}}
+	} else {
+		response.Metadata = &typesv1.SearchResponseMetadata{
+			SearchId: &typesv1.UUID{Value: uuid.New().String()},
+		}
+	}
+
 	log.Printf("CMAccount %s received request from CMAccount %s", md.Recipient, md.Sender)
 
 	if err := grpc.SetHeader(ctx, md.ToGrpcMD()); err != nil {
@@ -214,33 +205,4 @@ func (*TransportSearchV1Server) TransportSearch(ctx context.Context, req *transp
 	}
 
 	return response, nil
-}
-
-func filterTripsByProductCodes(trips []*transportv1.Trip, productCodes []*typesv1.ProductCode) []*transportv1.Trip {
-	if len(productCodes) == 0 {
-		return trips
-	}
-	filtered := []*transportv1.Trip{}
-	for _, trip := range trips {
-	segmentsLoop:
-		for _, segment := range trip.Segments {
-			for _, code := range productCodes {
-				if segment.GetProductCode().Code == code.GetCode() {
-					filtered = append(filtered, trip)
-					break segmentsLoop
-				}
-			}
-		}
-	}
-	return filtered
-}
-
-func filterTripsByMaxSegments(trips []*transportv1.Trip, maxSegments int32) []*transportv1.Trip {
-	filtered := []*transportv1.Trip{}
-	for _, trip := range trips {
-		if len(trip.Segments) <= int(maxSegments) {
-			filtered = append(filtered, trip)
-		}
-	}
-	return filtered
 }

--- a/pp-mock/handlers/transport/v1/transport_search.go
+++ b/pp-mock/handlers/transport/v1/transport_search.go
@@ -70,7 +70,8 @@ func (*TransportSearchV1Server) TransportSearch(ctx context.Context, req *transp
 							Message: fmt.Sprintf("Invalid query[%d].QueryTrips[%d]: can't be nil", queryIndex, queryTripIndex),
 							Type:    typesv1.AlertType_ALERT_TYPE_ERROR,
 						}},
-					}}, nil
+					},
+				}, nil
 			}
 
 			if queryTrip.Departure == nil || queryTrip.Arrival == nil ||
@@ -83,7 +84,8 @@ func (*TransportSearchV1Server) TransportSearch(ctx context.Context, req *transp
 							Message: "Invalid trip: departure and arrival must be provided",
 							Type:    typesv1.AlertType_ALERT_TYPE_ERROR,
 						}},
-					}}, nil
+					},
+				}, nil
 			}
 
 			if !common.AreTravelDatesValid(queryTrip.Departure.Date, queryTrip.Arrival.Date) {
@@ -94,7 +96,8 @@ func (*TransportSearchV1Server) TransportSearch(ctx context.Context, req *transp
 							Message: "Invalid travel dates: departure date must be in the future and departure must be before arrival",
 							Type:    typesv1.AlertType_ALERT_TYPE_ERROR,
 						}},
-					}}, nil
+					},
+				}, nil
 			}
 
 			searchParametersTransport := queryTrip.GetSearchParametersTransport()
@@ -113,7 +116,8 @@ func (*TransportSearchV1Server) TransportSearch(ctx context.Context, req *transp
 							Message: fmt.Sprintf("Invalid min price: decimals must be less than or equal to %d", price.NativeTokenDecimals),
 							Type:    typesv1.AlertType_ALERT_TYPE_ERROR,
 						}},
-					}}, nil
+					},
+				}, nil
 			}
 		}
 	}

--- a/pp-mock/handlers/transport/v1/transport_search.go
+++ b/pp-mock/handlers/transport/v1/transport_search.go
@@ -1,0 +1,245 @@
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"math/big"
+
+	"buf.build/gen/go/chain4travel/camino-messenger-protocol/grpc/go/cmp/services/transport/v1/transportv1grpc"
+	transportv1 "buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go/cmp/services/transport/v1"
+	typesv1 "buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go/cmp/types/v1"
+	"github.com/chain4travel/camino-messenger-bot/internal/metadata"
+	"github.com/chain4travel/camino-messenger-bot/pkg/price"
+	common "github.com/chain4travel/camino-messenger-bot/pp-mock/handlers"
+	mockdata "github.com/chain4travel/camino-messenger-bot/pp-mock/services/data"
+	"github.com/google/uuid"
+	"google.golang.org/grpc"
+)
+
+// TODO@ all changes/comments from v1 should be applied to v2 and v3
+
+var _ transportv1grpc.TransportSearchServiceServer = (*TransportSearchV1Server)(nil)
+
+type TransportSearchV1Server struct{}
+
+func (*TransportSearchV1Server) TransportSearch(ctx context.Context, req *transportv1.TransportSearchRequest) (*transportv1.TransportSearchResponse, error) {
+	md := metadata.Metadata{}
+
+	err := md.ExtractMetadata(ctx)
+	if err != nil {
+		log.Print("error extracting metadata")
+	}
+
+	md.Stamp(fmt.Sprintf("%s-%s", "ext-system", "response"))
+	log.Printf("Responding to request: %s (TransportSearch) v1", md.RequestID)
+
+	// if there is no query, return no results
+	if len(req.Queries) == 0 {
+		return &transportv1.TransportSearchResponse{
+			Header: &typesv1.ResponseHeader{
+				Status: typesv1.StatusType_STATUS_TYPE_FAILURE,
+				Alerts: []*typesv1.Alert{{
+					Message: "No queries provided",
+					Type:    typesv1.AlertType_ALERT_TYPE_ERROR,
+				}},
+			},
+		}, nil
+	}
+
+	if req.SearchParameters.GetCurrency() == nil {
+		return &transportv1.TransportSearchResponse{
+			Header: &typesv1.ResponseHeader{
+				Status: typesv1.StatusType_STATUS_TYPE_FAILURE,
+				Alerts: []*typesv1.Alert{{
+					Message: "SearchParameters.Currency is required",
+					Type:    typesv1.AlertType_ALERT_TYPE_ERROR,
+				}},
+			},
+		}, nil
+	}
+
+	for queryIndex, query := range req.Queries {
+		for queryTripIndex, queryTrip := range query.GetTrips() {
+			if queryTrip == nil {
+				return &transportv1.TransportSearchResponse{
+					Header: &typesv1.ResponseHeader{
+						Status: typesv1.StatusType_STATUS_TYPE_FAILURE,
+						Alerts: []*typesv1.Alert{{
+							Message: fmt.Sprintf("Invalid query[%d].QueryTrips[%d]: can't be nil", queryIndex, queryTripIndex),
+							Type:    typesv1.AlertType_ALERT_TYPE_ERROR,
+						}},
+					}}, nil
+			}
+
+			if queryTrip.Departure == nil || queryTrip.Arrival == nil ||
+				queryTrip.Departure.Date == nil || queryTrip.Arrival.Date == nil ||
+				queryTrip.Departure.LocationCode == nil || queryTrip.Arrival.LocationCode == nil {
+				return &transportv1.TransportSearchResponse{
+					Header: &typesv1.ResponseHeader{
+						Status: typesv1.StatusType_STATUS_TYPE_FAILURE,
+						Alerts: []*typesv1.Alert{{
+							Message: "Invalid trip: departure and arrival must be provided",
+							Type:    typesv1.AlertType_ALERT_TYPE_ERROR,
+						}},
+					}}, nil
+			}
+
+			if !common.AreTravelDatesValid(queryTrip.Departure.Date, queryTrip.Arrival.Date) {
+				return &transportv1.TransportSearchResponse{
+					Header: &typesv1.ResponseHeader{
+						Status: typesv1.StatusType_STATUS_TYPE_FAILURE,
+						Alerts: []*typesv1.Alert{{
+							Message: "Invalid travel dates: departure date must be in the future and departure must be before arrival",
+							Type:    typesv1.AlertType_ALERT_TYPE_ERROR,
+						}},
+					}}, nil
+			}
+
+			searchParametersTransport := queryTrip.GetSearchParametersTransport()
+			if searchParametersTransport == nil {
+				continue
+			}
+
+			// Mock simplification: we're limiting mock example to work only with currencies,
+			// that have <= than 18 decimals in order to avoid adding blockchain interaction
+			// to pp mock (it would be needed to get erc20 token decimals)
+			if searchParametersTransport.GetMinPrice().GetDecimals() > price.NativeTokenDecimals { // 18 decimals
+				return &transportv1.TransportSearchResponse{
+					Header: &typesv1.ResponseHeader{
+						Status: typesv1.StatusType_STATUS_TYPE_FAILURE,
+						Alerts: []*typesv1.Alert{{
+							Message: fmt.Sprintf("Invalid min price: decimals must be less than or equal to %d", price.NativeTokenDecimals),
+							Type:    typesv1.AlertType_ALERT_TYPE_ERROR,
+						}},
+					}}, nil
+			}
+		}
+	}
+
+	resultIDnum := int32(1)
+	searchResults := []*transportv1.TransportSearchResult{}
+
+	for _, query := range req.Queries {
+		queryTrips := query.GetTrips()
+		filteredTrips := mockdata.TripsV1
+		for _, queryTrip := range queryTrips {
+			if queryTrip == nil {
+				continue
+			}
+			searchParametersTransport := queryTrip.GetSearchParametersTransport()
+			if searchParametersTransport == nil {
+				continue
+			}
+
+			// This is just an example, not real business logic:
+			filteredTrips = filterTripsByProductCodes(filteredTrips, searchParametersTransport.GetProductCodes())
+			if searchParametersTransport.GetMaxSegments() != 0 {
+				filteredTrips = filterTripsByMaxSegments(filteredTrips, searchParametersTransport.GetMaxSegments())
+			}
+		}
+
+		totalPrice := big.NewInt(0)
+
+		for _, trip := range filteredTrips {
+			for _, segment := range trip.Segments {
+				price, err := price.ToBigInt(
+					segment.Price.Value,
+					segment.Price.Decimals,
+					price.NativeTokenDecimals, // max possible decimals
+				)
+				if err != nil {
+					return &transportv1.TransportSearchResponse{
+						Header: &typesv1.ResponseHeader{
+							Status: typesv1.StatusType_STATUS_TYPE_FAILURE,
+							Alerts: []*typesv1.Alert{{
+								Message: fmt.Sprintf("Failed to convert tripSegment price: %v", err),
+								Type:    typesv1.AlertType_ALERT_TYPE_ERROR,
+							}},
+						},
+					}, nil
+				}
+				totalPrice = new(big.Int).Add(totalPrice, price)
+			}
+		}
+
+		searchResults = append(searchResults, &transportv1.TransportSearchResult{
+			ResultId:        resultIDnum,
+			QueryId:         query.QueryId,
+			TravellerIds:    common.GetTravellerIDsV1(query.Travellers),
+			TravellingTrips: filteredTrips,
+			TotalPrice: &typesv1.PriceDetail{
+				Price: &typesv1.Price{
+					Value:    totalPrice.String(),
+					Decimals: price.NativeTokenDecimals,
+					Currency: req.SearchParameters.Currency,
+				},
+			},
+		})
+
+		resultIDnum++
+	}
+
+	if len(searchResults) == 0 {
+		return &transportv1.TransportSearchResponse{
+			Header: &typesv1.ResponseHeader{
+				Status: typesv1.StatusType_STATUS_TYPE_SUCCESS,
+				Alerts: []*typesv1.Alert{{
+					Message: fmt.Sprintf("No results found for search %v", req.Queries),
+					Type:    typesv1.AlertType_ALERT_TYPE_INFO,
+				}},
+			},
+		}, nil
+	}
+
+	searchID := uuid.New().String()
+
+	response := &transportv1.TransportSearchResponse{
+		Header: &typesv1.ResponseHeader{
+			Status: typesv1.StatusType_STATUS_TYPE_SUCCESS,
+		},
+		Metadata: &typesv1.SearchResponseMetadata{
+			SearchId: &typesv1.UUID{Value: searchID},
+		},
+		Results: searchResults,
+	}
+	log.Printf("CMAccount %s received request from CMAccount %s", md.Recipient, md.Sender)
+
+	if err := grpc.SetHeader(ctx, md.ToGrpcMD()); err != nil {
+		log.Printf("Failed to set header: %v", err)
+	}
+
+	return response, nil
+}
+
+func filterTripsByProductCodes(trips []*transportv1.Trip, productCodes []*typesv1.ProductCode) []*transportv1.Trip {
+	if len(productCodes) == 0 {
+		return trips
+	}
+	filtered := []*transportv1.Trip{}
+	for _, trip := range trips {
+	segmentsLoop:
+		for _, segment := range trip.Segments {
+			for _, code := range productCodes {
+				if segment.GetProductCode().Code == code.GetCode() {
+					filtered = append(filtered, trip)
+					break segmentsLoop
+				}
+			}
+		}
+	}
+	return filtered
+}
+
+func filterTripsByMaxSegments(trips []*transportv1.Trip, maxSegments int32) []*transportv1.Trip {
+	filtered := []*transportv1.Trip{}
+	for _, trip := range trips {
+		if len(trip.Segments) <= int(maxSegments) {
+			filtered = append(filtered, trip)
+		}
+	}
+	return filtered
+}

--- a/pp-mock/handlers/transport/v1/transport_search.go
+++ b/pp-mock/handlers/transport/v1/transport_search.go
@@ -20,8 +20,6 @@ import (
 	"google.golang.org/grpc"
 )
 
-// TODO@ all changes/comments from v1 should be applied to v2 and v3
-
 var _ transportv1grpc.TransportSearchServiceServer = (*TransportSearchV1Server)(nil)
 
 type TransportSearchV1Server struct{}
@@ -124,9 +122,8 @@ func (*TransportSearchV1Server) TransportSearch(ctx context.Context, req *transp
 	searchResults := []*transportv1.TransportSearchResult{}
 
 	for _, query := range req.Queries {
-		queryTrips := query.GetTrips()
 		filteredTrips := mockdata.TripsV1
-		for _, queryTrip := range queryTrips {
+		for _, queryTrip := range query.GetTrips() {
 			if queryTrip == nil {
 				continue
 			}

--- a/pp-mock/handlers/transport/v2/filters.go
+++ b/pp-mock/handlers/transport/v2/filters.go
@@ -1,0 +1,41 @@
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package handlers
+
+import (
+	transportv2 "buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go/cmp/services/transport/v2"
+	typesv2 "buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go/cmp/types/v2"
+	common "github.com/chain4travel/camino-messenger-bot/pp-mock/handlers"
+	"google.golang.org/protobuf/proto"
+)
+
+func filterTripsByProductCodes(trips []*transportv2.Trip, productCodes []*typesv2.ProductCode) []*transportv2.Trip {
+	if len(productCodes) == 0 {
+		return common.CloneProtoSlice(trips)
+	}
+
+	filtered := []*transportv2.Trip{}
+	for _, trip := range trips {
+	segmentsLoop:
+		for _, segment := range trip.Segments {
+			for _, code := range productCodes {
+				if proto.Equal(segment.GetProductCode(), code) {
+					filtered = append(filtered, common.CloneProto(trip))
+					break segmentsLoop
+				}
+			}
+		}
+	}
+	return filtered
+}
+
+func filterTripsByMaxSegments(trips []*transportv2.Trip, maxSegments int32) []*transportv2.Trip {
+	filtered := []*transportv2.Trip{}
+	for _, trip := range trips {
+		if len(trip.Segments) <= int(maxSegments) {
+			filtered = append(filtered, common.CloneProto(trip))
+		}
+	}
+	return filtered
+}

--- a/pp-mock/handlers/transport/v2/transport_search.go
+++ b/pp-mock/handlers/transport/v2/transport_search.go
@@ -1,0 +1,236 @@
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"math/big"
+
+	"buf.build/gen/go/chain4travel/camino-messenger-protocol/grpc/go/cmp/services/transport/v2/transportv2grpc"
+	transportv2 "buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go/cmp/services/transport/v2"
+	typesv1 "buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go/cmp/types/v1"
+	typesv2 "buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go/cmp/types/v2"
+	"github.com/chain4travel/camino-messenger-bot/internal/metadata"
+	"github.com/chain4travel/camino-messenger-bot/pkg/price"
+	common "github.com/chain4travel/camino-messenger-bot/pp-mock/handlers"
+	mockdata "github.com/chain4travel/camino-messenger-bot/pp-mock/services/data"
+	"github.com/google/uuid"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+)
+
+var _ transportv2grpc.TransportSearchServiceServer = (*TransportSearchV2Server)(nil)
+
+type TransportSearchV2Server struct{}
+
+func (*TransportSearchV2Server) TransportSearch(ctx context.Context, req *transportv2.TransportSearchRequest) (*transportv2.TransportSearchResponse, error) {
+	md := metadata.Metadata{}
+
+	// check if req is nil
+	if req == nil {
+		return nil, status.Errorf(codes.InvalidArgument, "request is nil")
+	}
+
+	err := md.ExtractMetadata(ctx)
+	if err != nil {
+		log.Print("error extracting metadata")
+	}
+
+	md.Stamp(fmt.Sprintf("%s-%s", "ext-system", "response"))
+	log.Printf("Responding to request: %s (TransportSearch) v2", md.RequestID)
+
+	// if there is no query, return no results
+	if len(req.Queries) == 0 {
+		return &transportv2.TransportSearchResponse{
+			Header: &typesv1.ResponseHeader{
+				Status: typesv1.StatusType_STATUS_TYPE_FAILURE,
+				Alerts: []*typesv1.Alert{{
+					Message: "No queries provided",
+					Type:    typesv1.AlertType_ALERT_TYPE_INFO,
+				}},
+			},
+		}, nil
+	}
+
+	var resultIDnum int32 = 1
+
+	searchResults := []*transportv2.TransportSearchResult{}
+
+	for _, query := range req.Queries {
+		filteredTrips := mockdata.TripsV2
+		queryTrips := query.GetTrips()
+		for _, queryTrip := range queryTrips {
+			if queryTrip == nil {
+				continue
+			}
+			searchParametersTransport := queryTrip.GetSearchParametersTransport()
+			if searchParametersTransport == nil {
+				continue
+			}
+
+			if queryTrip.Departure != nil && queryTrip.Arrival != nil && queryTrip.Departure.Date != nil && queryTrip.Arrival.Date != nil {
+				departureDate := queryTrip.Departure.Date
+				arrivalDate := queryTrip.Arrival.Date
+				// Check if the travel period is valid
+				if !common.AreTravelDatesValid(departureDate, arrivalDate) {
+					return &transportv2.TransportSearchResponse{
+						Header: &typesv1.ResponseHeader{
+							Status: typesv1.StatusType_STATUS_TYPE_FAILURE,
+							Alerts: []*typesv1.Alert{{
+								Message: "Invalid travel dates: departure date must be in the future and departure must be before arrival",
+								Type:    typesv1.AlertType_ALERT_TYPE_INFO,
+							},
+							},
+						},
+					}, nil
+				}
+			}
+			// This is just an example, not real business logic:
+			filteredTrips = filterTripsByProductCodes(filteredTrips, searchParametersTransport.GetProductCodes())
+			if searchParametersTransport.GetMaxSegments() != 0 {
+				filteredTrips = filterTripsByMaxSegments(filteredTrips, searchParametersTransport.GetMaxSegments())
+			}
+			filteredTrips = filterTripsByMaxPrice(filteredTrips, searchParametersTransport.GetMaxPrice())
+		}
+
+		searchResults = append(searchResults, &transportv2.TransportSearchResult{
+			ResultId:        resultIDnum,
+			QueryId:         query.QueryId,
+			TravellerIds:    common.GetTravellerIDsV2(query.Travellers),
+			TravellingTrips: filteredTrips,
+			TotalPrice: &typesv2.PriceDetail{
+				Price: &typesv2.Price{
+					Value: common.DefaultPrice,
+				},
+			},
+		})
+
+		resultIDnum++
+	}
+
+	if len(searchResults) == 0 {
+		return &transportv2.TransportSearchResponse{
+			Header: &typesv1.ResponseHeader{
+				Status: typesv1.StatusType_STATUS_TYPE_SUCCESS,
+				Alerts: []*typesv1.Alert{{
+					Message: fmt.Sprintf("No results found for search %v", req.Queries),
+					Type:    typesv1.AlertType_ALERT_TYPE_INFO,
+				}},
+			},
+		}, nil
+	}
+
+	searchID := uuid.New().String()
+
+	response := &transportv2.TransportSearchResponse{
+		Header: &typesv1.ResponseHeader{
+			Status: typesv1.StatusType_STATUS_TYPE_SUCCESS,
+		},
+		Metadata: &typesv2.SearchResponseMetadata{
+			SearchId: &typesv1.UUID{Value: searchID},
+		},
+		Results: searchResults,
+	}
+	log.Printf("CMAccount %s received request from CMAccount %s", md.Recipient, md.Sender)
+
+	if err := grpc.SetHeader(ctx, md.ToGrpcMD()); err != nil {
+		log.Printf("Failed to set header: %v", err)
+	}
+
+	return response, nil
+}
+
+func filterTripsByProductCodes(trips []*transportv2.Trip, productCodes []*typesv2.ProductCode) []*transportv2.Trip {
+	if len(productCodes) == 0 {
+		return trips
+	}
+	filtered := make([]*transportv2.Trip, 0)
+	for _, trip := range trips {
+		exists := false
+		for _, segment := range trip.Segments {
+			for _, code := range productCodes {
+				if segment.GetProductCode().Code != "" && segment.GetProductCode().Code == code.GetCode() {
+					filtered = append(filtered, trip)
+					exists = true
+					break
+				}
+			}
+			if exists {
+				break // Break out of segments loop after adding the trip
+			}
+		}
+	}
+	return filtered
+}
+
+func filterTripsByMaxSegments(trips []*transportv2.Trip, maxSegments int32) []*transportv2.Trip {
+	filtered := make([]*transportv2.Trip, 0)
+	for _, trip := range trips {
+		if len(trip.Segments) <= int(maxSegments) {
+			filtered = append(filtered, trip)
+		}
+	}
+	return filtered
+}
+
+func filterTripsByMaxPrice(trips []*transportv2.Trip, maxPrice *typesv2.Price) []*transportv2.Trip {
+	if maxPrice == nil {
+		return trips
+	}
+
+	filtered := make([]*transportv2.Trip, 0)
+
+	// Convert maxPrice to big.Int for comparison
+	maxPriceBigInt, err := price.ToBigInt(maxPrice.Value, maxPrice.Decimals, maxPrice.Decimals)
+	if err != nil {
+		// Mock simplification: If the max price can't be converted, return all trips
+		return trips
+	}
+
+	for _, trip := range trips {
+		totalPrice := big.NewInt(0)
+		validTrip := false // Flag to check if the trip has valid currency
+
+		for _, segment := range trip.Segments {
+			// Sum up the segment prices
+			if segment.Price == nil {
+				continue
+			}
+
+			segmentPrice := segment.GetPrice()
+			// TODO: @VjeraTurk this is a workaround for currency that is not parsed well from the .json
+			if segmentPrice.Currency == nil || segmentPrice.Currency.Currency == nil {
+				segmentPrice.Currency = &typesv2.Currency{
+					Currency: &typesv2.Currency_IsoCurrency{
+						IsoCurrency: typesv2.IsoCurrency_ISO_CURRENCY_EUR,
+					},
+				}
+			}
+
+			if !proto.Equal(segmentPrice.GetCurrency(), maxPrice.GetCurrency()) {
+				continue
+			}
+
+			segmentPriceBigInt, err := price.ToBigInt(segmentPrice.Value, segmentPrice.Decimals, maxPrice.Decimals)
+			if err != nil {
+				log.Printf("Failed to convert trip price: %v", err)
+				continue
+			}
+
+			totalPrice = new(big.Int).Add(totalPrice, segmentPriceBigInt)
+			validTrip = true
+		}
+
+		// Compare total price with max price only if the trip has valid currency
+		if validTrip && totalPrice.Cmp(maxPriceBigInt) <= 0 {
+			filtered = append(filtered, trip)
+		}
+	}
+
+	return filtered
+}

--- a/pp-mock/handlers/transport/v2/transport_search.go
+++ b/pp-mock/handlers/transport/v2/transport_search.go
@@ -129,18 +129,14 @@ func (*TransportSearchV2Server) TransportSearch(ctx context.Context, req *transp
 	for _, query := range req.Queries {
 		filteredTrips := mockdata.TripsV2
 		for _, queryTrip := range query.GetTrips() {
-			if queryTrip == nil {
-				continue
-			}
-			searchParametersTransport := queryTrip.GetSearchParametersTransport()
-			if searchParametersTransport == nil {
+			if queryTrip.SearchParametersTransport == nil { // its optional
 				continue
 			}
 
 			// This is just an example, not real business logic:
-			filteredTrips = filterTripsByProductCodes(filteredTrips, searchParametersTransport.GetProductCodes())
-			if searchParametersTransport.GetMaxSegments() != 0 {
-				filteredTrips = filterTripsByMaxSegments(filteredTrips, searchParametersTransport.GetMaxSegments())
+			filteredTrips = filterTripsByProductCodes(filteredTrips, queryTrip.SearchParametersTransport.ProductCodes)
+			if queryTrip.SearchParametersTransport.MaxSegments != 0 {
+				filteredTrips = filterTripsByMaxSegments(filteredTrips, queryTrip.SearchParametersTransport.MaxSegments)
 			}
 		}
 
@@ -185,29 +181,24 @@ func (*TransportSearchV2Server) TransportSearch(ctx context.Context, req *transp
 		resultIDnum++
 	}
 
-	if len(searchResults) == 0 {
-		return &transportv2.TransportSearchResponse{
-			Header: &typesv1.ResponseHeader{
-				Status: typesv1.StatusType_STATUS_TYPE_SUCCESS,
-				Alerts: []*typesv1.Alert{{
-					Message: fmt.Sprintf("No results found for search %v", req.Queries),
-					Type:    typesv1.AlertType_ALERT_TYPE_INFO,
-				}},
-			},
-		}, nil
-	}
-
-	searchID := uuid.New().String()
-
 	response := &transportv2.TransportSearchResponse{
 		Header: &typesv1.ResponseHeader{
 			Status: typesv1.StatusType_STATUS_TYPE_SUCCESS,
 		},
-		Metadata: &typesv2.SearchResponseMetadata{
-			SearchId: &typesv1.UUID{Value: searchID},
-		},
 		Results: searchResults,
 	}
+
+	if len(searchResults) == 0 {
+		response.Header.Alerts = []*typesv1.Alert{{
+			Message: fmt.Sprintf("No results found for search %v", req.Queries),
+			Type:    typesv1.AlertType_ALERT_TYPE_INFO,
+		}}
+	} else {
+		response.Metadata = &typesv2.SearchResponseMetadata{
+			SearchId: &typesv1.UUID{Value: uuid.New().String()},
+		}
+	}
+
 	log.Printf("CMAccount %s received request from CMAccount %s", md.Recipient, md.Sender)
 
 	if err := grpc.SetHeader(ctx, md.ToGrpcMD()); err != nil {
@@ -215,33 +206,4 @@ func (*TransportSearchV2Server) TransportSearch(ctx context.Context, req *transp
 	}
 
 	return response, nil
-}
-
-func filterTripsByProductCodes(trips []*transportv2.Trip, productCodes []*typesv2.ProductCode) []*transportv2.Trip {
-	if len(productCodes) == 0 {
-		return trips
-	}
-	filtered := []*transportv2.Trip{}
-	for _, trip := range trips {
-	segmentsLoop:
-		for _, segment := range trip.Segments {
-			for _, code := range productCodes {
-				if segment.GetProductCode().Code == code.GetCode() {
-					filtered = append(filtered, trip)
-					break segmentsLoop
-				}
-			}
-		}
-	}
-	return filtered
-}
-
-func filterTripsByMaxSegments(trips []*transportv2.Trip, maxSegments int32) []*transportv2.Trip {
-	filtered := []*transportv2.Trip{}
-	for _, trip := range trips {
-		if len(trip.Segments) <= int(maxSegments) {
-			filtered = append(filtered, trip)
-		}
-	}
-	return filtered
 }

--- a/pp-mock/handlers/transport/v2/transport_search.go
+++ b/pp-mock/handlers/transport/v2/transport_search.go
@@ -71,7 +71,8 @@ func (*TransportSearchV2Server) TransportSearch(ctx context.Context, req *transp
 							Message: fmt.Sprintf("Invalid query[%d].QueryTrips[%d]: can't be nil", queryIndex, queryTripIndex),
 							Type:    typesv1.AlertType_ALERT_TYPE_ERROR,
 						}},
-					}}, nil
+					},
+				}, nil
 			}
 
 			if queryTrip.Departure == nil || queryTrip.Arrival == nil ||
@@ -84,7 +85,8 @@ func (*TransportSearchV2Server) TransportSearch(ctx context.Context, req *transp
 							Message: "Invalid trip: departure and arrival must be provided",
 							Type:    typesv1.AlertType_ALERT_TYPE_ERROR,
 						}},
-					}}, nil
+					},
+				}, nil
 			}
 
 			if !common.AreTravelDatesValid(queryTrip.Departure.Date, queryTrip.Arrival.Date) {
@@ -95,7 +97,8 @@ func (*TransportSearchV2Server) TransportSearch(ctx context.Context, req *transp
 							Message: "Invalid travel dates: departure date must be in the future and departure must be before arrival",
 							Type:    typesv1.AlertType_ALERT_TYPE_ERROR,
 						}},
-					}}, nil
+					},
+				}, nil
 			}
 
 			searchParametersTransport := queryTrip.GetSearchParametersTransport()
@@ -114,7 +117,8 @@ func (*TransportSearchV2Server) TransportSearch(ctx context.Context, req *transp
 							Message: fmt.Sprintf("Invalid min price: decimals must be less than or equal to %d", price.NativeTokenDecimals),
 							Type:    typesv1.AlertType_ALERT_TYPE_ERROR,
 						}},
-					}}, nil
+					},
+				}, nil
 			}
 		}
 	}

--- a/pp-mock/handlers/transport/v2/transport_search.go
+++ b/pp-mock/handlers/transport/v2/transport_search.go
@@ -19,9 +19,6 @@ import (
 	mockdata "github.com/chain4travel/camino-messenger-bot/pp-mock/services/data"
 	"github.com/google/uuid"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-	"google.golang.org/protobuf/proto"
 )
 
 var _ transportv2grpc.TransportSearchServiceServer = (*TransportSearchV2Server)(nil)
@@ -30,11 +27,6 @@ type TransportSearchV2Server struct{}
 
 func (*TransportSearchV2Server) TransportSearch(ctx context.Context, req *transportv2.TransportSearchRequest) (*transportv2.TransportSearchResponse, error) {
 	md := metadata.Metadata{}
-
-	// check if req is nil
-	if req == nil {
-		return nil, status.Errorf(codes.InvalidArgument, "request is nil")
-	}
 
 	err := md.ExtractMetadata(ctx)
 	if err != nil {
@@ -51,20 +43,88 @@ func (*TransportSearchV2Server) TransportSearch(ctx context.Context, req *transp
 				Status: typesv1.StatusType_STATUS_TYPE_FAILURE,
 				Alerts: []*typesv1.Alert{{
 					Message: "No queries provided",
-					Type:    typesv1.AlertType_ALERT_TYPE_INFO,
+					Type:    typesv1.AlertType_ALERT_TYPE_ERROR,
 				}},
 			},
 		}, nil
 	}
 
-	var resultIDnum int32 = 1
+	if req.SearchParameters.GetCurrency() == nil {
+		return &transportv2.TransportSearchResponse{
+			Header: &typesv1.ResponseHeader{
+				Status: typesv1.StatusType_STATUS_TYPE_FAILURE,
+				Alerts: []*typesv1.Alert{{
+					Message: "SearchParameters.Currency is required",
+					Type:    typesv1.AlertType_ALERT_TYPE_ERROR,
+				}},
+			},
+		}, nil
+	}
 
+	for queryIndex, query := range req.Queries {
+		for queryTripIndex, queryTrip := range query.GetTrips() {
+			if queryTrip == nil {
+				return &transportv2.TransportSearchResponse{
+					Header: &typesv1.ResponseHeader{
+						Status: typesv1.StatusType_STATUS_TYPE_FAILURE,
+						Alerts: []*typesv1.Alert{{
+							Message: fmt.Sprintf("Invalid query[%d].QueryTrips[%d]: can't be nil", queryIndex, queryTripIndex),
+							Type:    typesv1.AlertType_ALERT_TYPE_ERROR,
+						}},
+					}}, nil
+			}
+
+			if queryTrip.Departure == nil || queryTrip.Arrival == nil ||
+				queryTrip.Departure.Date == nil || queryTrip.Arrival.Date == nil ||
+				queryTrip.Departure.LocationCode == nil || queryTrip.Arrival.LocationCode == nil {
+				return &transportv2.TransportSearchResponse{
+					Header: &typesv1.ResponseHeader{
+						Status: typesv1.StatusType_STATUS_TYPE_FAILURE,
+						Alerts: []*typesv1.Alert{{
+							Message: "Invalid trip: departure and arrival must be provided",
+							Type:    typesv1.AlertType_ALERT_TYPE_ERROR,
+						}},
+					}}, nil
+			}
+
+			if !common.AreTravelDatesValid(queryTrip.Departure.Date, queryTrip.Arrival.Date) {
+				return &transportv2.TransportSearchResponse{
+					Header: &typesv1.ResponseHeader{
+						Status: typesv1.StatusType_STATUS_TYPE_FAILURE,
+						Alerts: []*typesv1.Alert{{
+							Message: "Invalid travel dates: departure date must be in the future and departure must be before arrival",
+							Type:    typesv1.AlertType_ALERT_TYPE_ERROR,
+						}},
+					}}, nil
+			}
+
+			searchParametersTransport := queryTrip.GetSearchParametersTransport()
+			if searchParametersTransport == nil {
+				continue
+			}
+
+			// Mock simplification: we're limiting mock example to work only with currencies,
+			// that have <= than 18 decimals in order to avoid adding blockchain interaction
+			// to pp mock (it would be needed to get erc20 token decimals)
+			if searchParametersTransport.GetMinPrice().GetDecimals() > price.NativeTokenDecimals { // 18 decimals
+				return &transportv2.TransportSearchResponse{
+					Header: &typesv1.ResponseHeader{
+						Status: typesv1.StatusType_STATUS_TYPE_FAILURE,
+						Alerts: []*typesv1.Alert{{
+							Message: fmt.Sprintf("Invalid min price: decimals must be less than or equal to %d", price.NativeTokenDecimals),
+							Type:    typesv1.AlertType_ALERT_TYPE_ERROR,
+						}},
+					}}, nil
+			}
+		}
+	}
+
+	resultIDnum := int32(1)
 	searchResults := []*transportv2.TransportSearchResult{}
 
 	for _, query := range req.Queries {
 		filteredTrips := mockdata.TripsV2
-		queryTrips := query.GetTrips()
-		for _, queryTrip := range queryTrips {
+		for _, queryTrip := range query.GetTrips() {
 			if queryTrip == nil {
 				continue
 			}
@@ -73,29 +133,35 @@ func (*TransportSearchV2Server) TransportSearch(ctx context.Context, req *transp
 				continue
 			}
 
-			if queryTrip.Departure != nil && queryTrip.Arrival != nil && queryTrip.Departure.Date != nil && queryTrip.Arrival.Date != nil {
-				departureDate := queryTrip.Departure.Date
-				arrivalDate := queryTrip.Arrival.Date
-				// Check if the travel period is valid
-				if !common.AreTravelDatesValid(departureDate, arrivalDate) {
-					return &transportv2.TransportSearchResponse{
-						Header: &typesv1.ResponseHeader{
-							Status: typesv1.StatusType_STATUS_TYPE_FAILURE,
-							Alerts: []*typesv1.Alert{{
-								Message: "Invalid travel dates: departure date must be in the future and departure must be before arrival",
-								Type:    typesv1.AlertType_ALERT_TYPE_INFO,
-							},
-							},
-						},
-					}, nil
-				}
-			}
 			// This is just an example, not real business logic:
 			filteredTrips = filterTripsByProductCodes(filteredTrips, searchParametersTransport.GetProductCodes())
 			if searchParametersTransport.GetMaxSegments() != 0 {
 				filteredTrips = filterTripsByMaxSegments(filteredTrips, searchParametersTransport.GetMaxSegments())
 			}
-			filteredTrips = filterTripsByMaxPrice(filteredTrips, searchParametersTransport.GetMaxPrice())
+		}
+
+		totalPrice := big.NewInt(0)
+
+		for _, trip := range filteredTrips {
+			for _, segment := range trip.Segments {
+				price, err := price.ToBigInt(
+					segment.Price.Value,
+					segment.Price.Decimals,
+					price.NativeTokenDecimals, // max possible decimals
+				)
+				if err != nil {
+					return &transportv2.TransportSearchResponse{
+						Header: &typesv1.ResponseHeader{
+							Status: typesv1.StatusType_STATUS_TYPE_FAILURE,
+							Alerts: []*typesv1.Alert{{
+								Message: fmt.Sprintf("Failed to convert tripSegment price: %v", err),
+								Type:    typesv1.AlertType_ALERT_TYPE_ERROR,
+							}},
+						},
+					}, nil
+				}
+				totalPrice = new(big.Int).Add(totalPrice, price)
+			}
 		}
 
 		searchResults = append(searchResults, &transportv2.TransportSearchResult{
@@ -105,7 +171,9 @@ func (*TransportSearchV2Server) TransportSearch(ctx context.Context, req *transp
 			TravellingTrips: filteredTrips,
 			TotalPrice: &typesv2.PriceDetail{
 				Price: &typesv2.Price{
-					Value: common.DefaultPrice,
+					Value:    totalPrice.String(),
+					Decimals: price.NativeTokenDecimals,
+					Currency: req.SearchParameters.Currency,
 				},
 			},
 		})
@@ -149,19 +217,15 @@ func filterTripsByProductCodes(trips []*transportv2.Trip, productCodes []*typesv
 	if len(productCodes) == 0 {
 		return trips
 	}
-	filtered := make([]*transportv2.Trip, 0)
+	filtered := []*transportv2.Trip{}
 	for _, trip := range trips {
-		exists := false
+	segmentsLoop:
 		for _, segment := range trip.Segments {
 			for _, code := range productCodes {
-				if segment.GetProductCode().Code != "" && segment.GetProductCode().Code == code.GetCode() {
+				if segment.GetProductCode().Code == code.GetCode() {
 					filtered = append(filtered, trip)
-					exists = true
-					break
+					break segmentsLoop
 				}
-			}
-			if exists {
-				break // Break out of segments loop after adding the trip
 			}
 		}
 	}
@@ -169,68 +233,11 @@ func filterTripsByProductCodes(trips []*transportv2.Trip, productCodes []*typesv
 }
 
 func filterTripsByMaxSegments(trips []*transportv2.Trip, maxSegments int32) []*transportv2.Trip {
-	filtered := make([]*transportv2.Trip, 0)
+	filtered := []*transportv2.Trip{}
 	for _, trip := range trips {
 		if len(trip.Segments) <= int(maxSegments) {
 			filtered = append(filtered, trip)
 		}
 	}
-	return filtered
-}
-
-func filterTripsByMaxPrice(trips []*transportv2.Trip, maxPrice *typesv2.Price) []*transportv2.Trip {
-	if maxPrice == nil {
-		return trips
-	}
-
-	filtered := make([]*transportv2.Trip, 0)
-
-	// Convert maxPrice to big.Int for comparison
-	maxPriceBigInt, err := price.ToBigInt(maxPrice.Value, maxPrice.Decimals, maxPrice.Decimals)
-	if err != nil {
-		// Mock simplification: If the max price can't be converted, return all trips
-		return trips
-	}
-
-	for _, trip := range trips {
-		totalPrice := big.NewInt(0)
-		validTrip := false // Flag to check if the trip has valid currency
-
-		for _, segment := range trip.Segments {
-			// Sum up the segment prices
-			if segment.Price == nil {
-				continue
-			}
-
-			segmentPrice := segment.GetPrice()
-			// TODO: @VjeraTurk this is a workaround for currency that is not parsed well from the .json
-			if segmentPrice.Currency == nil || segmentPrice.Currency.Currency == nil {
-				segmentPrice.Currency = &typesv2.Currency{
-					Currency: &typesv2.Currency_IsoCurrency{
-						IsoCurrency: typesv2.IsoCurrency_ISO_CURRENCY_EUR,
-					},
-				}
-			}
-
-			if !proto.Equal(segmentPrice.GetCurrency(), maxPrice.GetCurrency()) {
-				continue
-			}
-
-			segmentPriceBigInt, err := price.ToBigInt(segmentPrice.Value, segmentPrice.Decimals, maxPrice.Decimals)
-			if err != nil {
-				log.Printf("Failed to convert trip price: %v", err)
-				continue
-			}
-
-			totalPrice = new(big.Int).Add(totalPrice, segmentPriceBigInt)
-			validTrip = true
-		}
-
-		// Compare total price with max price only if the trip has valid currency
-		if validTrip && totalPrice.Cmp(maxPriceBigInt) <= 0 {
-			filtered = append(filtered, trip)
-		}
-	}
-
 	return filtered
 }

--- a/pp-mock/handlers/transport/v3/filters.go
+++ b/pp-mock/handlers/transport/v3/filters.go
@@ -1,0 +1,41 @@
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package handlers
+
+import (
+	transportv3 "buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go/cmp/services/transport/v3"
+	typesv2 "buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go/cmp/types/v2"
+	common "github.com/chain4travel/camino-messenger-bot/pp-mock/handlers"
+	"google.golang.org/protobuf/proto"
+)
+
+func filterTripsByProductCodes(trips []*transportv3.TripExtended, productCodes []*typesv2.ProductCode) []*transportv3.TripExtended {
+	if len(productCodes) == 0 {
+		return common.CloneProtoSlice(trips)
+	}
+
+	filtered := []*transportv3.TripExtended{}
+	for _, trip := range trips {
+	segmentsLoop:
+		for _, segment := range trip.Segments {
+			for _, code := range productCodes {
+				if proto.Equal(segment.GetInfo().GetProductCode(), code) {
+					filtered = append(filtered, common.CloneProto(trip))
+					break segmentsLoop
+				}
+			}
+		}
+	}
+	return filtered
+}
+
+func filterTripsByMaxSegments(trips []*transportv3.TripExtended, maxSegments int32) []*transportv3.TripExtended {
+	filtered := []*transportv3.TripExtended{}
+	for _, trip := range trips {
+		if len(trip.Segments) <= int(maxSegments) {
+			filtered = append(filtered, common.CloneProto(trip))
+		}
+	}
+	return filtered
+}

--- a/pp-mock/handlers/transport/v3/filters.go
+++ b/pp-mock/handlers/transport/v3/filters.go
@@ -4,6 +4,8 @@
 package handlers
 
 import (
+	"time"
+
 	transportv3 "buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go/cmp/services/transport/v3"
 	typesv2 "buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go/cmp/types/v2"
 	common "github.com/chain4travel/camino-messenger-bot/pp-mock/handlers"
@@ -34,6 +36,20 @@ func filterTripsByMaxSegments(trips []*transportv3.TripExtended, maxSegments int
 	filtered := []*transportv3.TripExtended{}
 	for _, trip := range trips {
 		if len(trip.Segments) <= int(maxSegments) {
+			filtered = append(filtered, common.CloneProto(trip))
+		}
+	}
+	return filtered
+}
+
+// Returns properties that have been modified not before [lastModified].
+func filterPropertiesByLastModified(
+	trips []*transportv3.TripBasic,
+	lastModified time.Time,
+) []*transportv3.TripBasic {
+	filtered := []*transportv3.TripBasic{}
+	for _, trip := range trips {
+		if !trip.LastModified.AsTime().Before(lastModified) {
 			filtered = append(filtered, common.CloneProto(trip))
 		}
 	}

--- a/pp-mock/handlers/transport/v3/transport_product_list.go
+++ b/pp-mock/handlers/transport/v3/transport_product_list.go
@@ -30,14 +30,20 @@ func (*TransportProductListV3Server) TransportProductList(ctx context.Context, r
 	md.Stamp(fmt.Sprintf("%s-%s", "ext-system", "response"))
 	log.Printf("Responding to request: %s (TransportProductList)", md.RequestID)
 
-	trips := make([]*transportv3.TripBasic, len(mockdata.TripsBasicV3))
-	copy(trips, mockdata.TripsBasicV3)
+	filteredTrips := filterPropertiesByLastModified(mockdata.TripsBasicV3, req.GetModifiedAfter().AsTime())
 
 	response := &transportv3.TransportProductListResponse{
 		Header: &typesv1.ResponseHeader{
 			Status: typesv1.StatusType_STATUS_TYPE_SUCCESS,
 		},
-		Trips: trips,
+		Trips: filteredTrips,
+	}
+
+	if len(filteredTrips) == 0 {
+		response.Header.Alerts = []*typesv1.Alert{{
+			Message: "No trips found that match request",
+			Type:    typesv1.AlertType_ALERT_TYPE_INFO,
+		}}
 	}
 
 	log.Printf("CMAccount %s received request from CMAccount %s", md.Recipient, md.Sender)

--- a/pp-mock/handlers/transport/v3/transport_product_list.go
+++ b/pp-mock/handlers/transport/v3/transport_product_list.go
@@ -14,8 +14,6 @@ import (
 	"github.com/chain4travel/camino-messenger-bot/internal/metadata"
 	mockdata "github.com/chain4travel/camino-messenger-bot/pp-mock/services/data"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 var _ transportv3grpc.TransportProductListServiceServer = (*TransportProductListV3Server)(nil)
@@ -25,17 +23,11 @@ type TransportProductListV3Server struct{}
 func (*TransportProductListV3Server) TransportProductList(ctx context.Context, req *transportv3.TransportProductListRequest) (*transportv3.TransportProductListResponse, error) {
 	md := metadata.Metadata{}
 
-	// check if req is nil
-	if req == nil {
-		return nil, status.Errorf(codes.InvalidArgument, "request is nil")
-	}
-
 	if err := md.ExtractMetadata(ctx); err != nil {
 		log.Print("error extracting metadata")
 	}
 
 	md.Stamp(fmt.Sprintf("%s-%s", "ext-system", "response"))
-
 	log.Printf("Responding to request: %s (TransportProductList)", md.RequestID)
 
 	trips := make([]*transportv3.TripBasic, len(mockdata.TripsBasicV3))

--- a/pp-mock/handlers/transport/v3/transport_product_list.go
+++ b/pp-mock/handlers/transport/v3/transport_product_list.go
@@ -1,0 +1,58 @@
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"buf.build/gen/go/chain4travel/camino-messenger-protocol/grpc/go/cmp/services/transport/v3/transportv3grpc"
+	transportv3 "buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go/cmp/services/transport/v3"
+	typesv1 "buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go/cmp/types/v1"
+	"github.com/chain4travel/camino-messenger-bot/internal/metadata"
+	mockdata "github.com/chain4travel/camino-messenger-bot/pp-mock/services/data"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+var _ transportv3grpc.TransportProductListServiceServer = (*TransportProductListV3Server)(nil)
+
+type TransportProductListV3Server struct{}
+
+func (*TransportProductListV3Server) TransportProductList(ctx context.Context, req *transportv3.TransportProductListRequest) (*transportv3.TransportProductListResponse, error) {
+	md := metadata.Metadata{}
+
+	// check if req is nil
+	if req == nil {
+		return nil, status.Errorf(codes.InvalidArgument, "request is nil")
+	}
+
+	if err := md.ExtractMetadata(ctx); err != nil {
+		log.Print("error extracting metadata")
+	}
+
+	md.Stamp(fmt.Sprintf("%s-%s", "ext-system", "response"))
+
+	log.Printf("Responding to request: %s (TransportProductList)", md.RequestID)
+
+	trips := make([]*transportv3.TripBasic, len(mockdata.TripsBasicV3))
+	copy(trips, mockdata.TripsBasicV3)
+
+	response := &transportv3.TransportProductListResponse{
+		Header: &typesv1.ResponseHeader{
+			Status: typesv1.StatusType_STATUS_TYPE_SUCCESS,
+		},
+		Trips: trips,
+	}
+
+	log.Printf("CMAccount %s received request from CMAccount %s", md.Recipient, md.Sender)
+
+	if err := grpc.SetHeader(ctx, md.ToGrpcMD()); err != nil {
+		log.Printf("Failed to set header: %v", err)
+	}
+
+	return response, nil
+}

--- a/pp-mock/handlers/transport/v3/transport_search.go
+++ b/pp-mock/handlers/transport/v3/transport_search.go
@@ -1,0 +1,233 @@
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"buf.build/gen/go/chain4travel/camino-messenger-protocol/grpc/go/cmp/services/transport/v3/transportv3grpc"
+	transportv3 "buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go/cmp/services/transport/v3"
+	typesv1 "buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go/cmp/types/v1"
+	typesv2 "buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go/cmp/types/v2"
+	typesv3 "buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go/cmp/types/v3"
+
+	"github.com/chain4travel/camino-messenger-bot/internal/metadata"
+	"github.com/chain4travel/camino-messenger-bot/pkg/price"
+	common "github.com/chain4travel/camino-messenger-bot/pp-mock/handlers"
+	mockdata "github.com/chain4travel/camino-messenger-bot/pp-mock/services/data"
+	"github.com/google/uuid"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+)
+
+var _ transportv3grpc.TransportSearchServiceServer = (*TransportSearchV3Server)(nil)
+
+type TransportSearchV3Server struct{}
+
+func (*TransportSearchV3Server) TransportSearch(ctx context.Context, req *transportv3.TransportSearchRequest) (*transportv3.TransportSearchResponse, error) {
+	md := metadata.Metadata{}
+
+	// check if req is nil
+	if req == nil {
+		return nil, status.Errorf(codes.InvalidArgument, "request is nil")
+	}
+
+	err := md.ExtractMetadata(ctx)
+	if err != nil {
+		log.Print("error extracting metadata")
+	}
+
+	md.Stamp(fmt.Sprintf("%s-%s", "ext-system", "response"))
+	log.Printf("Responding to request: %s (TransportSearch) v3", md.RequestID)
+
+	// if there is no query, return no results
+	if len(req.Queries) == 0 {
+		return &transportv3.TransportSearchResponse{
+			Header: &typesv1.ResponseHeader{
+				Status: typesv1.StatusType_STATUS_TYPE_FAILURE,
+				Alerts: []*typesv1.Alert{{
+					Message: "No queries provided",
+					Type:    typesv1.AlertType_ALERT_TYPE_INFO,
+				}},
+			},
+		}, nil
+	}
+
+	var resultIDnum int32 = 1
+
+	searchResults := []*transportv3.TransportSearchResult{}
+
+	for _, query := range req.Queries {
+		filteredTrips := mockdata.TripsExtendedV3
+		queryTrips := query.GetTrips()
+		for _, queryTrip := range queryTrips {
+			if queryTrip == nil {
+				continue
+			}
+			searchParametersTransport := queryTrip.GetSearchParametersTransport()
+			if searchParametersTransport == nil {
+				continue
+			}
+
+			if queryTrip.Departure != nil && queryTrip.Arrival != nil && queryTrip.Departure.Date != nil && queryTrip.Arrival.Date != nil {
+				departureDate := queryTrip.Departure.Date
+				arrivalDate := queryTrip.Arrival.Date
+				// Check if the travel period is valid
+				if !common.AreTravelDatesValid(departureDate, arrivalDate) {
+					return &transportv3.TransportSearchResponse{
+						Header: &typesv1.ResponseHeader{
+							Status: typesv1.StatusType_STATUS_TYPE_FAILURE,
+							Alerts: []*typesv1.Alert{{
+								Message: "Invalid travel dates: departure date must be in the future and departure must be before arrival",
+								Type:    typesv1.AlertType_ALERT_TYPE_INFO,
+							},
+							},
+						},
+					}, nil
+				}
+			}
+			// This is just an example, not real business logic:
+			filteredTrips = filterTripsByProductCodes(filteredTrips, searchParametersTransport.GetProductCodes())
+			if searchParametersTransport.GetMaxSegments() != 0 {
+				filteredTrips = filterTripsByMaxSegments(filteredTrips, searchParametersTransport.GetMaxSegments())
+			}
+			filteredTrips = filterTripsByMaxPrice(filteredTrips, searchParametersTransport.GetMaxPrice())
+		}
+
+		var travellerIDs []int32
+		if query.Travellers != nil {
+			travellerIDs = common.GetTravellerIDsV3(query.Travellers)
+		}
+		searchResults = append(searchResults, &transportv3.TransportSearchResult{
+			ResultId:        resultIDnum,
+			QueryId:         query.QueryId,
+			TravellerIds:    travellerIDs,
+			TravellingTrips: filteredTrips,
+			TotalPrice: &typesv3.PriceDetail{
+				Price: &typesv3.Price{
+					Value: common.DefaultPrice,
+				},
+			},
+		})
+		resultIDnum++
+	}
+
+	if len(searchResults) == 0 {
+		return &transportv3.TransportSearchResponse{
+			Header: &typesv1.ResponseHeader{
+				Status: typesv1.StatusType_STATUS_TYPE_SUCCESS,
+				Alerts: []*typesv1.Alert{{
+					Message: fmt.Sprintf("No results found for search %v", req.Queries),
+					Type:    typesv1.AlertType_ALERT_TYPE_INFO,
+				}},
+			},
+		}, nil
+	}
+
+	searchID := uuid.New().String()
+
+	response := &transportv3.TransportSearchResponse{
+		Header: &typesv1.ResponseHeader{
+			Status: typesv1.StatusType_STATUS_TYPE_SUCCESS,
+		},
+		Metadata: &typesv3.SearchResponseMetadata{
+			SearchId: &typesv1.UUID{Value: searchID},
+		},
+		Results: searchResults,
+	}
+	log.Printf("CMAccount %s received request from CMAccount %s", md.Recipient, md.Sender)
+
+	if err := grpc.SetHeader(ctx, md.ToGrpcMD()); err != nil {
+		log.Printf("Failed to set header: %v", err)
+	}
+
+	return response, nil
+}
+
+func filterTripsByProductCodes(trips []*transportv3.TripExtended, productCodes []*typesv2.ProductCode) []*transportv3.TripExtended {
+	if len(productCodes) == 0 {
+		return trips
+	}
+
+	filtered := make([]*transportv3.TripExtended, 0)
+	for _, trip := range trips {
+		exists := false
+		for _, segment := range trip.Segments {
+			for _, code := range productCodes {
+				if segment.GetInfo().GetProductCode().Code != "" && segment.GetInfo().GetProductCode().Code == code.GetCode() {
+					filtered = append(filtered, trip)
+					exists = true
+					break
+				}
+			}
+			if exists {
+				break // Break out of segments loop after adding the trip
+			}
+		}
+	}
+	return filtered
+}
+
+func filterTripsByMaxSegments(trips []*transportv3.TripExtended, maxSegments int32) []*transportv3.TripExtended {
+	filtered := make([]*transportv3.TripExtended, 0)
+	for _, trip := range trips {
+		if len(trip.Segments) <= int(maxSegments) {
+			filtered = append(filtered, trip)
+		}
+	}
+	return filtered
+}
+
+func filterTripsByMaxPrice(trips []*transportv3.TripExtended, maxPrice *typesv3.Price) []*transportv3.TripExtended {
+	if maxPrice == nil {
+		return trips
+	}
+
+	filtered := make([]*transportv3.TripExtended, 0)
+
+	// Convert maxPrice to big.Int for comparison
+	maxPriceBigInt, err := price.ToBigInt(maxPrice.Value, maxPrice.Decimals, maxPrice.Decimals)
+	if err != nil {
+		// Mock simplification: If the max price can't be converted, return all trips
+		return trips
+	}
+
+	for _, trip := range trips {
+		tripPrice := trip.GetPrice()
+
+		if tripPrice == nil {
+			continue
+		}
+
+		// TODO: @VjeraTurk this is a workaround for currency that is not parsed well from the .json
+		if tripPrice.Currency == nil || tripPrice.Currency.Currency == nil {
+			tripPrice.Currency = &typesv3.Currency{
+				Currency: &typesv3.Currency_IsoCurrency{
+					IsoCurrency: typesv3.IsoCurrency_ISO_CURRENCY_EUR,
+				},
+			}
+		}
+
+		if !proto.Equal(tripPrice.GetCurrency(), maxPrice.GetCurrency()) {
+			continue
+		}
+
+		tripPriceBigInt, err := price.ToBigInt(tripPrice.Value, tripPrice.Decimals, maxPrice.Decimals)
+		if err != nil {
+			log.Printf("Failed to convert trip price: %v", err)
+			continue
+		}
+
+		// Compare total price with max price
+		if tripPriceBigInt.Cmp(maxPriceBigInt) <= 0 {
+			filtered = append(filtered, trip)
+		}
+	}
+
+	return filtered
+}

--- a/pp-mock/handlers/transport/v3/transport_search.go
+++ b/pp-mock/handlers/transport/v3/transport_search.go
@@ -73,7 +73,8 @@ func (*TransportSearchV3Server) TransportSearch(ctx context.Context, req *transp
 							Message: fmt.Sprintf("Invalid query[%d].QueryTrips[%d]: can't be nil", queryIndex, queryTripIndex),
 							Type:    typesv1.AlertType_ALERT_TYPE_ERROR,
 						}},
-					}}, nil
+					},
+				}, nil
 			}
 
 			if queryTrip.Departure == nil || queryTrip.Arrival == nil ||
@@ -86,7 +87,8 @@ func (*TransportSearchV3Server) TransportSearch(ctx context.Context, req *transp
 							Message: "Invalid trip: departure and arrival must be provided",
 							Type:    typesv1.AlertType_ALERT_TYPE_ERROR,
 						}},
-					}}, nil
+					},
+				}, nil
 			}
 
 			if !common.AreTravelDatesValid(queryTrip.Departure.Date, queryTrip.Arrival.Date) {
@@ -97,7 +99,8 @@ func (*TransportSearchV3Server) TransportSearch(ctx context.Context, req *transp
 							Message: "Invalid travel dates: departure date must be in the future and departure must be before arrival",
 							Type:    typesv1.AlertType_ALERT_TYPE_ERROR,
 						}},
-					}}, nil
+					},
+				}, nil
 			}
 
 			searchParametersTransport := queryTrip.GetSearchParametersTransport()
@@ -116,7 +119,8 @@ func (*TransportSearchV3Server) TransportSearch(ctx context.Context, req *transp
 							Message: fmt.Sprintf("Invalid min price: decimals must be less than or equal to %d", price.NativeTokenDecimals),
 							Type:    typesv1.AlertType_ALERT_TYPE_ERROR,
 						}},
-					}}, nil
+					},
+				}, nil
 			}
 		}
 	}

--- a/pp-mock/handlers/transport/v3/transport_search.go
+++ b/pp-mock/handlers/transport/v3/transport_search.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"math/big"
 
 	"buf.build/gen/go/chain4travel/camino-messenger-protocol/grpc/go/cmp/services/transport/v3/transportv3grpc"
 	transportv3 "buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go/cmp/services/transport/v3"
@@ -20,9 +21,6 @@ import (
 	mockdata "github.com/chain4travel/camino-messenger-bot/pp-mock/services/data"
 	"github.com/google/uuid"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-	"google.golang.org/protobuf/proto"
 )
 
 var _ transportv3grpc.TransportSearchServiceServer = (*TransportSearchV3Server)(nil)
@@ -31,11 +29,6 @@ type TransportSearchV3Server struct{}
 
 func (*TransportSearchV3Server) TransportSearch(ctx context.Context, req *transportv3.TransportSearchRequest) (*transportv3.TransportSearchResponse, error) {
 	md := metadata.Metadata{}
-
-	// check if req is nil
-	if req == nil {
-		return nil, status.Errorf(codes.InvalidArgument, "request is nil")
-	}
 
 	err := md.ExtractMetadata(ctx)
 	if err != nil {
@@ -52,20 +45,88 @@ func (*TransportSearchV3Server) TransportSearch(ctx context.Context, req *transp
 				Status: typesv1.StatusType_STATUS_TYPE_FAILURE,
 				Alerts: []*typesv1.Alert{{
 					Message: "No queries provided",
-					Type:    typesv1.AlertType_ALERT_TYPE_INFO,
+					Type:    typesv1.AlertType_ALERT_TYPE_ERROR,
 				}},
 			},
 		}, nil
 	}
 
-	var resultIDnum int32 = 1
+	if req.SearchParameters.GetCurrency() == nil {
+		return &transportv3.TransportSearchResponse{
+			Header: &typesv1.ResponseHeader{
+				Status: typesv1.StatusType_STATUS_TYPE_FAILURE,
+				Alerts: []*typesv1.Alert{{
+					Message: "SearchParameters.Currency is required",
+					Type:    typesv1.AlertType_ALERT_TYPE_ERROR,
+				}},
+			},
+		}, nil
+	}
 
+	for queryIndex, query := range req.Queries {
+		for queryTripIndex, queryTrip := range query.GetTrips() {
+			if queryTrip == nil {
+				return &transportv3.TransportSearchResponse{
+					Header: &typesv1.ResponseHeader{
+						Status: typesv1.StatusType_STATUS_TYPE_FAILURE,
+						Alerts: []*typesv1.Alert{{
+							Message: fmt.Sprintf("Invalid query[%d].QueryTrips[%d]: can't be nil", queryIndex, queryTripIndex),
+							Type:    typesv1.AlertType_ALERT_TYPE_ERROR,
+						}},
+					}}, nil
+			}
+
+			if queryTrip.Departure == nil || queryTrip.Arrival == nil ||
+				queryTrip.Departure.Date == nil || queryTrip.Arrival.Date == nil ||
+				queryTrip.Departure.LocationCode == nil || queryTrip.Arrival.LocationCode == nil {
+				return &transportv3.TransportSearchResponse{
+					Header: &typesv1.ResponseHeader{
+						Status: typesv1.StatusType_STATUS_TYPE_FAILURE,
+						Alerts: []*typesv1.Alert{{
+							Message: "Invalid trip: departure and arrival must be provided",
+							Type:    typesv1.AlertType_ALERT_TYPE_ERROR,
+						}},
+					}}, nil
+			}
+
+			if !common.AreTravelDatesValid(queryTrip.Departure.Date, queryTrip.Arrival.Date) {
+				return &transportv3.TransportSearchResponse{
+					Header: &typesv1.ResponseHeader{
+						Status: typesv1.StatusType_STATUS_TYPE_FAILURE,
+						Alerts: []*typesv1.Alert{{
+							Message: "Invalid travel dates: departure date must be in the future and departure must be before arrival",
+							Type:    typesv1.AlertType_ALERT_TYPE_ERROR,
+						}},
+					}}, nil
+			}
+
+			searchParametersTransport := queryTrip.GetSearchParametersTransport()
+			if searchParametersTransport == nil {
+				continue
+			}
+
+			// Mock simplification: we're limiting mock example to work only with currencies,
+			// that have <= than 18 decimals in order to avoid adding blockchain interaction
+			// to pp mock (it would be needed to get erc20 token decimals)
+			if searchParametersTransport.GetMinPrice().GetDecimals() > price.NativeTokenDecimals { // 18 decimals
+				return &transportv3.TransportSearchResponse{
+					Header: &typesv1.ResponseHeader{
+						Status: typesv1.StatusType_STATUS_TYPE_FAILURE,
+						Alerts: []*typesv1.Alert{{
+							Message: fmt.Sprintf("Invalid min price: decimals must be less than or equal to %d", price.NativeTokenDecimals),
+							Type:    typesv1.AlertType_ALERT_TYPE_ERROR,
+						}},
+					}}, nil
+			}
+		}
+	}
+
+	resultIDnum := int32(1)
 	searchResults := []*transportv3.TransportSearchResult{}
 
 	for _, query := range req.Queries {
 		filteredTrips := mockdata.TripsExtendedV3
-		queryTrips := query.GetTrips()
-		for _, queryTrip := range queryTrips {
+		for _, queryTrip := range query.GetTrips() {
 			if queryTrip == nil {
 				continue
 			}
@@ -74,43 +135,47 @@ func (*TransportSearchV3Server) TransportSearch(ctx context.Context, req *transp
 				continue
 			}
 
-			if queryTrip.Departure != nil && queryTrip.Arrival != nil && queryTrip.Departure.Date != nil && queryTrip.Arrival.Date != nil {
-				departureDate := queryTrip.Departure.Date
-				arrivalDate := queryTrip.Arrival.Date
-				// Check if the travel period is valid
-				if !common.AreTravelDatesValid(departureDate, arrivalDate) {
-					return &transportv3.TransportSearchResponse{
-						Header: &typesv1.ResponseHeader{
-							Status: typesv1.StatusType_STATUS_TYPE_FAILURE,
-							Alerts: []*typesv1.Alert{{
-								Message: "Invalid travel dates: departure date must be in the future and departure must be before arrival",
-								Type:    typesv1.AlertType_ALERT_TYPE_INFO,
-							},
-							},
-						},
-					}, nil
-				}
-			}
 			// This is just an example, not real business logic:
 			filteredTrips = filterTripsByProductCodes(filteredTrips, searchParametersTransport.GetProductCodes())
 			if searchParametersTransport.GetMaxSegments() != 0 {
 				filteredTrips = filterTripsByMaxSegments(filteredTrips, searchParametersTransport.GetMaxSegments())
 			}
-			filteredTrips = filterTripsByMaxPrice(filteredTrips, searchParametersTransport.GetMaxPrice())
 		}
 
-		var travellerIDs []int32
-		if query.Travellers != nil {
-			travellerIDs = common.GetTravellerIDsV3(query.Travellers)
+		totalPrice := big.NewInt(0)
+
+		for _, trip := range filteredTrips {
+			for _, segment := range trip.Segments {
+				price, err := price.ToBigInt(
+					segment.Price.Value,
+					segment.Price.Decimals,
+					price.NativeTokenDecimals, // max possible decimals
+				)
+				if err != nil {
+					return &transportv3.TransportSearchResponse{
+						Header: &typesv1.ResponseHeader{
+							Status: typesv1.StatusType_STATUS_TYPE_FAILURE,
+							Alerts: []*typesv1.Alert{{
+								Message: fmt.Sprintf("Failed to convert tripSegment price: %v", err),
+								Type:    typesv1.AlertType_ALERT_TYPE_ERROR,
+							}},
+						},
+					}, nil
+				}
+				totalPrice = new(big.Int).Add(totalPrice, price)
+			}
 		}
+
 		searchResults = append(searchResults, &transportv3.TransportSearchResult{
 			ResultId:        resultIDnum,
 			QueryId:         query.QueryId,
-			TravellerIds:    travellerIDs,
+			TravellerIds:    common.GetTravellerIDsV3(query.Travellers),
 			TravellingTrips: filteredTrips,
 			TotalPrice: &typesv3.PriceDetail{
 				Price: &typesv3.Price{
-					Value: common.DefaultPrice,
+					Value:    totalPrice.String(),
+					Decimals: price.NativeTokenDecimals,
+					Currency: req.SearchParameters.Currency,
 				},
 			},
 		})
@@ -153,20 +218,15 @@ func filterTripsByProductCodes(trips []*transportv3.TripExtended, productCodes [
 	if len(productCodes) == 0 {
 		return trips
 	}
-
-	filtered := make([]*transportv3.TripExtended, 0)
+	filtered := []*transportv3.TripExtended{}
 	for _, trip := range trips {
-		exists := false
+	segmentsLoop:
 		for _, segment := range trip.Segments {
 			for _, code := range productCodes {
-				if segment.GetInfo().GetProductCode().Code != "" && segment.GetInfo().GetProductCode().Code == code.GetCode() {
+				if segment.GetInfo().GetProductCode().Code == code.GetCode() {
 					filtered = append(filtered, trip)
-					exists = true
-					break
+					break segmentsLoop
 				}
-			}
-			if exists {
-				break // Break out of segments loop after adding the trip
 			}
 		}
 	}
@@ -174,60 +234,11 @@ func filterTripsByProductCodes(trips []*transportv3.TripExtended, productCodes [
 }
 
 func filterTripsByMaxSegments(trips []*transportv3.TripExtended, maxSegments int32) []*transportv3.TripExtended {
-	filtered := make([]*transportv3.TripExtended, 0)
+	filtered := []*transportv3.TripExtended{}
 	for _, trip := range trips {
 		if len(trip.Segments) <= int(maxSegments) {
 			filtered = append(filtered, trip)
 		}
 	}
-	return filtered
-}
-
-func filterTripsByMaxPrice(trips []*transportv3.TripExtended, maxPrice *typesv3.Price) []*transportv3.TripExtended {
-	if maxPrice == nil {
-		return trips
-	}
-
-	filtered := make([]*transportv3.TripExtended, 0)
-
-	// Convert maxPrice to big.Int for comparison
-	maxPriceBigInt, err := price.ToBigInt(maxPrice.Value, maxPrice.Decimals, maxPrice.Decimals)
-	if err != nil {
-		// Mock simplification: If the max price can't be converted, return all trips
-		return trips
-	}
-
-	for _, trip := range trips {
-		tripPrice := trip.GetPrice()
-
-		if tripPrice == nil {
-			continue
-		}
-
-		// TODO: @VjeraTurk this is a workaround for currency that is not parsed well from the .json
-		if tripPrice.Currency == nil || tripPrice.Currency.Currency == nil {
-			tripPrice.Currency = &typesv3.Currency{
-				Currency: &typesv3.Currency_IsoCurrency{
-					IsoCurrency: typesv3.IsoCurrency_ISO_CURRENCY_EUR,
-				},
-			}
-		}
-
-		if !proto.Equal(tripPrice.GetCurrency(), maxPrice.GetCurrency()) {
-			continue
-		}
-
-		tripPriceBigInt, err := price.ToBigInt(tripPrice.Value, tripPrice.Decimals, maxPrice.Decimals)
-		if err != nil {
-			log.Printf("Failed to convert trip price: %v", err)
-			continue
-		}
-
-		// Compare total price with max price
-		if tripPriceBigInt.Cmp(maxPriceBigInt) <= 0 {
-			filtered = append(filtered, trip)
-		}
-	}
-
 	return filtered
 }

--- a/pp-mock/handlers/transport/v3/transport_search.go
+++ b/pp-mock/handlers/transport/v3/transport_search.go
@@ -12,7 +12,6 @@ import (
 	"buf.build/gen/go/chain4travel/camino-messenger-protocol/grpc/go/cmp/services/transport/v3/transportv3grpc"
 	transportv3 "buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go/cmp/services/transport/v3"
 	typesv1 "buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go/cmp/types/v1"
-	typesv2 "buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go/cmp/types/v2"
 	typesv3 "buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go/cmp/types/v3"
 
 	"github.com/chain4travel/camino-messenger-bot/internal/metadata"
@@ -131,18 +130,14 @@ func (*TransportSearchV3Server) TransportSearch(ctx context.Context, req *transp
 	for _, query := range req.Queries {
 		filteredTrips := mockdata.TripsExtendedV3
 		for _, queryTrip := range query.GetTrips() {
-			if queryTrip == nil {
-				continue
-			}
-			searchParametersTransport := queryTrip.GetSearchParametersTransport()
-			if searchParametersTransport == nil {
+			if queryTrip.SearchParametersTransport == nil { // its optional
 				continue
 			}
 
 			// This is just an example, not real business logic:
-			filteredTrips = filterTripsByProductCodes(filteredTrips, searchParametersTransport.GetProductCodes())
-			if searchParametersTransport.GetMaxSegments() != 0 {
-				filteredTrips = filterTripsByMaxSegments(filteredTrips, searchParametersTransport.GetMaxSegments())
+			filteredTrips = filterTripsByProductCodes(filteredTrips, queryTrip.SearchParametersTransport.ProductCodes)
+			if queryTrip.SearchParametersTransport.MaxSegments != 0 {
+				filteredTrips = filterTripsByMaxSegments(filteredTrips, queryTrip.SearchParametersTransport.MaxSegments)
 			}
 		}
 
@@ -184,29 +179,24 @@ func (*TransportSearchV3Server) TransportSearch(ctx context.Context, req *transp
 		resultIDnum++
 	}
 
-	if len(searchResults) == 0 {
-		return &transportv3.TransportSearchResponse{
-			Header: &typesv1.ResponseHeader{
-				Status: typesv1.StatusType_STATUS_TYPE_SUCCESS,
-				Alerts: []*typesv1.Alert{{
-					Message: fmt.Sprintf("No results found for search %v", req.Queries),
-					Type:    typesv1.AlertType_ALERT_TYPE_INFO,
-				}},
-			},
-		}, nil
-	}
-
-	searchID := uuid.New().String()
-
 	response := &transportv3.TransportSearchResponse{
 		Header: &typesv1.ResponseHeader{
 			Status: typesv1.StatusType_STATUS_TYPE_SUCCESS,
 		},
-		Metadata: &typesv3.SearchResponseMetadata{
-			SearchId: &typesv1.UUID{Value: searchID},
-		},
 		Results: searchResults,
 	}
+
+	if len(searchResults) == 0 {
+		response.Header.Alerts = []*typesv1.Alert{{
+			Message: fmt.Sprintf("No results found for search %v", req.Queries),
+			Type:    typesv1.AlertType_ALERT_TYPE_INFO,
+		}}
+	} else {
+		response.Metadata = &typesv3.SearchResponseMetadata{
+			SearchId: &typesv1.UUID{Value: uuid.New().String()},
+		}
+	}
+
 	log.Printf("CMAccount %s received request from CMAccount %s", md.Recipient, md.Sender)
 
 	if err := grpc.SetHeader(ctx, md.ToGrpcMD()); err != nil {
@@ -214,33 +204,4 @@ func (*TransportSearchV3Server) TransportSearch(ctx context.Context, req *transp
 	}
 
 	return response, nil
-}
-
-func filterTripsByProductCodes(trips []*transportv3.TripExtended, productCodes []*typesv2.ProductCode) []*transportv3.TripExtended {
-	if len(productCodes) == 0 {
-		return trips
-	}
-	filtered := []*transportv3.TripExtended{}
-	for _, trip := range trips {
-	segmentsLoop:
-		for _, segment := range trip.Segments {
-			for _, code := range productCodes {
-				if segment.GetInfo().GetProductCode().Code == code.GetCode() {
-					filtered = append(filtered, trip)
-					break segmentsLoop
-				}
-			}
-		}
-	}
-	return filtered
-}
-
-func filterTripsByMaxSegments(trips []*transportv3.TripExtended, maxSegments int32) []*transportv3.TripExtended {
-	filtered := []*transportv3.TripExtended{}
-	for _, trip := range trips {
-		if len(trip.Segments) <= int(maxSegments) {
-			filtered = append(filtered, trip)
-		}
-	}
-	return filtered
 }

--- a/pp-mock/handlers/transport/v3/transport_search.go
+++ b/pp-mock/handlers/transport/v3/transport_search.go
@@ -145,25 +145,23 @@ func (*TransportSearchV3Server) TransportSearch(ctx context.Context, req *transp
 		totalPrice := big.NewInt(0)
 
 		for _, trip := range filteredTrips {
-			for _, segment := range trip.Segments {
-				price, err := price.ToBigInt(
-					segment.Price.Value,
-					segment.Price.Decimals,
-					price.NativeTokenDecimals, // max possible decimals
-				)
-				if err != nil {
-					return &transportv3.TransportSearchResponse{
-						Header: &typesv1.ResponseHeader{
-							Status: typesv1.StatusType_STATUS_TYPE_FAILURE,
-							Alerts: []*typesv1.Alert{{
-								Message: fmt.Sprintf("Failed to convert tripSegment price: %v", err),
-								Type:    typesv1.AlertType_ALERT_TYPE_ERROR,
-							}},
-						},
-					}, nil
-				}
-				totalPrice = new(big.Int).Add(totalPrice, price)
+			price, err := price.ToBigInt(
+				trip.Price.Value,
+				trip.Price.Decimals,
+				price.NativeTokenDecimals, // max possible decimals
+			)
+			if err != nil {
+				return &transportv3.TransportSearchResponse{
+					Header: &typesv1.ResponseHeader{
+						Status: typesv1.StatusType_STATUS_TYPE_FAILURE,
+						Alerts: []*typesv1.Alert{{
+							Message: fmt.Sprintf("Failed to convert tripSegment price: %v", err),
+							Type:    typesv1.AlertType_ALERT_TYPE_ERROR,
+						}},
+					},
+				}, nil
 			}
+			totalPrice = new(big.Int).Add(totalPrice, price)
 		}
 
 		searchResults = append(searchResults, &transportv3.TransportSearchResult{

--- a/pp-mock/server.go
+++ b/pp-mock/server.go
@@ -25,7 +25,7 @@ import (
 	"buf.build/gen/go/chain4travel/camino-messenger-protocol/grpc/go/cmp/services/transport/v1/transportv1grpc"
 	"buf.build/gen/go/chain4travel/camino-messenger-protocol/grpc/go/cmp/services/transport/v2/transportv2grpc"
 	"buf.build/gen/go/chain4travel/camino-messenger-protocol/grpc/go/cmp/services/transport/v3/transportv3grpc"
-	
+
 	handlers_accommodation_v1 "github.com/chain4travel/camino-messenger-bot/pp-mock/handlers/accommodation/v1"
 	handlers_accommodation_v2 "github.com/chain4travel/camino-messenger-bot/pp-mock/handlers/accommodation/v2"
 	handlers_accommodation_v3 "github.com/chain4travel/camino-messenger-bot/pp-mock/handlers/accommodation/v3"

--- a/pp-mock/server.go
+++ b/pp-mock/server.go
@@ -22,7 +22,10 @@ import (
 	"buf.build/gen/go/chain4travel/camino-messenger-protocol/grpc/go/cmp/services/book/v1/bookv1grpc"
 	"buf.build/gen/go/chain4travel/camino-messenger-protocol/grpc/go/cmp/services/book/v2/bookv2grpc"
 	"buf.build/gen/go/chain4travel/camino-messenger-protocol/grpc/go/cmp/services/ping/v1/pingv1grpc"
-
+	"buf.build/gen/go/chain4travel/camino-messenger-protocol/grpc/go/cmp/services/transport/v1/transportv1grpc"
+	"buf.build/gen/go/chain4travel/camino-messenger-protocol/grpc/go/cmp/services/transport/v2/transportv2grpc"
+	"buf.build/gen/go/chain4travel/camino-messenger-protocol/grpc/go/cmp/services/transport/v3/transportv3grpc"
+	
 	handlers_accommodation_v1 "github.com/chain4travel/camino-messenger-bot/pp-mock/handlers/accommodation/v1"
 	handlers_accommodation_v2 "github.com/chain4travel/camino-messenger-bot/pp-mock/handlers/accommodation/v2"
 	handlers_accommodation_v3 "github.com/chain4travel/camino-messenger-bot/pp-mock/handlers/accommodation/v3"
@@ -31,6 +34,9 @@ import (
 	handlers_validation_v1 "github.com/chain4travel/camino-messenger-bot/pp-mock/handlers/book/validation/v1"
 	handlers_validation_v2 "github.com/chain4travel/camino-messenger-bot/pp-mock/handlers/book/validation/v2"
 	handlers_ping_v1 "github.com/chain4travel/camino-messenger-bot/pp-mock/handlers/ping/v1"
+	handlers_transport_v1 "github.com/chain4travel/camino-messenger-bot/pp-mock/handlers/transport/v1"
+	handlers_transport_v2 "github.com/chain4travel/camino-messenger-bot/pp-mock/handlers/transport/v2"
+	handlers_transport_v3 "github.com/chain4travel/camino-messenger-bot/pp-mock/handlers/transport/v3"
 )
 
 func main() {
@@ -70,6 +76,14 @@ func run() error {
 
 	// Ping
 	pingv1grpc.RegisterPingServiceServer(grpcServer, &handlers_ping_v1.PingServiceV1Server{})
+
+	// Transport
+	transportv1grpc.RegisterTransportSearchServiceServer(grpcServer, &handlers_transport_v1.TransportSearchV1Server{})
+
+	transportv2grpc.RegisterTransportSearchServiceServer(grpcServer, &handlers_transport_v2.TransportSearchV2Server{})
+
+	transportv3grpc.RegisterTransportProductListServiceServer(grpcServer, &handlers_transport_v3.TransportProductListV3Server{})
+	transportv3grpc.RegisterTransportSearchServiceServer(grpcServer, &handlers_transport_v3.TransportSearchV3Server{})
 
 	reflection.Register(grpcServer)
 

--- a/pp-mock/services/data/mock_data.go
+++ b/pp-mock/services/data/mock_data.go
@@ -8,15 +8,30 @@ import (
 	accommodationv1 "buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go/cmp/services/accommodation/v1"
 	accommodationv2 "buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go/cmp/services/accommodation/v2"
 	accommodationv3 "buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go/cmp/services/accommodation/v3"
+	transportv1 "buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go/cmp/services/transport/v1"
+	transportv2 "buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go/cmp/services/transport/v2"
+	transportv3 "buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go/cmp/services/transport/v3"
 )
 
 //go:embed properties.json
 var propertiesJSON []byte
 
+//go:embed tripsv1.json
+var tripsV1JSON []byte
+
+//go:embed tripsv3.json
+var tripsV3JSON []byte
+
 var (
 	PropertiesV1 []*accommodationv1.PropertyExtendedInfo
 	PropertiesV2 []*accommodationv2.PropertyExtendedInfo
 	PropertiesV3 []*accommodationv3.PropertyExtendedInfo
+
+	TripsV1 []*transportv1.Trip
+	TripsV2 []*transportv2.Trip
+
+	TripsBasicV3    []*transportv3.TripBasic
+	TripsExtendedV3 []*transportv3.TripExtended
 )
 
 func init() {
@@ -28,6 +43,18 @@ func init() {
 	}
 	if err := json.Unmarshal(propertiesJSON, &PropertiesV3); err != nil {
 		panic(fmt.Errorf("error unmarshaling properties v3: %w", err))
+	}
+	if err := json.Unmarshal(tripsV1JSON, &TripsV1); err != nil {
+		panic(fmt.Errorf("error unmarshaling trips v1: %w", err))
+	}
+	if err := json.Unmarshal(tripsV1JSON, &TripsV2); err != nil {
+		panic(fmt.Errorf("error unmarshaling trips v2: %w", err))
+	}
+	if err := json.Unmarshal(tripsV3JSON, &TripsBasicV3); err != nil {
+		panic(fmt.Errorf("error unmarshaling trips v3 basic: %w", err))
+	}
+	if err := json.Unmarshal(tripsV3JSON, &TripsExtendedV3); err != nil {
+		panic(fmt.Errorf("error unmarshaling trips v3 extended: %w", err))
 	}
 	// TODO @evlekht do all data checks like make sure that properties has prop.Property.ContactInfo.Address[0] != nil
 }

--- a/pp-mock/services/data/tripsv1.json
+++ b/pp-mock/services/data/tripsv1.json
@@ -1,0 +1,118 @@
+[
+    {
+        "segments": [
+            {
+                "segment_id": "SEG1234",
+                "departure": {
+                    "date_time": {
+                        "seconds": 1715775600,
+                        "nanos": 0
+                    },
+                    "location_code": {
+                        "code": "PMI",
+                        "type": 2
+                    }
+                },
+                "arrival": {
+                    "date_time": {
+                        "seconds": 1715779200,
+                        "nanos": 0
+                    },
+                    "location_code": {
+                        "code": "BCN",
+                        "type": 2
+                    }
+                },
+                "service_type_code": "Y",
+                "service_type_description": "Economy Class",
+                "product_code": {
+                    "code": "IATA4589",
+                    "type": 3
+                },
+                "price": {
+                    "value": "15000",
+                    "decimals": 2,
+                    "currency": {
+                        "iso_currency": "ISO_CURRENCY_EUR"
+                    }
+                }
+            }
+        ]
+    },
+    {
+        "segments": [
+            {
+                "segment_id": "SEG234",
+                "departure": {
+                    "date_time": {
+                        "seconds": 1715782800,
+                        "nanos": 0
+                    },
+                    "location_code": {
+                        "code": "BCN",
+                        "type": 2
+                    }
+                },
+                "arrival": {
+                    "date_time": {
+                        "seconds": 1715786400,
+                        "nanos": 0
+                    },
+                    "location_code": {
+                        "code": "MAD",
+                        "type": 2
+                    }
+                },
+                "service_type_code": "J",
+                "service_type_description": "Business Class",
+                "product_code": {
+                    "code": "IATA1234",
+                    "type": 3
+                },
+                "price": {
+                    "value": "30000",
+                    "decimals": 2,
+                    "currency": {
+                        "iso_currency": "ISO_CURRENCY_EUR"
+                    }
+                }
+            },
+            {
+                "segment_id": "SEG235",
+                "departure": {
+                    "date_time": {
+                        "seconds": 1715790000,
+                        "nanos": 0
+                    },
+                    "location_code": {
+                        "code": "MAD",
+                        "type": 2
+                    }
+                },
+                "arrival": {
+                    "date_time": {
+                        "seconds": 1715793600,
+                        "nanos": 0
+                    },
+                    "location_code": {
+                        "code": "LIS",
+                        "type": 2
+                    }
+                },
+                "service_type_code": "F",
+                "service_type_description": "First Class",
+                "product_code": {
+                    "code": "IATA5678",
+                    "type": 3
+                },
+                "price": {
+                    "value": "45000",
+                    "decimals": 2,
+                    "currency": {
+                        "iso_currency": "ISO_CURRENCY_EUR"
+                    }
+                }
+            }
+        ]
+    }
+]

--- a/pp-mock/services/data/tripsv3.json
+++ b/pp-mock/services/data/tripsv3.json
@@ -1,0 +1,140 @@
+[
+    {
+        "supplier_code": {
+            "supplier_code": "SUP123",
+            "supplier_number": 124
+        },
+        "price": {
+            "value": "20000",
+            "decimals": 2,
+            "currency": {
+                "iso_currency": "ISO_CURRENCY_EUR"
+            }
+        },
+        "segments": [
+            {
+                "product_code": {
+                    "code": "IATA4589",
+                    "type": 3
+                },
+                "info": {
+                    "departure": {
+                        "date_time": {
+                            "seconds": 1715775600,
+                            "nanos": 0
+                        },
+                        "location_code": {
+                            "code": "PMI",
+                            "type": 0
+                        }
+                    },
+                    "arrival": {
+                        "date_time": {
+                            "seconds": 1715779200,
+                            "nanos": 0
+                        },
+                        "location_code": {
+                            "code": "BCN",
+                            "type": 2
+                        }
+                    },
+                    "product_code": {
+                        "code": "IATA4589",
+                        "type": 3
+                    },
+                    "segment_id": "SEG1234",
+                    "provider_code": "EW",
+                    "retailer_code": "IB",
+                    "sub_supplier_code": "NS"
+                }
+            }
+        ]
+    },
+    {
+        "supplier_code": {
+            "supplier_code": "SUP456",
+            "supplier_number": 456
+        },
+        "price": {
+            "value": "75000",
+            "decimals": 2,
+            "currency": {
+                "iso_currency": "ISO_CURRENCY_EUR"
+            }
+        },
+        "segments": [
+            {
+                "product_code": {
+                    "code": "IATA1234",
+                    "type": 3
+                },
+                "info": {
+                    "departure": {
+                        "date_time": {
+                            "seconds": 1715782800,
+                            "nanos": 0
+                        },
+                        "location_code": {
+                            "code": "BCN",
+                            "type": 0
+                        }
+                    },
+                    "arrival": {
+                        "date_time": {
+                            "seconds": 1715786400,
+                            "nanos": 0
+                        },
+                        "location_code": {
+                            "code": "MAD",
+                            "type": 2
+                        }
+                    },
+                    "product_code": {
+                        "code": "IATA1234",
+                        "type": 3
+                    },
+                    "segment_id": "SEG5678",
+                    "provider_code": "LH",
+                    "retailer_code": "BA",
+                    "sub_supplier_code": "NS"
+                }
+            },
+            {
+                "product_code": {
+                    "code": "IATA5678",
+                    "type": 3
+                },
+                "info": {
+                    "departure": {
+                        "date_time": {
+                            "seconds": 1715790000,
+                            "nanos": 0
+                        },
+                        "location_code": {
+                            "code": "MAD",
+                            "type": 0
+                        }
+                    },
+                    "arrival": {
+                        "date_time": {
+                            "seconds": 1715793600,
+                            "nanos": 0
+                        },
+                        "location_code": {
+                            "code": "LIS",
+                            "type": 2
+                        }
+                    },
+                    "product_code": {
+                        "code": "IATA5678",
+                        "type": 3
+                    },
+                    "segment_id": "SEG91011",
+                    "provider_code": "AF",
+                    "retailer_code": "KL",
+                    "sub_supplier_code": "NS"
+                }
+            }
+        ]
+    }
+]


### PR DESCRIPTION
## Why this should be merged
- It introduces examples of new messages

## How this works
#### 1. Transport Messages
pp-mock now contains examples of `TransportSearch`, `TransportProductList`
The mock showcases filtering
`filterTripsByProductCodes`
`filterTripsByMaxSegments`
`filterTripsByMaxPrice`

with some mock simplifications (e.g. no price conversion)

## How this was tested
Examples tested via Postman.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Upgraded service endpoints to support the latest accommodation and transport search and product listing capabilities.
  
- **Improvements**
  - Enhanced filtering, data validation, and error handling to deliver more reliable and accurate responses.
  - Improved logging and metadata management for a smoother overall experience.
  
- **Chores**
  - Updated dependencies, refined build scripts, and extended sample data to support the new features and ensure seamless integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->