### PR TITLE
Remove scheme from expected matrix userID

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -150,6 +150,8 @@ func NewApp(ctx context.Context, cfg *config.Config, logger *zap.SugaredLogger) 
 	// get matrix hostname without schema
 	matrixHostname := cfg.Matrix.Host
 	if !strings.Contains(matrixHostname, "://") {
+		// Add dummy protocol to make the url pkg happy, 
+		// we just want to extract the hostname
 		matrixHostname = "dummy://" + matrixHostname
 	}
 	u, err := url.Parse(matrixHostname)

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -6,6 +6,8 @@ package app
 import (
 	"context"
 	"fmt"
+	"net/url"
+	"strings"
 	"time"
 
 	"github.com/chain4travel/camino-messenger-bot/config"
@@ -145,8 +147,19 @@ func NewApp(ctx context.Context, cfg *config.Config, logger *zap.SugaredLogger) 
 		return nil, err
 	}
 
+	// get matrix hostname without schema
+	matrixHostname := cfg.Matrix.Host
+	if !strings.Contains(matrixHostname, "://") {
+		matrixHostname = "dummy://" + matrixHostname
+	}
+	u, err := url.Parse(matrixHostname)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse matrix host: %w", err)
+	}
+	matrixHostname = u.Hostname()
+
 	botAddress := crypto.PubkeyToAddress(cfg.BotKey.PublicKey)
-	botUserID := messaging.UserIDFromAddress(botAddress, cfg.Matrix.Host)
+	botUserID := messaging.UserIDFromAddress(botAddress, matrixHostname)
 
 	messageProcessor := messaging.NewMessageProcessor(
 		matrixMessenger,

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -150,7 +150,7 @@ func NewApp(ctx context.Context, cfg *config.Config, logger *zap.SugaredLogger) 
 	// get matrix hostname without schema
 	matrixHostname := cfg.Matrix.Host
 	if !strings.Contains(matrixHostname, "://") {
-		// Add dummy protocol to make the url pkg happy, 
+		// Add dummy protocol to make the url pkg happy,
 		// we just want to extract the hostname
 		matrixHostname = "dummy://" + matrixHostname
 	}


### PR DESCRIPTION
If matrix host from config contains schema, it will result userID homeserver part containing schema, leading to ambiguity.
PR fixes that by ensuring that expect userID is constructed from matrix host without schema.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced matrix hostname parsing and validation
	- Improved application startup and shutdown processes

- **Chores**
	- Added more detailed logging for application component lifecycle
	- Restructured control flow for more robust startup sequence

- **Performance**
	- Implemented more flexible concurrent startup mechanism

<!-- end of auto-generated comment: release notes by coderabbit.ai -->