### PR TITLE
[E2E] Unified debug print of request and response

### DIFF
--- a/tests/e2e/tests/test_accommodation_v2.go
+++ b/tests/e2e/tests/test_accommodation_v2.go
@@ -79,17 +79,17 @@ func testAccommodationV2ProductListService(
 
 	expectedTotalResults := len(hotelCodes)
 
+	req := &accommodationv2.AccommodationProductListRequest{
+		Header: &typesv1.RequestHeader{BaseHeader: &typesv1.Header{}},
+	}
 	resp, err := distributorBot.AccommodationProductListServiceV2.AccommodationProductList(
 		requestContext(ctx, &metadata.Metadata{
 			Recipient: supplierBot.CMAccountAddress().Hex(),
 		}),
-		&accommodationv2.AccommodationProductListRequest{
-			Header: &typesv1.RequestHeader{BaseHeader: &typesv1.Header{}},
-		},
+		req,
 	)
 	require.NoError(t, err)
-
-	tt.logger.Debug("AccommodationProductListServiceV2.AccommodationProductList response:\n", protoMessageToJSON(tt, resp))
+	debugPrintRequestResponse(tt, getCurrentFuncName(), req, resp)
 
 	require.Equal(t, typesv1.StatusType_STATUS_TYPE_SUCCESS, resp.Header.Status, "unexpected response status")
 	require.Empty(t, resp.Header.Alerts, "unexpected response alerts")
@@ -117,20 +117,20 @@ func testAccommodationV2ProductListServiceWithFilter(
 	const modifiedAfterSecs int64 = 1710489050
 	const hotelCode = "HOTEL567890"
 
+	req := &accommodationv2.AccommodationProductListRequest{
+		Header: &typesv1.RequestHeader{BaseHeader: &typesv1.Header{}},
+		ModifiedAfter: &timestamppb.Timestamp{
+			Seconds: modifiedAfterSecs,
+		},
+	}
 	resp, err := distributorBot.AccommodationProductListServiceV2.AccommodationProductList(
 		requestContext(ctx, &metadata.Metadata{
 			Recipient: supplierBot.CMAccountAddress().Hex(),
 		}),
-		&accommodationv2.AccommodationProductListRequest{
-			Header: &typesv1.RequestHeader{BaseHeader: &typesv1.Header{}},
-			ModifiedAfter: &timestamppb.Timestamp{
-				Seconds: modifiedAfterSecs,
-			},
-		},
+		req,
 	)
 	require.NoError(t, err)
-
-	tt.logger.Debug("AccommodationProductListServiceV2.AccommodationProductList response:\n", protoMessageToJSON(tt, resp))
+	debugPrintRequestResponse(tt, getCurrentFuncName(), req, resp)
 
 	require.Equal(t, typesv1.StatusType_STATUS_TYPE_SUCCESS, resp.Header.Status, "unexpected response status")
 	require.Empty(t, resp.Header.Alerts, "unexpected response alerts")
@@ -153,20 +153,20 @@ func testAccommodationV2ProductInfoService(
 ) {
 	const hotelCode = "HOTEL789012"
 
+	req := &accommodationv2.AccommodationProductInfoRequest{
+		Header: &typesv1.RequestHeader{BaseHeader: &typesv1.Header{}},
+		SupplierCodes: []*typesv2.SupplierProductCode{
+			{SupplierCode: hotelCode},
+		},
+	}
 	resp, err := distributorBot.AccommodationProductInfoServiceV2.AccommodationProductInfo(
 		requestContext(ctx, &metadata.Metadata{
 			Recipient: supplierBot.CMAccountAddress().Hex(),
 		}),
-		&accommodationv2.AccommodationProductInfoRequest{
-			Header: &typesv1.RequestHeader{BaseHeader: &typesv1.Header{}},
-			SupplierCodes: []*typesv2.SupplierProductCode{
-				{SupplierCode: hotelCode},
-			},
-		},
+		req,
 	)
 	require.NoError(t, err)
-
-	tt.logger.Debug("AccommodationProductInfoServiceV2.AccommodationProductInfo response:\n", protoMessageToJSON(tt, resp))
+	debugPrintRequestResponse(tt, getCurrentFuncName(), req, resp)
 
 	require.Equal(t, typesv1.StatusType_STATUS_TYPE_SUCCESS, resp.Header.Status, "unexpected response status")
 	require.Empty(t, resp.Header.Alerts, "unexpected response alerts")
@@ -206,24 +206,24 @@ func testAccommodationV2SearchServiceWithoutCurrency(
 ) {
 	const hotelCode = "HOTEL345678"
 
+	req := &accommodationv2.AccommodationSearchRequest{
+		Header: &typesv1.RequestHeader{BaseHeader: &typesv1.Header{}},
+		Queries: []*accommodationv2.AccommodationSearchQuery{{
+			SearchParametersAccommodation: &accommodationv2.AccommodationSearchParameters{
+				SupplierCodes: []*typesv2.SupplierProductCode{
+					{SupplierCode: hotelCode},
+				},
+			},
+		}},
+	}
 	resp, err := distributorBot.AccommodationSearchServiceV2.AccommodationSearch(
 		requestContext(ctx, &metadata.Metadata{
 			Recipient: supplierBot.CMAccountAddress().Hex(),
 		}),
-		&accommodationv2.AccommodationSearchRequest{
-			Header: &typesv1.RequestHeader{BaseHeader: &typesv1.Header{}},
-			Queries: []*accommodationv2.AccommodationSearchQuery{{
-				SearchParametersAccommodation: &accommodationv2.AccommodationSearchParameters{
-					SupplierCodes: []*typesv2.SupplierProductCode{
-						{SupplierCode: hotelCode},
-					},
-				},
-			}},
-		},
+		req,
 	)
 	require.NoError(t, err)
-
-	tt.logger.Debug("AccommodationSearchServiceV2.AccommodationSearch response:\n", protoMessageToJSON(tt, resp))
+	debugPrintRequestResponse(tt, getCurrentFuncName(), req, resp)
 	require.Equal(t, typesv1.StatusType_STATUS_TYPE_FAILURE, resp.Header.Status, "unexpected response status")
 }
 
@@ -237,27 +237,27 @@ func testAccommodationV2SearchServiceWithoutTravelPeriod(
 ) {
 	const hotelCode = "HOTEL345678"
 
+	req := &accommodationv2.AccommodationSearchRequest{
+		Header: &typesv1.RequestHeader{BaseHeader: &typesv1.Header{}},
+		SearchParametersGeneric: &typesv2.SearchParameters{
+			Currency: &typesv2.Currency{Currency: &typesv2.Currency_NativeToken{}},
+		},
+		Queries: []*accommodationv2.AccommodationSearchQuery{{
+			SearchParametersAccommodation: &accommodationv2.AccommodationSearchParameters{
+				SupplierCodes: []*typesv2.SupplierProductCode{
+					{SupplierCode: hotelCode},
+				},
+			},
+		}},
+	}
 	resp, err := distributorBot.AccommodationSearchServiceV2.AccommodationSearch(
 		requestContext(ctx, &metadata.Metadata{
 			Recipient: supplierBot.CMAccountAddress().Hex(),
 		}),
-		&accommodationv2.AccommodationSearchRequest{
-			Header: &typesv1.RequestHeader{BaseHeader: &typesv1.Header{}},
-			SearchParametersGeneric: &typesv2.SearchParameters{
-				Currency: &typesv2.Currency{Currency: &typesv2.Currency_NativeToken{}},
-			},
-			Queries: []*accommodationv2.AccommodationSearchQuery{{
-				SearchParametersAccommodation: &accommodationv2.AccommodationSearchParameters{
-					SupplierCodes: []*typesv2.SupplierProductCode{
-						{SupplierCode: hotelCode},
-					},
-				},
-			}},
-		},
+		req,
 	)
 	require.NoError(t, err)
-
-	tt.logger.Debug("AccommodationSearchServiceV2.AccommodationSearch response:\n", protoMessageToJSON(tt, resp))
+	debugPrintRequestResponse(tt, getCurrentFuncName(), req, resp)
 	require.Equal(t, typesv1.StatusType_STATUS_TYPE_FAILURE, resp.Header.Status, "unexpected response status")
 }
 
@@ -275,31 +275,31 @@ func testAccommodationV2SearchServiceTravelPeriodOutOfBounds(
 	startDate := time.Now().Add(time.Hour * 24 * 100) // in 100 days, outside of allowed travel period
 	endDate := startDate.Add(time.Hour * 24 * time.Duration(nights))
 
+	req := &accommodationv2.AccommodationSearchRequest{
+		Header: &typesv1.RequestHeader{BaseHeader: &typesv1.Header{}},
+		SearchParametersGeneric: &typesv2.SearchParameters{
+			Currency: &typesv2.Currency{Currency: &typesv2.Currency_NativeToken{}},
+		},
+		Queries: []*accommodationv2.AccommodationSearchQuery{{
+			SearchParametersAccommodation: &accommodationv2.AccommodationSearchParameters{
+				SupplierCodes: []*typesv2.SupplierProductCode{
+					{SupplierCode: hotelCode},
+				},
+			},
+			TravelPeriod: &typesv1.TravelPeriod{
+				StartDate: common.TimeToDateV1(startDate),
+				EndDate:   common.TimeToDateV1(endDate),
+			},
+		}},
+	}
 	resp, err := distributorBot.AccommodationSearchServiceV2.AccommodationSearch(
 		requestContext(ctx, &metadata.Metadata{
 			Recipient: supplierBot.CMAccountAddress().Hex(),
 		}),
-		&accommodationv2.AccommodationSearchRequest{
-			Header: &typesv1.RequestHeader{BaseHeader: &typesv1.Header{}},
-			SearchParametersGeneric: &typesv2.SearchParameters{
-				Currency: &typesv2.Currency{Currency: &typesv2.Currency_NativeToken{}},
-			},
-			Queries: []*accommodationv2.AccommodationSearchQuery{{
-				SearchParametersAccommodation: &accommodationv2.AccommodationSearchParameters{
-					SupplierCodes: []*typesv2.SupplierProductCode{
-						{SupplierCode: hotelCode},
-					},
-				},
-				TravelPeriod: &typesv1.TravelPeriod{
-					StartDate: common.TimeToDateV1(startDate),
-					EndDate:   common.TimeToDateV1(endDate),
-				},
-			}},
-		},
+		req,
 	)
 	require.NoError(t, err)
-
-	tt.logger.Debug("AccommodationSearchServiceV2.AccommodationSearch response:\n", protoMessageToJSON(tt, resp))
+	debugPrintRequestResponse(tt, getCurrentFuncName(), req, resp)
 	require.Equal(t, typesv1.StatusType_STATUS_TYPE_FAILURE, resp.Header.Status, "unexpected response status")
 }
 
@@ -317,31 +317,31 @@ func testAccommodationV2SearchServiceTravelPeriodReversed(
 	endDate := time.Now().Add(time.Hour * 24)                        // tomorrow
 	startDate := endDate.Add(time.Hour * 24 * time.Duration(nights)) // start date after end date
 
+	req := &accommodationv2.AccommodationSearchRequest{
+		Header: &typesv1.RequestHeader{BaseHeader: &typesv1.Header{}},
+		SearchParametersGeneric: &typesv2.SearchParameters{
+			Currency: &typesv2.Currency{Currency: &typesv2.Currency_NativeToken{}},
+		},
+		Queries: []*accommodationv2.AccommodationSearchQuery{{
+			SearchParametersAccommodation: &accommodationv2.AccommodationSearchParameters{
+				SupplierCodes: []*typesv2.SupplierProductCode{
+					{SupplierCode: hotelCode},
+				},
+			},
+			TravelPeriod: &typesv1.TravelPeriod{
+				StartDate: common.TimeToDateV1(startDate),
+				EndDate:   common.TimeToDateV1(endDate),
+			},
+		}},
+	}
 	resp, err := distributorBot.AccommodationSearchServiceV2.AccommodationSearch(
 		requestContext(ctx, &metadata.Metadata{
 			Recipient: supplierBot.CMAccountAddress().Hex(),
 		}),
-		&accommodationv2.AccommodationSearchRequest{
-			Header: &typesv1.RequestHeader{BaseHeader: &typesv1.Header{}},
-			SearchParametersGeneric: &typesv2.SearchParameters{
-				Currency: &typesv2.Currency{Currency: &typesv2.Currency_NativeToken{}},
-			},
-			Queries: []*accommodationv2.AccommodationSearchQuery{{
-				SearchParametersAccommodation: &accommodationv2.AccommodationSearchParameters{
-					SupplierCodes: []*typesv2.SupplierProductCode{
-						{SupplierCode: hotelCode},
-					},
-				},
-				TravelPeriod: &typesv1.TravelPeriod{
-					StartDate: common.TimeToDateV1(startDate),
-					EndDate:   common.TimeToDateV1(endDate),
-				},
-			}},
-		},
+		req,
 	)
 	require.NoError(t, err)
-
-	tt.logger.Debug("AccommodationSearchServiceV2.AccommodationSearch response:\n", protoMessageToJSON(tt, resp))
+	debugPrintRequestResponse(tt, getCurrentFuncName(), req, resp)
 	require.Equal(t, typesv1.StatusType_STATUS_TYPE_FAILURE, resp.Header.Status, "unexpected response status")
 }
 
@@ -379,9 +379,6 @@ func testAccommodationV2SearchServiceWithTravelPeriod(
 			},
 		}},
 	}
-
-	tt.logger.Debug("AccommodationSearchServiceV2.AccommodationSearch request:\n", protoMessageToJSON(tt, req))
-
 	resp, err := distributorBot.AccommodationSearchServiceV2.AccommodationSearch(
 		requestContext(ctx, &metadata.Metadata{
 			Recipient: supplierBot.CMAccountAddress().Hex(),
@@ -389,8 +386,7 @@ func testAccommodationV2SearchServiceWithTravelPeriod(
 		req,
 	)
 	require.NoError(t, err)
-
-	tt.logger.Debug("AccommodationSearchServiceV2.AccommodationSearch response:\n", protoMessageToJSON(tt, resp))
+	debugPrintRequestResponse(tt, getCurrentFuncName(), req, resp)
 
 	require.Equal(t, typesv1.StatusType_STATUS_TYPE_SUCCESS, resp.Header.Status, "unexpected response status")
 	require.Empty(t, resp.Header.Alerts, "unexpected response alerts")
@@ -436,22 +432,22 @@ func testAccommodationV2ValidateV2(
 	resultID int32,
 	expectedTotalPrice float64,
 ) (validateID string) {
+	req := &bookv2.ValidationRequest{
+		ValidationObject: &bookv2.ValidationObject{
+			SearchIdentifier: &typesv2.SearchIdentifier{
+				SearchId: &typesv1.UUID{Value: searchID},
+				ResultId: resultID,
+			},
+		},
+	}
 	resp, err := distributorBot.ValidationServiceV2.Validation(
 		requestContext(ctx, &metadata.Metadata{
 			Recipient: supplierBot.CMAccountAddress().Hex(),
 		}),
-		&bookv2.ValidationRequest{
-			ValidationObject: &bookv2.ValidationObject{
-				SearchIdentifier: &typesv2.SearchIdentifier{
-					SearchId: &typesv1.UUID{Value: searchID},
-					ResultId: resultID,
-				},
-			},
-		},
+		req,
 	)
 	require.NoError(t, err)
-
-	tt.logger.Debug("ValidationServiceV2.Validation response:\n", protoMessageToJSON(tt, resp))
+	debugPrintRequestResponse(tt, getCurrentFuncName(), req, resp)
 
 	require.Equal(t, typesv1.StatusType_STATUS_TYPE_SUCCESS, resp.Header.Status, "unexpected response status")
 	require.Empty(t, resp.Header.Alerts, "unexpected response alerts")
@@ -490,18 +486,18 @@ func testAccommodationV2MintV2(
 	tokenID uint64,
 	price *typesv2.Price,
 ) {
+	req := &bookv2.MintRequest{
+		Header:       &typesv1.RequestHeader{BaseHeader: &typesv1.Header{}},
+		ValidationId: &typesv1.UUID{Value: validationID},
+	}
 	resp, err := distributorBot.MintServiceV2.Mint(
 		requestContext(ctx, &metadata.Metadata{
 			Recipient: supplierBot.CMAccountAddress().Hex(),
 		}),
-		&bookv2.MintRequest{
-			Header:       &typesv1.RequestHeader{BaseHeader: &typesv1.Header{}},
-			ValidationId: &typesv1.UUID{Value: validationID},
-		},
+		req,
 	)
 	require.NoError(t, err)
-
-	tt.logger.Debug("MintServiceV2.Mint response:\n", protoMessageToJSON(tt, resp))
+	debugPrintRequestResponse(tt, getCurrentFuncName(), req, resp)
 
 	require.Equal(t, typesv1.StatusType_STATUS_TYPE_SUCCESS, resp.Header.Status, "unexpected response status")
 

--- a/tests/e2e/tests/test_accommodation_v3.go
+++ b/tests/e2e/tests/test_accommodation_v3.go
@@ -81,17 +81,17 @@ func testAccommodationV3ProductListService(
 
 	expectedTotalResults := len(hotelCodes)
 
+	req := &accommodationv3.AccommodationProductListRequest{
+		Header: &typesv1.RequestHeader{BaseHeader: &typesv1.Header{}},
+	}
 	resp, err := distributorBot.AccommodationProductListServiceV3.AccommodationProductList(
 		requestContext(ctx, &metadata.Metadata{
 			Recipient: supplierBot.CMAccountAddress().Hex(),
 		}),
-		&accommodationv3.AccommodationProductListRequest{
-			Header: &typesv1.RequestHeader{BaseHeader: &typesv1.Header{}},
-		},
+		req,
 	)
 	require.NoError(t, err)
-
-	tt.logger.Debug("AccommodationProductListServiceV3.AccommodationProductList response:\n", protoMessageToJSON(tt, resp))
+	debugPrintRequestResponse(tt, getCurrentFuncName(), req, resp)
 
 	require.Equal(t, typesv1.StatusType_STATUS_TYPE_SUCCESS, resp.Header.Status, "unexpected response status")
 	require.Empty(t, resp.Header.Alerts, "unexpected response alerts")
@@ -119,20 +119,20 @@ func testAccommodationV3ProductListServiceWithFilter(
 	const modifiedAfterSecs int64 = 1710489050
 	const hotelCode = "HOTEL567890"
 
+	req := &accommodationv3.AccommodationProductListRequest{
+		Header: &typesv1.RequestHeader{BaseHeader: &typesv1.Header{}},
+		ModifiedAfter: &timestamppb.Timestamp{
+			Seconds: modifiedAfterSecs,
+		},
+	}
 	resp, err := distributorBot.AccommodationProductListServiceV3.AccommodationProductList(
 		requestContext(ctx, &metadata.Metadata{
 			Recipient: supplierBot.CMAccountAddress().Hex(),
 		}),
-		&accommodationv3.AccommodationProductListRequest{
-			Header: &typesv1.RequestHeader{BaseHeader: &typesv1.Header{}},
-			ModifiedAfter: &timestamppb.Timestamp{
-				Seconds: modifiedAfterSecs,
-			},
-		},
+		req,
 	)
 	require.NoError(t, err)
-
-	tt.logger.Debug("AccommodationProductListServiceV3.AccommodationProductList response:\n", protoMessageToJSON(tt, resp))
+	debugPrintRequestResponse(tt, getCurrentFuncName(), req, resp)
 
 	require.Equal(t, typesv1.StatusType_STATUS_TYPE_SUCCESS, resp.Header.Status, "unexpected response status")
 	require.Empty(t, resp.Header.Alerts, "unexpected response alerts")
@@ -155,20 +155,20 @@ func testAccommodationV3ProductInfoService(
 ) {
 	const hotelCode = "HOTEL789012"
 
+	req := &accommodationv3.AccommodationProductInfoRequest{
+		Header: &typesv1.RequestHeader{BaseHeader: &typesv1.Header{}},
+		SupplierCodes: []*typesv2.SupplierProductCode{
+			{SupplierCode: hotelCode},
+		},
+	}
 	resp, err := distributorBot.AccommodationProductInfoServiceV3.AccommodationProductInfo(
 		requestContext(ctx, &metadata.Metadata{
 			Recipient: supplierBot.CMAccountAddress().Hex(),
 		}),
-		&accommodationv3.AccommodationProductInfoRequest{
-			Header: &typesv1.RequestHeader{BaseHeader: &typesv1.Header{}},
-			SupplierCodes: []*typesv2.SupplierProductCode{
-				{SupplierCode: hotelCode},
-			},
-		},
+		req,
 	)
 	require.NoError(t, err)
-
-	tt.logger.Debug("AccommodationProductInfoServiceV3.AccommodationProductInfo response:\n", protoMessageToJSON(tt, resp))
+	debugPrintRequestResponse(tt, getCurrentFuncName(), req, resp)
 
 	require.Equal(t, typesv1.StatusType_STATUS_TYPE_SUCCESS, resp.Header.Status, "unexpected response status")
 	require.Empty(t, resp.Header.Alerts, "unexpected response alerts")
@@ -208,24 +208,24 @@ func testAccommodationV3SearchServiceWithoutCurrency(
 ) {
 	const hotelCode = "HOTEL345678"
 
+	req := &accommodationv3.AccommodationSearchRequest{
+		Header: &typesv1.RequestHeader{BaseHeader: &typesv1.Header{}},
+		Queries: []*accommodationv3.AccommodationSearchQuery{{
+			SearchParametersAccommodation: &accommodationv2.AccommodationSearchParameters{
+				SupplierCodes: []*typesv2.SupplierProductCode{
+					{SupplierCode: hotelCode},
+				},
+			},
+		}},
+	}
 	resp, err := distributorBot.AccommodationSearchServiceV3.AccommodationSearch(
 		requestContext(ctx, &metadata.Metadata{
 			Recipient: supplierBot.CMAccountAddress().Hex(),
 		}),
-		&accommodationv3.AccommodationSearchRequest{
-			Header: &typesv1.RequestHeader{BaseHeader: &typesv1.Header{}},
-			Queries: []*accommodationv3.AccommodationSearchQuery{{
-				SearchParametersAccommodation: &accommodationv2.AccommodationSearchParameters{
-					SupplierCodes: []*typesv2.SupplierProductCode{
-						{SupplierCode: hotelCode},
-					},
-				},
-			}},
-		},
+		req,
 	)
 	require.NoError(t, err)
-
-	tt.logger.Debug("AccommodationSearchServiceV3.AccommodationSearch response:\n", protoMessageToJSON(tt, resp))
+	debugPrintRequestResponse(tt, getCurrentFuncName(), req, resp)
 	require.Equal(t, typesv1.StatusType_STATUS_TYPE_FAILURE, resp.Header.Status, "unexpected response status")
 }
 
@@ -239,27 +239,27 @@ func testAccommodationV3SearchServiceWithoutTravelPeriod(
 ) {
 	const hotelCode = "HOTEL345678"
 
+	req := &accommodationv3.AccommodationSearchRequest{
+		Header: &typesv1.RequestHeader{BaseHeader: &typesv1.Header{}},
+		SearchParametersGeneric: &typesv3.SearchParameters{
+			Currency: &typesv3.Currency{Currency: &typesv3.Currency_NativeToken{}},
+		},
+		Queries: []*accommodationv3.AccommodationSearchQuery{{
+			SearchParametersAccommodation: &accommodationv2.AccommodationSearchParameters{
+				SupplierCodes: []*typesv2.SupplierProductCode{
+					{SupplierCode: hotelCode},
+				},
+			},
+		}},
+	}
 	resp, err := distributorBot.AccommodationSearchServiceV3.AccommodationSearch(
 		requestContext(ctx, &metadata.Metadata{
 			Recipient: supplierBot.CMAccountAddress().Hex(),
 		}),
-		&accommodationv3.AccommodationSearchRequest{
-			Header: &typesv1.RequestHeader{BaseHeader: &typesv1.Header{}},
-			SearchParametersGeneric: &typesv3.SearchParameters{
-				Currency: &typesv3.Currency{Currency: &typesv3.Currency_NativeToken{}},
-			},
-			Queries: []*accommodationv3.AccommodationSearchQuery{{
-				SearchParametersAccommodation: &accommodationv2.AccommodationSearchParameters{
-					SupplierCodes: []*typesv2.SupplierProductCode{
-						{SupplierCode: hotelCode},
-					},
-				},
-			}},
-		},
+		req,
 	)
 	require.NoError(t, err)
-
-	tt.logger.Debug("AccommodationSearchServiceV3.AccommodationSearch response:\n", protoMessageToJSON(tt, resp))
+	debugPrintRequestResponse(tt, getCurrentFuncName(), req, resp)
 	require.Equal(t, typesv1.StatusType_STATUS_TYPE_FAILURE, resp.Header.Status, "unexpected response status")
 }
 
@@ -277,31 +277,31 @@ func testAccommodationV3SearchServiceTravelPeriodOutOfBounds(
 	startDate := time.Now().Add(time.Hour * 24 * 100) // in 100 days, outside of allowed travel period
 	endDate := startDate.Add(time.Hour * 24 * time.Duration(nights))
 
+	req := &accommodationv3.AccommodationSearchRequest{
+		Header: &typesv1.RequestHeader{BaseHeader: &typesv1.Header{}},
+		SearchParametersGeneric: &typesv3.SearchParameters{
+			Currency: &typesv3.Currency{Currency: &typesv3.Currency_NativeToken{}},
+		},
+		Queries: []*accommodationv3.AccommodationSearchQuery{{
+			SearchParametersAccommodation: &accommodationv2.AccommodationSearchParameters{
+				SupplierCodes: []*typesv2.SupplierProductCode{
+					{SupplierCode: hotelCode},
+				},
+			},
+			TravelPeriod: &typesv1.TravelPeriod{
+				StartDate: common.TimeToDateV1(startDate),
+				EndDate:   common.TimeToDateV1(endDate),
+			},
+		}},
+	}
 	resp, err := distributorBot.AccommodationSearchServiceV3.AccommodationSearch(
 		requestContext(ctx, &metadata.Metadata{
 			Recipient: supplierBot.CMAccountAddress().Hex(),
 		}),
-		&accommodationv3.AccommodationSearchRequest{
-			Header: &typesv1.RequestHeader{BaseHeader: &typesv1.Header{}},
-			SearchParametersGeneric: &typesv3.SearchParameters{
-				Currency: &typesv3.Currency{Currency: &typesv3.Currency_NativeToken{}},
-			},
-			Queries: []*accommodationv3.AccommodationSearchQuery{{
-				SearchParametersAccommodation: &accommodationv2.AccommodationSearchParameters{
-					SupplierCodes: []*typesv2.SupplierProductCode{
-						{SupplierCode: hotelCode},
-					},
-				},
-				TravelPeriod: &typesv1.TravelPeriod{
-					StartDate: common.TimeToDateV1(startDate),
-					EndDate:   common.TimeToDateV1(endDate),
-				},
-			}},
-		},
+		req,
 	)
 	require.NoError(t, err)
-
-	tt.logger.Debug("AccommodationSearchServiceV3.AccommodationSearch response:\n", protoMessageToJSON(tt, resp))
+	debugPrintRequestResponse(tt, getCurrentFuncName(), req, resp)
 	require.Equal(t, typesv1.StatusType_STATUS_TYPE_FAILURE, resp.Header.Status, "unexpected response status")
 }
 
@@ -319,31 +319,31 @@ func testAccommodationV3SearchServiceTravelPeriodReversed(
 	endDate := time.Now().Add(time.Hour * 24)                        // tomorrow
 	startDate := endDate.Add(time.Hour * 24 * time.Duration(nights)) // start date after end date
 
+	req := &accommodationv3.AccommodationSearchRequest{
+		Header: &typesv1.RequestHeader{BaseHeader: &typesv1.Header{}},
+		SearchParametersGeneric: &typesv3.SearchParameters{
+			Currency: &typesv3.Currency{Currency: &typesv3.Currency_NativeToken{}},
+		},
+		Queries: []*accommodationv3.AccommodationSearchQuery{{
+			SearchParametersAccommodation: &accommodationv2.AccommodationSearchParameters{
+				SupplierCodes: []*typesv2.SupplierProductCode{
+					{SupplierCode: hotelCode},
+				},
+			},
+			TravelPeriod: &typesv1.TravelPeriod{
+				StartDate: common.TimeToDateV1(startDate),
+				EndDate:   common.TimeToDateV1(endDate),
+			},
+		}},
+	}
 	resp, err := distributorBot.AccommodationSearchServiceV3.AccommodationSearch(
 		requestContext(ctx, &metadata.Metadata{
 			Recipient: supplierBot.CMAccountAddress().Hex(),
 		}),
-		&accommodationv3.AccommodationSearchRequest{
-			Header: &typesv1.RequestHeader{BaseHeader: &typesv1.Header{}},
-			SearchParametersGeneric: &typesv3.SearchParameters{
-				Currency: &typesv3.Currency{Currency: &typesv3.Currency_NativeToken{}},
-			},
-			Queries: []*accommodationv3.AccommodationSearchQuery{{
-				SearchParametersAccommodation: &accommodationv2.AccommodationSearchParameters{
-					SupplierCodes: []*typesv2.SupplierProductCode{
-						{SupplierCode: hotelCode},
-					},
-				},
-				TravelPeriod: &typesv1.TravelPeriod{
-					StartDate: common.TimeToDateV1(startDate),
-					EndDate:   common.TimeToDateV1(endDate),
-				},
-			}},
-		},
+		req,
 	)
 	require.NoError(t, err)
-
-	tt.logger.Debug("AccommodationSearchServiceV3.AccommodationSearch response:\n", protoMessageToJSON(tt, resp))
+	debugPrintRequestResponse(tt, getCurrentFuncName(), req, resp)
 	require.Equal(t, typesv1.StatusType_STATUS_TYPE_FAILURE, resp.Header.Status, "unexpected response status")
 }
 
@@ -381,9 +381,6 @@ func testAccommodationV3SearchServiceWithTravelPeriod(
 			},
 		}},
 	}
-
-	tt.logger.Debug("AccommodationSearchServiceV3.AccommodationSearch request:\n", protoMessageToJSON(tt, req))
-
 	resp, err := distributorBot.AccommodationSearchServiceV3.AccommodationSearch(
 		requestContext(ctx, &metadata.Metadata{
 			Recipient: supplierBot.CMAccountAddress().Hex(),
@@ -391,8 +388,7 @@ func testAccommodationV3SearchServiceWithTravelPeriod(
 		req,
 	)
 	require.NoError(t, err)
-
-	tt.logger.Debug("AccommodationSearchServiceV3.AccommodationSearch response:\n", protoMessageToJSON(tt, resp))
+	debugPrintRequestResponse(tt, getCurrentFuncName(), req, resp)
 
 	require.Equal(t, typesv1.StatusType_STATUS_TYPE_SUCCESS, resp.Header.Status, "unexpected response status")
 	require.Empty(t, resp.Header.Alerts, "unexpected response alerts")
@@ -438,22 +434,22 @@ func testAccommodationV3ValidateV2(
 	resultID int32,
 	expectedTotalPrice float64,
 ) (validateID string) {
+	req := &bookv2.ValidationRequest{
+		ValidationObject: &bookv2.ValidationObject{
+			SearchIdentifier: &typesv2.SearchIdentifier{
+				SearchId: &typesv1.UUID{Value: searchID},
+				ResultId: resultID,
+			},
+		},
+	}
 	resp, err := distributorBot.ValidationServiceV2.Validation(
 		requestContext(ctx, &metadata.Metadata{
 			Recipient: supplierBot.CMAccountAddress().Hex(),
 		}),
-		&bookv2.ValidationRequest{
-			ValidationObject: &bookv2.ValidationObject{
-				SearchIdentifier: &typesv2.SearchIdentifier{
-					SearchId: &typesv1.UUID{Value: searchID},
-					ResultId: resultID,
-				},
-			},
-		},
+		req,
 	)
 	require.NoError(t, err)
-
-	tt.logger.Debug("ValidationServiceV2.Validation response:\n", protoMessageToJSON(tt, resp))
+	debugPrintRequestResponse(tt, getCurrentFuncName(), req, resp)
 
 	require.Equal(t, typesv1.StatusType_STATUS_TYPE_SUCCESS, resp.Header.Status, "unexpected response status")
 	require.Empty(t, resp.Header.Alerts, "unexpected response alerts")
@@ -492,18 +488,18 @@ func testAccommodationV3MintV2(
 	tokenID uint64,
 	price *typesv2.Price,
 ) {
+	req := &bookv2.MintRequest{
+		Header:       &typesv1.RequestHeader{BaseHeader: &typesv1.Header{}},
+		ValidationId: &typesv1.UUID{Value: validationID},
+	}
 	resp, err := distributorBot.MintServiceV2.Mint(
 		requestContext(ctx, &metadata.Metadata{
 			Recipient: supplierBot.CMAccountAddress().Hex(),
 		}),
-		&bookv2.MintRequest{
-			Header:       &typesv1.RequestHeader{BaseHeader: &typesv1.Header{}},
-			ValidationId: &typesv1.UUID{Value: validationID},
-		},
+		req,
 	)
 	require.NoError(t, err)
-
-	tt.logger.Debug("MintServiceV2.Mint response:\n", protoMessageToJSON(tt, resp))
+	debugPrintRequestResponse(tt, getCurrentFuncName(), req, resp)
 
 	require.Equal(t, typesv1.StatusType_STATUS_TYPE_SUCCESS, resp.Header.Status, "unexpected response status")
 

--- a/tests/e2e/tests/test_ping.go
+++ b/tests/e2e/tests/test_ping.go
@@ -42,18 +42,20 @@ func TestPingV1(t *testing.T, tt *Test) {
 	pingMessage := "ping"
 	expectedResponceMessageSubString := fmt.Sprintf("Ping response to [%s] with request ID:", pingMessage)
 
+	req := &pingv1.PingRequest{
+		Header:      &typesv1.RequestHeader{BaseHeader: &typesv1.Header{}},
+		PingMessage: pingMessage,
+		Timestamp:   timestamppb.Now(),
+	}
 	resp, err := distributorBot.PingServiceV1.Ping(
 		requestContext(ctx, &metadata.Metadata{
 			Recipient: supplierBot.CMAccountAddress().Hex(),
 		}),
-		&pingv1.PingRequest{
-			Header:      &typesv1.RequestHeader{BaseHeader: &typesv1.Header{}},
-			PingMessage: pingMessage,
-			Timestamp:   timestamppb.Now(),
-		},
+		req,
 	)
 
 	require.NoError(t, err)
+	debugPrintRequestResponse(tt, getCurrentFuncName(), req, resp)
 	require.Equal(t, typesv1.StatusType_STATUS_TYPE_SUCCESS, resp.Header.Status, "unexpected response status")
 	require.Empty(t, resp.Header.Alerts, "unexpected response alerts")
 	require.Contains(t, resp.PingMessage, expectedResponceMessageSubString, "unexpected response message")

--- a/tests/e2e/tests/test_transport_v3.go
+++ b/tests/e2e/tests/test_transport_v3.go
@@ -81,17 +81,17 @@ func testTransportV3ProductListService(
 	}
 	expectedTotalResults := len(productCodes)
 
+	req := &transportv3.TransportProductListRequest{
+		Header: &typesv1.RequestHeader{BaseHeader: &typesv1.Header{}},
+	}
 	resp, err := distributorBot.TransportProductListServiceV3.TransportProductList(
 		requestContext(ctx, &metadata.Metadata{
 			Recipient: supplierBot.CMAccountAddress().Hex(),
 		}),
-		&transportv3.TransportProductListRequest{
-			Header: &typesv1.RequestHeader{BaseHeader: &typesv1.Header{}},
-		},
+		req,
 	)
 	require.NoError(t, err)
-
-	tt.logger.Debug("TransportProductListServiceV3.TransportProductList response:\n", protoMessageToJSON(tt, resp))
+	debugPrintRequestResponse(tt, getCurrentFuncName(), req, resp)
 
 	require.Equal(t, typesv1.StatusType_STATUS_TYPE_SUCCESS, resp.Header.Status, "unexpected response status")
 	require.Empty(t, resp.Header.Alerts, "unexpected response alerts")
@@ -137,20 +137,20 @@ func testTransportV3ProductListServiceWithFilter(
 	expectedTotalResults := len(productCodes)
 	modifiedAfter := 1740500000
 
+	req := &transportv3.TransportProductListRequest{
+		Header: &typesv1.RequestHeader{BaseHeader: &typesv1.Header{}},
+		ModifiedAfter: &timestamppb.Timestamp{
+			Seconds: int64(modifiedAfter),
+		},
+	}
 	resp, err := distributorBot.TransportProductListServiceV3.TransportProductList(
 		requestContext(ctx, &metadata.Metadata{
 			Recipient: supplierBot.CMAccountAddress().Hex(),
 		}),
-		&transportv3.TransportProductListRequest{
-			Header: &typesv1.RequestHeader{BaseHeader: &typesv1.Header{}},
-			ModifiedAfter: &timestamppb.Timestamp{
-				Seconds: int64(modifiedAfter),
-			},
-		},
+		req,
 	)
 	require.NoError(t, err)
-
-	tt.logger.Debug("TransportProductListServiceV3.TransportProductList response:\n", protoMessageToJSON(tt, resp))
+	debugPrintRequestResponse(tt, getCurrentFuncName(), req, resp)
 
 	require.Equal(t, typesv1.StatusType_STATUS_TYPE_SUCCESS, resp.Header.Status, "unexpected response status")
 	require.Empty(t, resp.Header.Alerts, "unexpected response alerts")
@@ -180,18 +180,18 @@ func testTransportV3SearchServiceWithoutQuery(
 	distributorBot *bot.Bot,
 	supplierBot *bot.Bot,
 ) {
+	req := &transportv3.TransportSearchRequest{
+		Header:  &typesv1.RequestHeader{BaseHeader: &typesv1.Header{}},
+		Queries: []*transportv3.TransportSearchQuery{},
+	}
 	resp, err := distributorBot.TransportSearchServiceV3.TransportSearch(
 		requestContext(ctx, &metadata.Metadata{
 			Recipient: supplierBot.CMAccountAddress().Hex(),
 		}),
-		&transportv3.TransportSearchRequest{
-			Header:  &typesv1.RequestHeader{BaseHeader: &typesv1.Header{}},
-			Queries: []*transportv3.TransportSearchQuery{},
-		},
+		req,
 	)
 	require.NoError(t, err)
-
-	tt.logger.Debug("TransportSearchServiceV3.TransportSearch response:\n", protoMessageToJSON(tt, resp))
+	debugPrintRequestResponse(tt, getCurrentFuncName(), req, resp)
 	require.Equal(t, typesv1.StatusType_STATUS_TYPE_FAILURE, resp.Header.Status, "unexpected response status")
 }
 
@@ -207,66 +207,66 @@ func testTransportV3SearchServiceTravelDatesReversed(
 	endDate := time.Now().Add(time.Hour * 24)                        // tomorrow
 	startDate := endDate.Add(time.Hour * 24 * time.Duration(nights)) // start date after end date
 
-	resp, err := distributorBot.TransportSearchServiceV3.TransportSearch(
-		requestContext(ctx, &metadata.Metadata{
-			Recipient: supplierBot.CMAccountAddress().Hex(),
-		}),
-		&transportv3.TransportSearchRequest{
-			Header: &typesv1.RequestHeader{BaseHeader: &typesv1.Header{}},
-			SearchParameters: &typesv3.SearchParameters{
-				Currency: &typesv3.Currency{
-					Currency: &typesv3.Currency_NativeToken{},
-				},
+	req := &transportv3.TransportSearchRequest{
+		Header: &typesv1.RequestHeader{BaseHeader: &typesv1.Header{}},
+		SearchParameters: &typesv3.SearchParameters{
+			Currency: &typesv3.Currency{
+				Currency: &typesv3.Currency_NativeToken{},
 			},
-			Queries: []*transportv3.TransportSearchQuery{
-				{
-					Travellers: []*typesv3.BasicTraveller{
-						{
-							TravellerId: 0,
-							Type:        typesv3.TravellerType_TRAVELLER_TYPE_ADULT,
-							Birthdate: &typesv1.Date{
-								Year:  1980, //nolint:gosec
-								Month: 1,    //nolint:gosec
-								Day:   1,    //nolint:gosec
-							},
-							Nationality: typesv2.Country_COUNTRY_DE,
+		},
+		Queries: []*transportv3.TransportSearchQuery{
+			{
+				Travellers: []*typesv3.BasicTraveller{
+					{
+						TravellerId: 0,
+						Type:        typesv3.TravellerType_TRAVELLER_TYPE_ADULT,
+						Birthdate: &typesv1.Date{
+							Year:  1980, //nolint:gosec
+							Month: 1,    //nolint:gosec
+							Day:   1,    //nolint:gosec
 						},
-						{
-							TravellerId: 1,
-							Type:        typesv3.TravellerType_TRAVELLER_TYPE_ADULT,
-							Birthdate: &typesv1.Date{
-								Year:  1980, //nolint:gosec
-								Month: 1,    //nolint:gosec
-								Day:   2,    //nolint:gosec
-							},
-							Nationality: typesv2.Country_COUNTRY_IT,
-						},
+						Nationality: typesv2.Country_COUNTRY_DE,
 					},
-					Trips: []*transportv3.QueryTrip{
-						{
-							Departure: &transportv3.QueryTransitEvent{
-								Date: common.TimeToDateV1(startDate),
-								LocationCode: &typesv2.LocationCode{
-									Code: "PMI",
-									Type: typesv2.LocationCodeType_LOCATION_CODE_TYPE_IATA_CODE,
-								},
+					{
+						TravellerId: 1,
+						Type:        typesv3.TravellerType_TRAVELLER_TYPE_ADULT,
+						Birthdate: &typesv1.Date{
+							Year:  1980, //nolint:gosec
+							Month: 1,    //nolint:gosec
+							Day:   2,    //nolint:gosec
+						},
+						Nationality: typesv2.Country_COUNTRY_IT,
+					},
+				},
+				Trips: []*transportv3.QueryTrip{
+					{
+						Departure: &transportv3.QueryTransitEvent{
+							Date: common.TimeToDateV1(startDate),
+							LocationCode: &typesv2.LocationCode{
+								Code: "PMI",
+								Type: typesv2.LocationCodeType_LOCATION_CODE_TYPE_IATA_CODE,
 							},
-							Arrival: &transportv3.QueryTransitEvent{
-								Date: common.TimeToDateV1(endDate),
-								LocationCode: &typesv2.LocationCode{
-									Code: "BCN",
-									Type: typesv2.LocationCodeType_LOCATION_CODE_TYPE_IATA_CODE,
-								},
+						},
+						Arrival: &transportv3.QueryTransitEvent{
+							Date: common.TimeToDateV1(endDate),
+							LocationCode: &typesv2.LocationCode{
+								Code: "BCN",
+								Type: typesv2.LocationCodeType_LOCATION_CODE_TYPE_IATA_CODE,
 							},
 						},
 					},
 				},
 			},
 		},
+	}
+	resp, err := distributorBot.TransportSearchServiceV3.TransportSearch(
+		requestContext(ctx, &metadata.Metadata{
+			Recipient: supplierBot.CMAccountAddress().Hex(),
+		}),
+		req,
 	)
 	require.NoError(t, err)
-
-	tt.logger.Debug("TransportSearchServiceV3.TransportSearch response:\n", protoMessageToJSON(tt, resp))
+	debugPrintRequestResponse(tt, getCurrentFuncName(), req, resp)
 	require.Equal(t, typesv1.StatusType_STATUS_TYPE_FAILURE, resp.Header.Status, "unexpected response status")
 }
 
@@ -281,66 +281,66 @@ func testTransportV3SearchServiceTravelDatesWrong(
 	departureDate := time.Unix(1741959420, 0) // 14. May 2025 -- Not in mock data
 	arrivalDate := time.Unix(1742045820, 0)   // 15. May 2025 -- In mock data
 
-	resp, err := distributorBot.TransportSearchServiceV3.TransportSearch(
-		requestContext(ctx, &metadata.Metadata{
-			Recipient: supplierBot.CMAccountAddress().Hex(),
-		}),
-		&transportv3.TransportSearchRequest{
-			Header: &typesv1.RequestHeader{BaseHeader: &typesv1.Header{}},
-			SearchParameters: &typesv3.SearchParameters{
-				Currency: &typesv3.Currency{
-					Currency: &typesv3.Currency_NativeToken{},
-				},
+	req := &transportv3.TransportSearchRequest{
+		Header: &typesv1.RequestHeader{BaseHeader: &typesv1.Header{}},
+		SearchParameters: &typesv3.SearchParameters{
+			Currency: &typesv3.Currency{
+				Currency: &typesv3.Currency_NativeToken{},
 			},
-			Queries: []*transportv3.TransportSearchQuery{
-				{
-					Travellers: []*typesv3.BasicTraveller{
-						{
-							TravellerId: 0,
-							Type:        typesv3.TravellerType_TRAVELLER_TYPE_ADULT,
-							Birthdate: &typesv1.Date{
-								Year:  1980, //nolint:gosec
-								Month: 1,    //nolint:gosec
-								Day:   1,    //nolint:gosec
-							},
-							Nationality: typesv2.Country_COUNTRY_DE,
+		},
+		Queries: []*transportv3.TransportSearchQuery{
+			{
+				Travellers: []*typesv3.BasicTraveller{
+					{
+						TravellerId: 0,
+						Type:        typesv3.TravellerType_TRAVELLER_TYPE_ADULT,
+						Birthdate: &typesv1.Date{
+							Year:  1980, //nolint:gosec
+							Month: 1,    //nolint:gosec
+							Day:   1,    //nolint:gosec
 						},
-						{
-							TravellerId: 1,
-							Type:        typesv3.TravellerType_TRAVELLER_TYPE_ADULT,
-							Birthdate: &typesv1.Date{
-								Year:  1980, //nolint:gosec
-								Month: 1,    //nolint:gosec
-								Day:   2,    //nolint:gosec
-							},
-							Nationality: typesv2.Country_COUNTRY_IT,
-						},
+						Nationality: typesv2.Country_COUNTRY_DE,
 					},
-					Trips: []*transportv3.QueryTrip{
-						{
-							Departure: &transportv3.QueryTransitEvent{
-								Date: common.TimeToDateV1(departureDate),
-								LocationCode: &typesv2.LocationCode{
-									Code: "PMI",
-									Type: typesv2.LocationCodeType_LOCATION_CODE_TYPE_IATA_CODE,
-								},
+					{
+						TravellerId: 1,
+						Type:        typesv3.TravellerType_TRAVELLER_TYPE_ADULT,
+						Birthdate: &typesv1.Date{
+							Year:  1980, //nolint:gosec
+							Month: 1,    //nolint:gosec
+							Day:   2,    //nolint:gosec
+						},
+						Nationality: typesv2.Country_COUNTRY_IT,
+					},
+				},
+				Trips: []*transportv3.QueryTrip{
+					{
+						Departure: &transportv3.QueryTransitEvent{
+							Date: common.TimeToDateV1(departureDate),
+							LocationCode: &typesv2.LocationCode{
+								Code: "PMI",
+								Type: typesv2.LocationCodeType_LOCATION_CODE_TYPE_IATA_CODE,
 							},
-							Arrival: &transportv3.QueryTransitEvent{
-								Date: common.TimeToDateV1(arrivalDate),
-								LocationCode: &typesv2.LocationCode{
-									Code: "BCN",
-									Type: typesv2.LocationCodeType_LOCATION_CODE_TYPE_IATA_CODE,
-								},
+						},
+						Arrival: &transportv3.QueryTransitEvent{
+							Date: common.TimeToDateV1(arrivalDate),
+							LocationCode: &typesv2.LocationCode{
+								Code: "BCN",
+								Type: typesv2.LocationCodeType_LOCATION_CODE_TYPE_IATA_CODE,
 							},
 						},
 					},
 				},
 			},
 		},
+	}
+	resp, err := distributorBot.TransportSearchServiceV3.TransportSearch(
+		requestContext(ctx, &metadata.Metadata{
+			Recipient: supplierBot.CMAccountAddress().Hex(),
+		}),
+		req,
 	)
 	require.NoError(t, err)
-
-	tt.logger.Debug("TransportSearchServiceV3.TransportSearch response:\n", protoMessageToJSON(tt, resp))
+	debugPrintRequestResponse(tt, getCurrentFuncName(), req, resp)
 	// Note: an empty result is still a success as the request was valid
 	// There is just no result for the given filters
 	require.Equal(t, typesv1.StatusType_STATUS_TYPE_SUCCESS, resp.Header.Status, "unexpected response status")
@@ -373,66 +373,64 @@ func testTransportV3SearchServiceWithFilters(
 	arrivalLocationCode := lastSegmentArrival.LocationCode
 	expectedTotalPrice := 750.0
 
-	resp, err := distributorBot.TransportSearchServiceV3.TransportSearch(
-		requestContext(ctx, &metadata.Metadata{
-			Recipient: supplierBot.CMAccountAddress().Hex(),
-		}),
-		&transportv3.TransportSearchRequest{
-			Header: &typesv1.RequestHeader{BaseHeader: &typesv1.Header{}},
-			SearchParameters: &typesv3.SearchParameters{
-				Currency: &typesv3.Currency{
-					Currency: &typesv3.Currency_IsoCurrency{
-						IsoCurrency: typesv3.IsoCurrency(*typesv2.IsoCurrency_ISO_CURRENCY_EUR.Enum()),
-					},
+	req := &transportv3.TransportSearchRequest{
+		Header: &typesv1.RequestHeader{BaseHeader: &typesv1.Header{}},
+		SearchParameters: &typesv3.SearchParameters{
+			Currency: &typesv3.Currency{
+				Currency: &typesv3.Currency_IsoCurrency{
+					IsoCurrency: typesv3.IsoCurrency(*typesv2.IsoCurrency_ISO_CURRENCY_EUR.Enum()),
 				},
 			},
-			Queries: []*transportv3.TransportSearchQuery{
-				{
-					Travellers: []*typesv3.BasicTraveller{
-						{
-							TravellerId: 0,
-							Type:        typesv3.TravellerType_TRAVELLER_TYPE_ADULT,
-							Birthdate: &typesv1.Date{
-								Year:  1980, //nolint:gosec
-								Month: 1,    //nolint:gosec
-								Day:   1,    //nolint:gosec
-							},
-							Nationality: typesv2.Country_COUNTRY_DE,
+		},
+		Queries: []*transportv3.TransportSearchQuery{
+			{
+				Travellers: []*typesv3.BasicTraveller{
+					{
+						TravellerId: 0,
+						Type:        typesv3.TravellerType_TRAVELLER_TYPE_ADULT,
+						Birthdate: &typesv1.Date{
+							Year:  1980, //nolint:gosec
+							Month: 1,    //nolint:gosec
+							Day:   1,    //nolint:gosec
 						},
-						{
-							TravellerId: 1,
-							Type:        typesv3.TravellerType_TRAVELLER_TYPE_ADULT,
-							Birthdate: &typesv1.Date{
-								Year:  1980, //nolint:gosec
-								Month: 1,    //nolint:gosec
-								Day:   2,    //nolint:gosec
-							},
-							Nationality: typesv2.Country_COUNTRY_IT,
-						},
+						Nationality: typesv2.Country_COUNTRY_DE,
 					},
-					Trips: []*transportv3.QueryTrip{
-						{
-							Departure: &transportv3.QueryTransitEvent{
-								Date:         common.TimeToDateV1(departureDate),
-								LocationCode: departureLocationCode,
-							},
-							Arrival: &transportv3.QueryTransitEvent{
-								Date:         common.TimeToDateV1(arrivalDate),
-								LocationCode: arrivalLocationCode,
-							},
+					{
+						TravellerId: 1,
+						Type:        typesv3.TravellerType_TRAVELLER_TYPE_ADULT,
+						Birthdate: &typesv1.Date{
+							Year:  1980, //nolint:gosec
+							Month: 1,    //nolint:gosec
+							Day:   2,    //nolint:gosec
+						},
+						Nationality: typesv2.Country_COUNTRY_IT,
+					},
+				},
+				Trips: []*transportv3.QueryTrip{
+					{
+						Departure: &transportv3.QueryTransitEvent{
+							Date:         common.TimeToDateV1(departureDate),
+							LocationCode: departureLocationCode,
+						},
+						Arrival: &transportv3.QueryTransitEvent{
+							Date:         common.TimeToDateV1(arrivalDate),
+							LocationCode: arrivalLocationCode,
 						},
 					},
 				},
 			},
 		},
+	}
+	resp, err := distributorBot.TransportSearchServiceV3.TransportSearch(
+		requestContext(ctx, &metadata.Metadata{
+			Recipient: supplierBot.CMAccountAddress().Hex(),
+		}),
+		req,
 	)
 	require.NoError(t, err)
+	debugPrintRequestResponse(tt, getCurrentFuncName(), req, resp)
 
-	tt.logger.Debug("TransportSearchServiceV3.TransportSearch response:\n", protoMessageToJSON(tt, resp))
-	// Note: an empty result is still a success as the request was valid
-	// There is just no result for the given filters
 	require.Equal(t, typesv1.StatusType_STATUS_TYPE_SUCCESS, resp.Header.Status, "unexpected response status")
-
 	// We expect 1 result
 	require.Len(t, resp.Results, 1, "unexpected number of results in response")
 
@@ -475,22 +473,22 @@ func testTransportV3ValidateV2(
 	resultID int32,
 	expectedTotalPrice float64,
 ) (validateID string) {
+	req := &bookv2.ValidationRequest{
+		ValidationObject: &bookv2.ValidationObject{
+			SearchIdentifier: &typesv2.SearchIdentifier{
+				SearchId: &typesv1.UUID{Value: searchID},
+				ResultId: resultID,
+			},
+		},
+	}
 	resp, err := distributorBot.ValidationServiceV2.Validation(
 		requestContext(ctx, &metadata.Metadata{
 			Recipient: supplierBot.CMAccountAddress().Hex(),
 		}),
-		&bookv2.ValidationRequest{
-			ValidationObject: &bookv2.ValidationObject{
-				SearchIdentifier: &typesv2.SearchIdentifier{
-					SearchId: &typesv1.UUID{Value: searchID},
-					ResultId: resultID,
-				},
-			},
-		},
+		req,
 	)
 	require.NoError(t, err)
-
-	tt.logger.Debug("ValidationServiceV2.Validation response:\n", protoMessageToJSON(tt, resp))
+	debugPrintRequestResponse(tt, getCurrentFuncName(), req, resp)
 
 	require.Equal(t, typesv1.StatusType_STATUS_TYPE_SUCCESS, resp.Header.Status, "unexpected response status")
 	require.Empty(t, resp.Header.Alerts, "unexpected response alerts")
@@ -530,18 +528,18 @@ func testTransportV3MintV2(
 	tokenID uint64,
 	price *typesv2.Price,
 ) {
+	req := &bookv2.MintRequest{
+		Header:       &typesv1.RequestHeader{BaseHeader: &typesv1.Header{}},
+		ValidationId: &typesv1.UUID{Value: validationID},
+	}
 	resp, err := distributorBot.MintServiceV2.Mint(
 		requestContext(ctx, &metadata.Metadata{
 			Recipient: supplierBot.CMAccountAddress().Hex(),
 		}),
-		&bookv2.MintRequest{
-			Header:       &typesv1.RequestHeader{BaseHeader: &typesv1.Header{}},
-			ValidationId: &typesv1.UUID{Value: validationID},
-		},
+		req,
 	)
 	require.NoError(t, err)
-
-	tt.logger.Debug("MintServiceV2.Mint response:\n", protoMessageToJSON(tt, resp))
+	debugPrintRequestResponse(tt, getCurrentFuncName(), req, resp)
 
 	require.Equal(t, typesv1.StatusType_STATUS_TYPE_SUCCESS, resp.Header.Status, "unexpected response status")
 

--- a/tests/e2e/tests/utils.go
+++ b/tests/e2e/tests/utils.go
@@ -27,7 +27,7 @@ func requestContext(ctx context.Context, metadata *messageMetadata.Metadata) con
 // Gets the current function name including the whole package path
 func getCurrentFuncName() string {
 	pc, _, _, _ := runtime.Caller(1)
-	return fmt.Sprintf("%s", runtime.FuncForPC(pc).Name())
+	return runtime.FuncForPC(pc).Name()
 }
 
 // Get printable type information including the package path

--- a/tests/e2e/tests/utils.go
+++ b/tests/e2e/tests/utils.go
@@ -15,6 +15,7 @@ import (
 	"github.com/chain4travel/camino-messenger-bot/pkg/booking"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
 	grpcMetadata "google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
@@ -26,12 +27,18 @@ func requestContext(ctx context.Context, metadata *messageMetadata.Metadata) con
 
 // Gets the current function name including the whole package path
 func getCurrentFuncName() string {
-	pc, _, _, _ := runtime.Caller(1)
+	pc, _, _, ok := runtime.Caller(1)
+	if !ok {
+		return "unknown"
+	}
 	return runtime.FuncForPC(pc).Name()
 }
 
 // Get printable type information including the package path
 func getTypeInfo(myvar interface{}) (res string) {
+	if myvar == nil {
+		return "nil"
+	}
 	t := reflect.TypeOf(myvar)
 	for t.Kind() == reflect.Ptr {
 		t = t.Elem()
@@ -42,9 +49,12 @@ func getTypeInfo(myvar interface{}) (res string) {
 
 // Debug print used in each test case to print the request and response as json
 func debugPrintRequestResponse(tt *Test, functionName string, request proto.Message, response proto.Message) {
-	tt.logger.Debugf("Function: %s", functionName)
-	tt.logger.Debugf("Request (%s):\n%s", getTypeInfo(request), protoMessageToJSON(tt, request))
-	tt.logger.Debugf("Response (%s):\n%s", getTypeInfo(response), protoMessageToJSON(tt, response))
+	// Skip the potentially expensive conversion to JSON if debug logging is disabled
+	if tt.logger.Level().Enabled(zapcore.DebugLevel) {
+		tt.logger.Debugf("Function: %s", functionName)
+		tt.logger.Debugf("Request (%s):\n%s", getTypeInfo(request), protoMessageToJSON(tt, request))
+		tt.logger.Debugf("Response (%s):\n%s", getTypeInfo(response), protoMessageToJSON(tt, response))
+	}
 }
 
 // Service function to convert the responses into pretty-printed JSON.

--- a/tests/e2e/tests/utils.go
+++ b/tests/e2e/tests/utils.go
@@ -5,6 +5,9 @@ package tests
 
 import (
 	"context"
+	"fmt"
+	"reflect"
+	"runtime"
 	"testing"
 
 	typesv2 "buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go/cmp/types/v2"
@@ -19,6 +22,29 @@ import (
 
 func requestContext(ctx context.Context, metadata *messageMetadata.Metadata) context.Context {
 	return grpcMetadata.NewOutgoingContext(ctx, metadata.ToGrpcMD())
+}
+
+// Gets the current function name including the whole package path
+func getCurrentFuncName() string {
+	pc, _, _, _ := runtime.Caller(1)
+	return fmt.Sprintf("%s", runtime.FuncForPC(pc).Name())
+}
+
+// Get printable type information including the package path
+func getTypeInfo(myvar interface{}) (res string) {
+	t := reflect.TypeOf(myvar)
+	for t.Kind() == reflect.Ptr {
+		t = t.Elem()
+		res += "*"
+	}
+	return fmt.Sprintf("%s%s [Package: %s]", res, t.String(), t.PkgPath())
+}
+
+// Debug print used in each test case to print the request and response as json
+func debugPrintRequestResponse(tt *Test, functionName string, request proto.Message, response proto.Message) {
+	tt.logger.Debugf("Function: %s", functionName)
+	tt.logger.Debugf("Request (%s):\n%s", getTypeInfo(request), protoMessageToJSON(tt, request))
+	tt.logger.Debugf("Response (%s):\n%s", getTypeInfo(response), protoMessageToJSON(tt, response))
 }
 
 // Service function to convert the responses into pretty-printed JSON.


### PR DESCRIPTION
Unified the way of debug printing in every test case. 
Now every case prints both the request and response in case the debug flag is set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined test routines by standardizing how requests are constructed, reducing redundancy and improving code clarity.

- **Tests**
  - Enhanced diagnostic logging to capture detailed request and response information.
  - Introduced new utility functions to support more consistent and informative debugging during test execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->