### PR TITLE
E2E-Test additions.

### DIFF
--- a/tests/e2e/blockchain/network.go
+++ b/tests/e2e/blockchain/network.go
@@ -280,9 +280,9 @@ func (n *Network) startNewNode(
 	if err := os.MkdirAll(nodeDir, 0o755); err != nil {
 		return nil, nil, fmt.Errorf("failed to create node directory: %w", err)
 	}
-	logfile, err := os.OpenFile(nodeDir+"/node.log", os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0600)
+	logfile, err := os.OpenFile(path.Join(nodeDir, fmt.Sprintf("node-%d.log", nodeIndex)), os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0600)
 	if err != nil {
-		panic(err)
+		return nil, nil, fmt.Errorf("failed to create node log file: %w", err)
 	}
 
 	cmd.Stdout = logfile

--- a/tests/e2e/blockchain/network.go
+++ b/tests/e2e/blockchain/network.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"fmt"
-	"io"
 	"math/big"
 	"os"
 	"os/exec"
@@ -57,7 +56,6 @@ func StartNewNetwork(
 	dataDir string,
 	nodeBinPath string,
 	validatorsCount int,
-	w io.Writer,
 ) (*Network, chan error, error) {
 	logger.Infof("Starting blockchain network (%d validators)...", validatorsCount)
 
@@ -160,7 +158,6 @@ func StartNewNetwork(
 		errGroup.Go(func() error {
 			n.nodes[i], errChans[i], err = n.startNewNode(
 				gCtx,
-				w,
 				path.Join(networkDir, validators[i].nodeID.String(), "node"),
 				path.Join(networkDir, validators[i].nodeID.String(), "staker.key"),
 				path.Join(networkDir, validators[i].nodeID.String(), "staker.crt"),
@@ -252,7 +249,6 @@ type Network struct {
 
 func (n *Network) startNewNode(
 	ctx context.Context,
-	w io.Writer,
 	nodeDir string,
 	stakerKeyPath string,
 	stakerCertPath string,
@@ -280,8 +276,17 @@ func (n *Network) startNewNode(
 		fmt.Sprintf("--%s=%s", config.BootstrapIPsKey, bootstrapIPsArg),
 		fmt.Sprintf("--%s=%s", config.NetworkNameKey, n.networkName),
 	)
-	cmd.Stdout = w
-	cmd.Stderr = w
+
+	if err := os.MkdirAll(nodeDir, 0o755); err != nil {
+		return nil, nil, fmt.Errorf("failed to create node directory: %w", err)
+	}
+	logfile, err := os.OpenFile(nodeDir+"/node.log", os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0600)
+	if err != nil {
+		panic(err)
+	}
+
+	cmd.Stdout = logfile
+	cmd.Stderr = logfile
 
 	if err := cmd.Start(); err != nil {
 		return nil, nil, fmt.Errorf("failed to start node (%d): %w", cmd.Process.Pid, err)
@@ -291,6 +296,7 @@ func (n *Network) startNewNode(
 		logger:  n.logger,
 		pid:     cmd.Process.Pid,
 		nodeURI: fmt.Sprintf("http://localhost:%d", httpPort),
+		logfile: logfile,
 	}
 
 	// health check will fail if its 1 node network, so we're doing bootstrap check

--- a/tests/e2e/blockchain/node.go
+++ b/tests/e2e/blockchain/node.go
@@ -6,6 +6,7 @@ package blockchain
 import (
 	"context"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/chain4travel/caminogoeth-compat/caminogo/info"
@@ -21,6 +22,7 @@ type Node struct {
 	pid     int
 	client  *Client
 	nodeURI string
+	logfile *os.File
 }
 
 func (n *Node) Stop(ctx context.Context) error {
@@ -28,6 +30,7 @@ func (n *Node) Stop(ctx context.Context) error {
 		return fmt.Errorf("failed to stop node process with pid %d: %w", n.pid, err)
 	}
 	n.logger.Infof("Blockchain node (pid %d) stopped", n.pid)
+	n.logfile.Close()
 	return nil
 }
 

--- a/tests/e2e/blockchain/node.go
+++ b/tests/e2e/blockchain/node.go
@@ -31,7 +31,7 @@ func (n *Node) Stop(ctx context.Context) error {
 	}
 	n.logger.Infof("Blockchain node (pid %d) stopped", n.pid)
 	if err := n.logfile.Close(); err != nil {
-		return fmt.Errorf("failed to close partner plugin logfile: %w", err)
+		return fmt.Errorf("failed to close node logfile: %w", err)
 	}
 	return nil
 }

--- a/tests/e2e/blockchain/node.go
+++ b/tests/e2e/blockchain/node.go
@@ -30,7 +30,9 @@ func (n *Node) Stop(ctx context.Context) error {
 		return fmt.Errorf("failed to stop node process with pid %d: %w", n.pid, err)
 	}
 	n.logger.Infof("Blockchain node (pid %d) stopped", n.pid)
-	n.logfile.Close()
+	if err := n.logfile.Close(); err != nil {
+		return fmt.Errorf("failed to close partner plugin logfile: %w", err)
+	}
 	return nil
 }
 

--- a/tests/e2e/bot/bot.go
+++ b/tests/e2e/bot/bot.go
@@ -6,6 +6,7 @@ package bot
 import (
 	"context"
 	"fmt"
+	"os"
 	"time"
 
 	"go.uber.org/zap"
@@ -24,6 +25,7 @@ type Bot struct {
 	logger           *zap.SugaredLogger
 	pid              int
 	cmAccountAddress common.Address
+	logfile          *os.File
 
 	*rpcClient
 }
@@ -36,6 +38,7 @@ func (b *Bot) Stop(ctx context.Context) error {
 		return fmt.Errorf("failed to stop cmb process with pid %d: %w", b.pid, err)
 	}
 	b.logger.Infof("Bot (pid %d) stopped", b.pid)
+	b.logfile.Close()
 	return nil
 }
 

--- a/tests/e2e/bot/bot.go
+++ b/tests/e2e/bot/bot.go
@@ -38,7 +38,9 @@ func (b *Bot) Stop(ctx context.Context) error {
 		return fmt.Errorf("failed to stop cmb process with pid %d: %w", b.pid, err)
 	}
 	b.logger.Infof("Bot (pid %d) stopped", b.pid)
-	b.logfile.Close()
+	if err := b.logfile.Close(); err != nil {
+		return fmt.Errorf("failed to close partner plugin logfile: %w", err)
+	}
 	return nil
 }
 

--- a/tests/e2e/bot/factory.go
+++ b/tests/e2e/bot/factory.go
@@ -10,7 +10,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"os/exec"
 	"path"
@@ -76,7 +75,6 @@ func (f *Factory) CreateBot(
 	enableRPCServer bool,
 	partnerPlugin *partnerplugin.PartnerPlugin,
 	services []CMService,
-	out io.Writer,
 ) (*Bot, chan error, error) {
 	key, err := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
 	if err != nil {
@@ -184,8 +182,13 @@ func (f *Factory) CreateBot(
 	// Start bot
 
 	cmd := exec.Command(f.binPath, "--config", configPath)
-	cmd.Stdout = out
-	cmd.Stderr = out
+
+	logfile, err := os.OpenFile(path.Join(botDir, "bot.log"), os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0600)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to open bot log file: %w", err)
+	}
+	cmd.Stdout = logfile
+	cmd.Stderr = logfile
 
 	if err := cmd.Start(); err != nil {
 		return nil, nil, fmt.Errorf("failed to start bot (%d): %w", cmd.Process.Pid, err)
@@ -199,6 +202,7 @@ func (f *Factory) CreateBot(
 			Client:                 e2eGenerated.NewClient(clientConnection),
 		},
 		cmAccountAddress: cmAccountAddress,
+		logfile:          logfile,
 	}
 
 	// Await bot readiness

--- a/tests/e2e/matrix/conduit.go
+++ b/tests/e2e/matrix/conduit.go
@@ -83,12 +83,11 @@ func StartNewMatrixServer(
 
 	logfile, err := os.OpenFile(matrixDir+"/conduit-server.log", os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0600)
 	if err != nil {
-		panic(err)
+		return nil, nil, fmt.Errorf("failed to create conduit server log file: %w", err)
 	}
 
 	cmd.Stdout = logfile
 	cmd.Stderr = logfile
-
 	if err := cmd.Start(); err != nil {
 		return nil, nil, fmt.Errorf("failed to start matrix server (%d): %w", cmd.Process.Pid, err)
 	}
@@ -158,7 +157,9 @@ func (m *MatrixServer) Stop(ctx context.Context) error {
 	if err := process.StopProcess(ctx, m.pid); err != nil {
 		return fmt.Errorf("failed to stop matrix server process with pid %d: %w", m.pid, err)
 	}
-	m.logfile.Close()
+	if err := m.logfile.Close(); err != nil {
+		return fmt.Errorf("failed to close partner plugin logfile: %w", err)
+	}
 	m.logger.Infof("Matrix server (pid %d) stopped", m.pid)
 	return nil
 }

--- a/tests/e2e/matrix/conduit.go
+++ b/tests/e2e/matrix/conduit.go
@@ -158,7 +158,7 @@ func (m *MatrixServer) Stop(ctx context.Context) error {
 		return fmt.Errorf("failed to stop matrix server process with pid %d: %w", m.pid, err)
 	}
 	if err := m.logfile.Close(); err != nil {
-		return fmt.Errorf("failed to close partner plugin logfile: %w", err)
+		return fmt.Errorf("failed to close matrix server logfile: %w", err)
 	}
 	m.logger.Infof("Matrix server (pid %d) stopped", m.pid)
 	return nil

--- a/tests/e2e/matrix/conduit.go
+++ b/tests/e2e/matrix/conduit.go
@@ -8,7 +8,6 @@ import (
 	"crypto/ecdsa"
 	"crypto/rand"
 	"fmt"
-	"io"
 	"net/url"
 	"os"
 	"os/exec"
@@ -44,6 +43,7 @@ func init() {
 	// os.Setenv("CONDUIT_LOG", "debug,rocket=off,_=off,sled=off")
 	os.Setenv("CONDUIT_ADDRESS", "0.0.0.0")
 	os.Setenv("CONDUIT_NETWORK_ID", "1002")
+	os.Setenv("CONDUIT_LOG", "trace,rocket=off,_=off,sled=off")
 }
 
 func StartNewMatrixServer(
@@ -54,7 +54,6 @@ func StartNewMatrixServer(
 	matrixBinPath string,
 	networkFeeKey *ecdsa.PrivateKey,
 	networkClient *blockchain.Client,
-	w io.Writer,
 ) (*MatrixServer, chan error, error) {
 	logger.Info("Starting matrix server...")
 
@@ -81,8 +80,14 @@ func StartNewMatrixServer(
 		"CONDUIT_DATABASE_PATH="+dbDir,
 		"CONDUIT_PORT="+strconv.Itoa(port),
 	)
-	cmd.Stdout = w
-	cmd.Stderr = w
+
+	logfile, err := os.OpenFile(matrixDir+"/conduit-server.log", os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0600)
+	if err != nil {
+		panic(err)
+	}
+
+	cmd.Stdout = logfile
+	cmd.Stderr = logfile
 
 	if err := cmd.Start(); err != nil {
 		return nil, nil, fmt.Errorf("failed to start matrix server (%d): %w", cmd.Process.Pid, err)
@@ -94,6 +99,7 @@ func StartNewMatrixServer(
 		matrixDir:            matrixDir,
 		client:               client,
 		networkFeeBotAddress: crypto.PubkeyToAddress(networkFeeKey.PublicKey),
+		logfile:              logfile,
 	}
 
 	if err := m.awaitReady(ctx); err != nil {
@@ -137,6 +143,7 @@ type MatrixServer struct {
 	client                     *mautrix.Client
 	networkFeeBotAddress       common.Address
 	networkFeeCMAccountAddress common.Address
+	logfile                    *os.File
 }
 
 func (m *MatrixServer) Host() *url.URL {
@@ -147,9 +154,11 @@ func (m *MatrixServer) Stop(ctx context.Context) error {
 	if m == nil {
 		return nil
 	}
+
 	if err := process.StopProcess(ctx, m.pid); err != nil {
 		return fmt.Errorf("failed to stop matrix server process with pid %d: %w", m.pid, err)
 	}
+	m.logfile.Close()
 	m.logger.Infof("Matrix server (pid %d) stopped", m.pid)
 	return nil
 }

--- a/tests/e2e/partner_plugin/factory.go
+++ b/tests/e2e/partner_plugin/factory.go
@@ -7,9 +7,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"net/url"
+	"os"
 	"os/exec"
+	"path"
 
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
@@ -23,12 +24,14 @@ import (
 func NewFactory(
 	logger *zap.SugaredLogger,
 	resourceManagerSession *resources.Session,
+	e2eTmpDir string,
 	binPath string,
 ) *Factory {
 	return &Factory{
 		logger:                 logger,
 		resourceManagerSession: resourceManagerSession,
 		binPath:                binPath,
+		dir:                    path.Join(e2eTmpDir, "pp-mock"),
 	}
 }
 
@@ -36,6 +39,7 @@ func NewFactory(
 type Factory struct {
 	logger                 *zap.SugaredLogger
 	resourceManagerSession *resources.Session
+	dir                    string
 	binPath                string
 	partnerPlugins         []*PartnerPlugin
 }
@@ -44,7 +48,7 @@ func (f *Factory) PartnerPluginsCount() int {
 	return len(f.partnerPlugins)
 }
 
-func (f *Factory) CreatePartnerPlugin(ctx context.Context, out io.Writer) (*PartnerPlugin, chan error, error) {
+func (f *Factory) CreatePartnerPlugin(ctx context.Context) (*PartnerPlugin, chan error, error) {
 	port, err := f.resourceManagerSession.GetNetworkPort()
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get free port: %w", err)
@@ -64,8 +68,18 @@ func (f *Factory) CreatePartnerPlugin(ctx context.Context, out io.Writer) (*Part
 
 	cmd := exec.Command(f.binPath)
 	cmd.Env = append(cmd.Env, fmt.Sprintf("CMB_PARTNER_PLUGIN_MOCK_PORT=%d", port))
-	cmd.Stdout = out
-	cmd.Stderr = out
+
+	if err := os.MkdirAll(f.dir, 0o755); err != nil {
+		return nil, nil, fmt.Errorf("failed to create pp-mock directory: %w", err)
+	}
+	logfile_name := path.Join(f.dir, fmt.Sprintf("partner-plugin-%d.log", port))
+	logfile, err := os.OpenFile(logfile_name, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0600)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to open pp-mock log file: %w", err)
+	}
+
+	cmd.Stdout = logfile
+	cmd.Stderr = logfile
 
 	if err := cmd.Start(); err != nil {
 		return nil, nil, fmt.Errorf("failed to start partner-plugin (%d): %w", cmd.Process.Pid, err)
@@ -76,6 +90,7 @@ func (f *Factory) CreatePartnerPlugin(ctx context.Context, out io.Writer) (*Part
 		pid:        cmd.Process.Pid,
 		host:       hostURL,
 		pingClient: pingv1grpc.NewPingServiceClient(clientConnection),
+		logfile:    logfile,
 	}
 
 	if err := pp.awaitReady(ctx); err != nil {

--- a/tests/e2e/partner_plugin/partner_plugin.go
+++ b/tests/e2e/partner_plugin/partner_plugin.go
@@ -45,7 +45,9 @@ func (pp *PartnerPlugin) Stop(ctx context.Context) error {
 		return fmt.Errorf("failed to stop partner plugin process with pid %d: %w", pp.pid, err)
 	}
 	pp.logger.Infof("Partner plugin (pid %d) stopped", pp.pid)
-	pp.logfile.Close()
+	if err := pp.logfile.Close(); err != nil {
+		return fmt.Errorf("failed to close partner plugin logfile: %w", err)
+	}
 	return nil
 }
 

--- a/tests/e2e/partner_plugin/partner_plugin.go
+++ b/tests/e2e/partner_plugin/partner_plugin.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"os"
 	"time"
 
 	"buf.build/gen/go/chain4travel/camino-messenger-protocol/grpc/go/cmp/services/ping/v1/pingv1grpc"
@@ -26,6 +27,7 @@ type PartnerPlugin struct {
 	pid        int
 	host       *url.URL
 	pingClient pingv1grpc.PingServiceClient
+	logfile    *os.File
 }
 
 func (pp *PartnerPlugin) Host() string {
@@ -43,6 +45,7 @@ func (pp *PartnerPlugin) Stop(ctx context.Context) error {
 		return fmt.Errorf("failed to stop partner plugin process with pid %d: %w", pp.pid, err)
 	}
 	pp.logger.Infof("Partner plugin (pid %d) stopped", pp.pid)
+	pp.logfile.Close()
 	return nil
 }
 

--- a/tests/e2e/process/process.go
+++ b/tests/e2e/process/process.go
@@ -14,6 +14,7 @@ import (
 )
 
 const processTickerInterval = 50 * time.Millisecond
+const killTimeout = 2 * time.Second
 
 func ListenForProcessError(cmd *exec.Cmd) chan error {
 	errChan := make(chan error)
@@ -41,16 +42,20 @@ func StopProcess(ctx context.Context, pid int) error {
 		return fmt.Errorf("failed to send SIGTERM to process with pid %d: %w", pid, err)
 	}
 
-	if err := waitForProcessToStop(ctx, pid); err != nil {
+	if err := waitKillProcess(ctx, pid); err != nil {
 		return fmt.Errorf("failed to wait for process with pid %d to stop: %w", pid, err)
 	}
 
 	return nil
 }
 
-func waitForProcessToStop(ctx context.Context, pid int) error {
+func waitKillProcess(ctx context.Context, pid int) error {
 	ticker := time.NewTicker(processTickerInterval)
 	defer ticker.Stop()
+
+	killTimeoutCtx, cancelKillTimeout := context.WithTimeout(ctx, killTimeout)
+	defer cancelKillTimeout()
+
 	for {
 		process, err := getProcess(pid)
 		switch {
@@ -63,6 +68,13 @@ func waitForProcessToStop(ctx context.Context, pid int) error {
 		select {
 		case <-ctx.Done():
 			return fmt.Errorf("failed to see process %d stop: %w", pid, ctx.Err())
+		case <-killTimeoutCtx.Done():
+			// Process did not stop in time (killTimeout), killing it
+			if err := process.Signal(syscall.SIGKILL); err != nil {
+				return fmt.Errorf("failed to send SIGKILL to process with pid %d: %w", pid, err)
+			}
+			// The timeout is done - prevent it from triggering again
+			cancelKillTimeout()
 		case <-ticker.C:
 		}
 	}

--- a/tests/e2e/tests/suite.go
+++ b/tests/e2e/tests/suite.go
@@ -6,6 +6,7 @@ package tests
 import (
 	"context"
 	"path"
+	"sync"
 	"testing"
 	"time"
 
@@ -102,7 +103,6 @@ func (s *Suite) NewTest(t *testing.T) *Test {
 			dataDir,
 			s.nodeBinPath,
 			validatorsCount,
-			nil,
 		)
 		require.NoError(t, err)
 		expectNoErrorAsync(t, errChan)
@@ -116,7 +116,6 @@ func (s *Suite) NewTest(t *testing.T) *Test {
 		s.matrixBinPath,
 		tt.networkFeeKey,
 		tt.caminoNetwork.Client,
-		nil,
 	)
 	require.NoError(t, err)
 	expectNoErrorAsync(t, errChan)
@@ -124,6 +123,7 @@ func (s *Suite) NewTest(t *testing.T) *Test {
 	tt.partnerPluginFactory = partnerplugin.NewFactory(
 		s.logger,
 		tt.resourceManagerSession,
+		dataDir,
 		s.partnerPluginBinPath,
 	)
 
@@ -144,10 +144,35 @@ func (s *Suite) Cleanup(t *testing.T, tt *Test) {
 	ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout*10)
 	defer cancel()
 
-	require.NoError(t, tt.matrix.Stop(ctx))
-	require.NoError(t, tt.caminoNetwork.Stop(ctx))
-	require.NoError(t, tt.botFactory.StopBots(ctx))
-	require.NoError(t, tt.partnerPluginFactory.StopPartnerPlugins(ctx))
+	var wg sync.WaitGroup
+
+	tt.logger.Info("Stopping all services")
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		require.NoError(t, tt.botFactory.StopBots(ctx))
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		require.NoError(t, tt.partnerPluginFactory.StopPartnerPlugins(ctx))
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		require.NoError(t, tt.matrix.Stop(ctx))
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		require.NoError(t, tt.caminoNetwork.Stop(ctx))
+	}()
+
+	wg.Wait()
+	tt.logger.Info("All services stopped")
 
 	tt.resourceManagerSession.ReleaseResources()
 }

--- a/tests/e2e/tests/test.go
+++ b/tests/e2e/tests/test.go
@@ -6,7 +6,6 @@ package tests
 import (
 	"context"
 	"crypto/ecdsa"
-	"io"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -37,11 +36,10 @@ func (tt *Test) CreateBot(
 	t *testing.T,
 	enableRPCServer bool,
 	partnerPlugin *partnerplugin.PartnerPlugin,
-	out io.Writer,
 	services []bot.CMService,
 ) *bot.Bot {
 	t.Helper()
-	bot, errChan, err := tt.botFactory.CreateBot(ctx, enableRPCServer, partnerPlugin, services, out)
+	bot, errChan, err := tt.botFactory.CreateBot(ctx, enableRPCServer, partnerPlugin, services)
 	require.NoError(t, err)
 	expectNoErrorAsync(t, errChan)
 	return bot
@@ -50,10 +48,9 @@ func (tt *Test) CreateBot(
 func (tt *Test) CreatePartnerPlugin(
 	ctx context.Context,
 	t *testing.T,
-	out io.Writer,
 ) *partnerplugin.PartnerPlugin {
 	t.Helper()
-	partnerPlugin, errChan, err := tt.partnerPluginFactory.CreatePartnerPlugin(ctx, out)
+	partnerPlugin, errChan, err := tt.partnerPluginFactory.CreatePartnerPlugin(ctx)
 	require.NoError(t, err)
 	expectNoErrorAsync(t, errChan)
 	return partnerPlugin

--- a/tests/e2e/tests/test_ping.go
+++ b/tests/e2e/tests/test_ping.go
@@ -23,15 +23,15 @@ func TestPingV1(t *testing.T, tt *Test) {
 
 	require.NoError(t, tt.caminoNetwork.Client.RegisterCMService(ctx, botGenerated.PingServiceV1))
 
-	supplierPartnerPlugin := tt.CreatePartnerPlugin(ctx, t, nil)
+	supplierPartnerPlugin := tt.CreatePartnerPlugin(ctx, t)
 
 	// bot with partnerPlugin and without rpc server (supplier)
-	supplierBot := tt.CreateBot(ctx, t, false, supplierPartnerPlugin, nil, []bot.CMService{
+	supplierBot := tt.CreateBot(ctx, t, false, supplierPartnerPlugin, []bot.CMService{
 		{Name: botGenerated.PingServiceV1, Fee: 100},
 	})
 
 	// bot without partnerPlugin and with rpc server (distributor)
-	distributorBot := tt.CreateBot(ctx, t, true, nil, nil, nil)
+	distributorBot := tt.CreateBot(ctx, t, true, nil, nil)
 
 	pingMessage := "ping"
 	expectedResponceMessageSubString := fmt.Sprintf("Ping response to [%s] with request ID:", pingMessage)
@@ -46,6 +46,7 @@ func TestPingV1(t *testing.T, tt *Test) {
 			Timestamp:   timestamppb.Now(),
 		},
 	)
+
 	require.NoError(t, err)
 	require.Equal(t, typesv1.StatusType_STATUS_TYPE_SUCCESS, resp.Header.Status, "unexpected response status")
 	require.Empty(t, resp.Header.Alerts, "unexpected response alerts")


### PR DESCRIPTION
* Added logfiles to conduit server, bot, pp-mock, node.
* Introduced workaround for shutdown timeout in conduit waiting for 30s before it's down.
* Fixed this by introducing a SIGKILL after a 2s timeout. 
* Changed the process cleanup for the test to execute all shutdowns in parallel.
* Raised log level for the conduit server to trace which might be overkill but it's only temporary anyways and we should be able to see something if it fails.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced logging now captures outputs in dedicated files for improved diagnostics.

- **Refactor**
  - Simplified configurations by eliminating redundant output parameters for a cleaner setup.

- **Enhancements**
  - Introduced a robust termination mechanism with timeout for reliable shutdown.
  - Optimized cleanup operations with concurrent execution for faster, more efficient resource management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->