### PR TITLE
Improve logging and e2e script

### DIFF
--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -13,6 +13,9 @@ CONDUIT_VERSION="$default_version"
 FALLBACK_BRANCH="dev"
 BUILD_SCRIPT="./scripts/build.sh"
 
+DEBUG=0
+CLEAN=0
+
 OUT_BINARY=""
 
 while [[ $# -gt 0 ]]; do
@@ -25,6 +28,14 @@ while [[ $# -gt 0 ]]; do
             CONDUIT_VERSION="$2"
             shift 2
             ;;
+		--clean)
+			CLEAN=1
+			shift
+			;;
+		--debug)
+			DEBUG=1
+			shift
+			;;
         *)
             echo "Unknown argument: $1"
             exit 1
@@ -42,60 +53,64 @@ function download_and_extract() {
     local repo_url=$3
     local dest_dir="$dependency_dir/$repo_name"
 
-	echo "Attemting to download $repo_name"
+	echo "Processing dependency: $repo_name"
 
 	OUT_BINARY=""
 
     # Remove existing directory to ensure fresh download
-    if [ -d "$dest_dir" ]; then
-        echo "Removing existing $repo_name directory..."
-        rm -rf "$dest_dir"
-    fi
+	if [ $CLEAN -eq 1 ] ; then
+		echo "Removing existing $repo_name directory..."
+		rm -rf "$dest_dir"
+	fi
 
-    mkdir -p "$dest_dir"
-    release_version=""
-    if [ "$version" = "latest" ]; then
-        release_version=$(curl -s "https://api.github.com/repos/chain4travel/$repo_name/releases/latest" | grep -Po '"tag_name": "\K[^"]*' || echo "")
-    fi
+	release_version=""
+	if [ "$version" = "latest" ]; then
+		release_version=$(curl -s "https://api.github.com/repos/chain4travel/$repo_name/releases/latest" | grep -Po '"tag_name": "\K[^"]*' || echo "")
+	fi
 
-	if [ -z "$release_version" ] ; then
-		if [ "$version" = "latest" ]; then
-			branch=$FALLBACK_BRANCH
+	if [ -d "$dest_dir" ] ; then
+		echo "Directory $dest_dir already exists. Skipping download and build."
+	else 
+		mkdir -p "$dest_dir"
+		if [ -z "$release_version" ] ; then
+			if [ "$version" = "latest" ]; then
+				branch=$FALLBACK_BRANCH
+			else
+				branch=$version
+			fi
+
+			echo "WARN: Unable to get the released version of $repo_name! Fallback to clone and build of the branch '$branch'."
+
+			if git ls-remote --heads --tags "$repo_url" | grep -q "$branch"; then
+				git clone --depth 1 --branch "$branch" "$repo_url" "$dest_dir"
+			elif git ls-remote "$repo_url" | grep -q "$branch"; then
+				git clone --depth 1 "$repo_url" "$dest_dir"
+				cd "$dest_dir"
+				git checkout "$branch"
+			else
+				echo "Version/tag/commit '$branch' not found for $repo_name, aborting."
+				exit 1
+			fi
+			
+			cd "${ORIG_DIR}/$dest_dir"
+			if [ ! -f $BUILD_SCRIPT ] ; then
+				echo "CRIT: No build script found at '$BUILD_SCRIPT' in cloned repository. Abort."
+				exit 1
+			fi
+			$BUILD_SCRIPT
+			cd "$ORIG_DIR"
 		else
-			branch=$version
-		fi
+			local url="https://github.com/chain4travel/$repo_name/releases/download/$release_version/${repo_name}-linux-amd64-${release_version}.tar.gz"
 
-		echo "WARN: Unable to get the released version of $repo_name! Fallback to clone and build of the branch '$branch'."
-
-		if git ls-remote --heads --tags "$repo_url" | grep -q "$branch"; then
-            git clone --depth 1 --branch "$branch" "$repo_url" "$dest_dir"
-        elif git ls-remote "$repo_url" | grep -q "$branch"; then
-            git clone --depth 1 "$repo_url" "$dest_dir"
-            cd "$dest_dir"
-            git checkout "$branch"
-        else
-            echo "Version/tag/commit '$branch' not found for $repo_name, aborting."
-            exit 1
-        fi
-        
-        cd "${ORIG_DIR}/$dest_dir"
-		if [ ! -f $BUILD_SCRIPT ] ; then
-			echo "CRIT: No build script found at '$BUILD_SCRIPT' in cloned repository. Abort."
-			exit 1
-		fi
-		$BUILD_SCRIPT
-        cd "$ORIG_DIR"
-	else
-	    local url="https://github.com/chain4travel/$repo_name/releases/download/$release_version/${repo_name}-linux-amd64-${release_version}.tar.gz"
-
-	    echo "Downloading $repo_name version $release_version..."
-	    if curl --output /dev/null --silent --head --fail "$url"; then
-    	    curl -s -L "$url" -o "$dest_dir/${repo_name}.tar.gz"
-	        tar -xzf "$dest_dir/${repo_name}.tar.gz" -C "$dest_dir"
-	        rm "$dest_dir/${repo_name}.tar.gz"
-    	else
-			echo "CRIT: Unable to download the release '$release_version' of $repo_name."
-			exit 1
+			echo "Downloading $repo_name version $release_version..."
+			if curl --output /dev/null --silent --head --fail "$url"; then
+				curl -s -L "$url" -o "$dest_dir/${repo_name}.tar.gz"
+				tar -xzf "$dest_dir/${repo_name}.tar.gz" -C "$dest_dir"
+				rm "$dest_dir/${repo_name}.tar.gz"
+			else
+				echo "CRIT: Unable to download the release '$release_version' of $repo_name."
+				exit 1
+			fi
 		fi
 	fi
 
@@ -165,10 +180,16 @@ CMB_DB_MIGRATIONS_PATH="$(realpath "${CMB_DB_MIGRATIONS_PATH}")"
 
 echo "Running e2e tests..."
 
+ADD_PARAM=()
+if [ $DEBUG -eq 1 ] ; then
+	ADD_PARAM+=("-debug")
+fi
+
 ./$E2E_BIN_OUT \
 	-test.v \
 	-node="${CAMINOGO_BIN_PATH}" \
 	-matrix="${MATRIX_BIN_PATH}" \
 	-partner-plugin="${PARTNER_PLUGIN_BIN_PATH}" \
 	-cmb="${CMB_BIN_PATH}" \
-	-migration="${CMB_DB_MIGRATIONS_PATH}"
+	-migration="${CMB_DB_MIGRATIONS_PATH}" \
+	"${ADD_PARAM[@]}"

--- a/tests/e2e/blockchain/network.go
+++ b/tests/e2e/blockchain/network.go
@@ -57,7 +57,7 @@ func StartNewNetwork(
 	nodeBinPath string,
 	validatorsCount int,
 ) (*Network, chan error, error) {
-	logger.Infof("Starting blockchain network (%d validators)...", validatorsCount)
+	logger.Debugf("Starting blockchain network (%d validators)...", validatorsCount)
 
 	var err error
 	httpPorts := make([]int, validatorsCount)
@@ -180,19 +180,19 @@ func StartNewNetwork(
 
 	n.Client = n.nodes[0].client
 
-	logger.Info("Preparing EVM admin...")
+	logger.Debug("Preparing EVM admin...")
 
 	if err := n.Client.prepareAdmin(ctx); err != nil {
 		return n, nil, fmt.Errorf("failed to prepare EVM admin: %w", err)
 	}
 
-	logger.Info("Preparing CMB contracts...")
+	logger.Debug("Preparing CMB contracts...")
 
 	if err := n.Client.prepareCMBContracts(ctx); err != nil {
 		return n, nil, fmt.Errorf("failed to prepare CMB contracts: %w", err)
 	}
 
-	logger.Info("Blockchain network started")
+	logger.Debug("Blockchain network started")
 
 	return n, combineErrChannels(errChans...), nil
 }
@@ -258,7 +258,7 @@ func (n *Network) startNewNode(
 	bootstrapIPsArg string,
 	nodeIndex int,
 ) (*Node, chan error, error) {
-	n.logger.Infof("Starting blockchain node %d (http port %d)...", nodeIndex, httpPort)
+	n.logger.Debugf("Starting blockchain node %d (http port %d)...", nodeIndex, httpPort)
 
 	if err := os.RemoveAll(nodeDir); err != nil {
 		return nil, nil, fmt.Errorf("failed to remove blockchain node tmp dir: %w", err)
@@ -310,7 +310,7 @@ func (n *Network) startNewNode(
 	}
 	node.client = client
 
-	n.logger.Infof("Blockchain node %d (pid %d) started", nodeIndex, node.pid)
+	n.logger.Debugf("Blockchain node %d (pid %d) started", nodeIndex, node.pid)
 
 	errChan := make(chan error)
 	go func() {
@@ -333,7 +333,7 @@ func (n *Network) Stop(ctx context.Context) error {
 			return fmt.Errorf("failed to stop node: %w", err)
 		}
 	}
-	n.logger.Info("Blockchain network stopped")
+	n.logger.Debug("Blockchain network stopped")
 	return nil
 }
 

--- a/tests/e2e/blockchain/node.go
+++ b/tests/e2e/blockchain/node.go
@@ -29,7 +29,7 @@ func (n *Node) Stop(ctx context.Context) error {
 	if err := process.StopProcess(ctx, n.pid); err != nil {
 		return fmt.Errorf("failed to stop node process with pid %d: %w", n.pid, err)
 	}
-	n.logger.Infof("Blockchain node (pid %d) stopped", n.pid)
+	n.logger.Debugf("Blockchain node (pid %d) stopped", n.pid)
 	if err := n.logfile.Close(); err != nil {
 		return fmt.Errorf("failed to close node logfile: %w", err)
 	}

--- a/tests/e2e/bot/bot.go
+++ b/tests/e2e/bot/bot.go
@@ -37,7 +37,7 @@ func (b *Bot) Stop(ctx context.Context) error {
 	if err := process.StopProcess(ctx, b.pid); err != nil {
 		return fmt.Errorf("failed to stop cmb process with pid %d: %w", b.pid, err)
 	}
-	b.logger.Infof("Bot (pid %d) stopped", b.pid)
+	b.logger.Debugf("Bot (pid %d) stopped", b.pid)
 	if err := b.logfile.Close(); err != nil {
 		return fmt.Errorf("failed to close partner plugin logfile: %w", err)
 	}

--- a/tests/e2e/bot/factory.go
+++ b/tests/e2e/bot/factory.go
@@ -212,10 +212,10 @@ func (f *Factory) CreateBot(
 			return bot, nil, fmt.Errorf("failed to await bot readiness: %w", err)
 		}
 	} else {
-		f.logger.Warnf("bot (pid %d) started without RPC server: no readiness check", cmd.Process.Pid)
+		f.logger.Debugf("bot (pid %d) started without RPC server: no readiness check", cmd.Process.Pid)
 	}
 
-	f.logger.Infof("bot (pid %d) started", cmd.Process.Pid)
+	f.logger.Debugf("bot (pid %d) started", cmd.Process.Pid)
 
 	f.bots = append(f.bots, bot)
 

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -29,6 +29,7 @@ const (
 	flagKeyPartnerPluginBinPath = "partner-plugin"
 	flagKeyCMBBinPath           = "cmb"
 	flagKeyMigrationsDir        = "migration"
+	flagKeyDebug                = "debug"
 )
 
 var (
@@ -40,21 +41,19 @@ var (
 	flagTestsDataDir            string
 	flagExistingNetworkNodeURI  string
 	flagExistingNetworkAdminKey string
+	flagDebug                   bool
 )
 
 func init() {
 	flag.StringVar(&flagNodeBinPath, flagKeyNodeBinPath, "", "Path to node binary.")
 	flag.StringVar(&flagExistingNetworkNodeURI, "existing-network-node-uri", "", "URI of existing network node.")
 	flag.StringVar(&flagExistingNetworkAdminKey, "existing-network-admin-key", "", "Admin key of existing network.")
-
 	flag.StringVar(&flagMatrixBinPath, flagKeyMatrixBinPath, "", "Path to matrix binary.")
-
 	flag.StringVar(&flagPartnerPluginBinPath, flagKeyPartnerPluginBinPath, "", "Path to partner plugin binary.")
-
 	flag.StringVar(&flagCMBBinPath, flagKeyCMBBinPath, "", "Path to CMB binary.")
 	flag.StringVar(&flagMigrationsDir, flagKeyMigrationsDir, "", "Path to migration files dir.")
-
 	flag.StringVar(&flagTestsDataDir, "tests-data-dir", "/tmp/cmb-e2e", "Path to dir with temp tests data.")
+	flag.BoolVar(&flagDebug, flagKeyDebug, false, "Debug mode")
 }
 
 func TestE2E(t *testing.T) {
@@ -103,6 +102,7 @@ func TestE2E(t *testing.T) {
 		flagTestsDataDir,
 		flagExistingNetworkNodeURI,
 		existingNetworkAdminKey,
+		flagDebug,
 	)
 	require.NoError(t, err)
 

--- a/tests/e2e/matrix/conduit.go
+++ b/tests/e2e/matrix/conduit.go
@@ -55,7 +55,7 @@ func StartNewMatrixServer(
 	networkFeeKey *ecdsa.PrivateKey,
 	networkClient *blockchain.Client,
 ) (*MatrixServer, chan error, error) {
-	logger.Info("Starting matrix server...")
+	logger.Debug("Starting matrix server...")
 
 	matrixDir := path.Join(dataDir, "matrix")
 	if err := os.RemoveAll(matrixDir); err != nil {
@@ -119,7 +119,7 @@ func StartNewMatrixServer(
 		return nil, nil, fmt.Errorf("failed to add bot to CM account: %w", err)
 	}
 
-	logger.Infof("Matrix server (pid %d) started", cmd.Process.Pid)
+	logger.Debugf("Matrix server (pid %d) started", cmd.Process.Pid)
 
 	errChan := make(chan error)
 	go func() {
@@ -160,7 +160,7 @@ func (m *MatrixServer) Stop(ctx context.Context) error {
 	if err := m.logfile.Close(); err != nil {
 		return fmt.Errorf("failed to close matrix server logfile: %w", err)
 	}
-	m.logger.Infof("Matrix server (pid %d) stopped", m.pid)
+	m.logger.Debugf("Matrix server (pid %d) stopped", m.pid)
 	return nil
 }
 

--- a/tests/e2e/partner_plugin/factory.go
+++ b/tests/e2e/partner_plugin/factory.go
@@ -97,7 +97,7 @@ func (f *Factory) CreatePartnerPlugin(ctx context.Context) (*PartnerPlugin, chan
 		return pp, nil, fmt.Errorf("failed to wait for partner-plugin to be ready: %w", err)
 	}
 
-	f.logger.Infof("Partner-plugin (pid %d) started", cmd.Process.Pid)
+	f.logger.Debugf("Partner-plugin (pid %d) started", cmd.Process.Pid)
 
 	f.partnerPlugins = append(f.partnerPlugins, pp)
 

--- a/tests/e2e/partner_plugin/partner_plugin.go
+++ b/tests/e2e/partner_plugin/partner_plugin.go
@@ -44,7 +44,7 @@ func (pp *PartnerPlugin) Stop(ctx context.Context) error {
 	if err := process.StopProcess(ctx, pp.pid); err != nil {
 		return fmt.Errorf("failed to stop partner plugin process with pid %d: %w", pp.pid, err)
 	}
-	pp.logger.Infof("Partner plugin (pid %d) stopped", pp.pid)
+	pp.logger.Debugf("Partner plugin (pid %d) stopped", pp.pid)
 	if err := pp.logfile.Close(); err != nil {
 		return fmt.Errorf("failed to close partner plugin logfile: %w", err)
 	}

--- a/tests/e2e/tests/suite.go
+++ b/tests/e2e/tests/suite.go
@@ -38,8 +38,15 @@ func NewSuite(
 	testsDataDir string,
 	existingNetworkNodeURI string,
 	existingNetworkAdminKey *secp256k1.PrivateKey,
+	debug bool,
 ) (*Suite, error) {
-	logger, err := zap.NewDevelopment()
+	zapConfig := zap.NewDevelopmentConfig()
+	zapConfig.Level.SetLevel(zap.InfoLevel)
+	if debug {
+		zapConfig.Level.SetLevel(zap.DebugLevel)
+	}
+	logger, err := zapConfig.Build()
+
 	if err != nil {
 		return nil, err
 	}
@@ -146,7 +153,7 @@ func (s *Suite) Cleanup(t *testing.T, tt *Test) {
 
 	var wg sync.WaitGroup
 
-	tt.logger.Info("Stopping all services")
+	tt.logger.Debug("Stopping all services")
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
@@ -172,7 +179,7 @@ func (s *Suite) Cleanup(t *testing.T, tt *Test) {
 	}()
 
 	wg.Wait()
-	tt.logger.Info("All services stopped")
+	tt.logger.Debug("All services stopped")
 
 	tt.resourceManagerSession.ReleaseResources()
 }


### PR DESCRIPTION
* Moved pretty much all the chatty log output into the debug level. 
* Introducing a new flag to the e2e-test script '--debug' which allows for easier testcase creation but leaves the log clean for normal runs.
* Introduced a new flag to the e2e-test script '--clean'. Now the default behavior is to re-use already downloaded dependencies but in case one wants to enforce a re-download just use the flag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new command-line options for cleaning up dependencies and enabling debug mode.
	- Added a flag for activating debug functionality in the test suite.
- **Improvements**
	- Adjusted logging outputs to reduce routine verbosity while offering more detailed logs when debug mode is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->