### PR TITLE
Bugfix for stuck shutdown

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -261,10 +261,6 @@ func (a *App) Run(ctx context.Context) error {
 	})
 
 	g.Go(func() error {
-		<-cashInStatusCheckDone
-		<-schedulerStarted
-		<-messageProcessorStarted
-
 		if !awaitChans(
 			gCtx,
 			[]<-chan struct{}{

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -232,17 +232,6 @@ func (a *App) Run(ctx context.Context) error {
 	schedulerStarted := make(chan struct{})
 	messageProcessorStarted := make(chan struct{})
 
-	if a.rpcServer != nil { // rpcServer will be nil, if its disabled in config
-		g.Go(func() error {
-			<-messengerReceiverStarted
-			<-cashInStatusCheckDone
-			<-schedulerStarted
-			<-messageProcessorStarted
-			a.logger.Info("Starting gRPC server...")
-			return a.rpcServer.Start()
-		})
-	}
-
 	g.Go(func() error {
 		a.logger.Info("Starting start-up cash-in status check...")
 		if err := a.chequeHandler.CheckCashInStatus(gCtx); err != nil {
@@ -265,9 +254,27 @@ func (a *App) Run(ctx context.Context) error {
 	})
 
 	g.Go(func() error {
+		a.logger.Info("Starting message processor...")
+		close(messageProcessorStarted)
+		a.messageProcessor.Start(gCtx)
+		return nil
+	})
+
+	g.Go(func() error {
 		<-cashInStatusCheckDone
 		<-schedulerStarted
 		<-messageProcessorStarted
+
+		if !awaitChans(
+			gCtx,
+			[]<-chan struct{}{
+				cashInStatusCheckDone,
+				schedulerStarted,
+				messageProcessorStarted,
+			},
+		) {
+			return nil
+		}
 		a.logger.Info("Starting message receiver...")
 		matrixUserID, err := a.messenger.StartReceiver()
 		if err != nil {
@@ -280,19 +287,31 @@ func (a *App) Run(ctx context.Context) error {
 		return nil
 	})
 
-	g.Go(func() error {
-		a.logger.Info("Starting message processor...")
-		close(messageProcessorStarted)
-		a.messageProcessor.Start(gCtx)
-		return nil
-	})
+	if a.rpcServer != nil { // rpcServer will be nil, if its disabled in config
+		g.Go(func() error {
+			if !awaitChans(
+				gCtx,
+				[]<-chan struct{}{
+					messengerReceiverStarted,
+					cashInStatusCheckDone,
+					schedulerStarted,
+					messageProcessorStarted,
+				},
+			) {
+				return nil
+			}
+
+			a.logger.Info("Starting gRPC server...")
+			return a.rpcServer.Start()
+		})
+	}
 
 	// stop
-	// <-gCtx.Done() means that all "run" goroutines are finished
 
 	if a.rpcClient != nil { // rpcClient will be nil, if its disabled in partner plugin config section
 		g.Go(func() error {
 			<-gCtx.Done()
+			a.logger.Info("Stopping gRPC client...")
 			return a.rpcClient.Shutdown()
 		})
 	}
@@ -300,6 +319,7 @@ func (a *App) Run(ctx context.Context) error {
 	if a.rpcServer != nil { // rpcServer will be nil, if its disabled in config
 		g.Go(func() error {
 			<-gCtx.Done()
+			a.logger.Info("Stopping gRPC server...")
 			a.rpcServer.Stop()
 			return nil
 		})
@@ -307,7 +327,14 @@ func (a *App) Run(ctx context.Context) error {
 
 	g.Go(func() error {
 		<-gCtx.Done()
+		a.logger.Info("Stopping message receiver...")
 		return a.messenger.StopReceiver()
+	})
+
+	g.Go(func() error {
+		<-gCtx.Done()
+		a.logger.Info("Stopping scheduler...")
+		return a.scheduler.Stop()
 	})
 
 	// wait
@@ -316,5 +343,24 @@ func (a *App) Run(ctx context.Context) error {
 	if err != nil {
 		a.logger.Error(err) // will log first run/stop error
 	}
+
 	return err
+}
+
+func awaitChan(ctx context.Context, ch <-chan struct{}) bool {
+	select {
+	case <-ch:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+func awaitChans(ctx context.Context, chans []<-chan struct{}) bool {
+	for _, ch := range chans {
+		if !awaitChan(ctx, ch) {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/rpc/server/server.go
+++ b/internal/rpc/server/server.go
@@ -8,16 +8,16 @@ import (
 	"fmt"
 	"net"
 
+	"github.com/chain4travel/camino-messenger-bot/config"
+	"github.com/chain4travel/camino-messenger-bot/internal/messaging"
 	"github.com/chain4travel/camino-messenger-bot/internal/messaging/types"
+	"github.com/chain4travel/camino-messenger-bot/internal/metadata"
 	"github.com/chain4travel/camino-messenger-bot/internal/rpc"
 	"github.com/chain4travel/camino-messenger-bot/internal/rpc/generated"
 	"github.com/chain4travel/camino-messenger-bot/internal/tracing"
 	"github.com/chain4travel/camino-messenger-bot/proto/pb/readiness"
+	"github.com/chain4travel/camino-messenger-bot/utils/tls"
 
-	"github.com/chain4travel/camino-messenger-bot/config"
-	"github.com/chain4travel/camino-messenger-bot/internal/messaging"
-	"github.com/chain4travel/camino-messenger-bot/internal/metadata"
-	utils "github.com/chain4travel/camino-messenger-bot/utils/tls"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
@@ -52,7 +52,7 @@ func NewServer(
 	if cfg.Unencrypted {
 		logger.Warn("Running gRPC server without TLS!")
 	} else {
-		creds, err := utils.LoadTLSCredentials(cfg.ServerCertFile, cfg.ServerKeyFile)
+		creds, err := tls.LoadTLSCredentials(cfg.ServerCertFile, cfg.ServerKeyFile)
 		if err != nil {
 			return nil, fmt.Errorf("could not load TLS keys: %w", err)
 		}
@@ -95,7 +95,6 @@ func (s *server) Start() error {
 }
 
 func (s *server) Stop() {
-	s.logger.Info("Stopping gRPC server...")
 	s.grpcServer.Stop()
 }
 
@@ -129,6 +128,8 @@ func (s *server) processMetadata(ctx context.Context, id trace.TraceID) (metadat
 	return md, err
 }
 
+const StatusReady = "ready"
+
 func (s *server) Readiness(context.Context, *emptypb.Empty) (*readiness.ReadinessResponse, error) {
-	return &readiness.ReadinessResponse{Status: "ready"}, nil
+	return &readiness.ReadinessResponse{Status: StatusReady}, nil
 }

--- a/utils/tls/tls.go
+++ b/utils/tls/tls.go
@@ -1,7 +1,7 @@
 // Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-package utils
+package tls
 
 import (
 	"crypto/tls"


### PR DESCRIPTION
When bot encountered error on startup, rpcServer goroutine could hung forever, because it awaits for channel of other component to be closed first (to signal that this component is started).

PR fixes that by making select between awaited chan and context.Done: if app is shutting down, context is canceled and chan await will be unblocked.

Also, small cleanup: renamed utils/tls package utils to package tls for consistency.