### PR TITLE
[E2E] Filter parameter for e2e.sh

### DIFF
--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -36,6 +36,10 @@ while [[ $# -gt 0 ]]; do
 			DEBUG=1
 			shift
 			;;
+		--filter)
+			FILTER="$2"
+			shift 2
+			;;
         *)
             echo "Unknown argument: $1"
             exit 1
@@ -183,6 +187,10 @@ echo "Running e2e tests..."
 ADD_PARAM=()
 if [ $DEBUG -eq 1 ] ; then
 	ADD_PARAM+=("-debug")
+fi
+
+if [ -n "$FILTER" ] ; then
+	ADD_PARAM+=("-filter=$FILTER")
 fi
 
 ./$E2E_BIN_OUT \

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -41,7 +41,6 @@ var (
 	flagExistingNetworkNodeURI  string
 	flagExistingNetworkAdminKey string
 	flagFilter                  string
-	flagFilterElements          []string
 	flagDebug                   bool
 )
 

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -28,6 +28,7 @@ const (
 	flagKeyCMBBinPath           = "cmb"
 	flagKeyMigrationsDir        = "migration"
 	flagKeyDebug                = "debug"
+	flagKeyFilter               = "filter"
 )
 
 var (
@@ -39,6 +40,8 @@ var (
 	flagTestsDataDir            string
 	flagExistingNetworkNodeURI  string
 	flagExistingNetworkAdminKey string
+	flagFilter                  string
+	flagFilterElements          []string
 	flagDebug                   bool
 )
 
@@ -51,6 +54,7 @@ func init() {
 	flag.StringVar(&flagCMBBinPath, flagKeyCMBBinPath, "", "Path to CMB binary.")
 	flag.StringVar(&flagMigrationsDir, flagKeyMigrationsDir, "", "Path to migration files dir.")
 	flag.StringVar(&flagTestsDataDir, "tests-data-dir", "/tmp/cmb-e2e", "Path to dir with temp tests data.")
+	flag.StringVar(&flagFilter, flagKeyFilter, "", "Filter for (comma separated) top level test names e.g. PingV1,AccommodationV3.")
 	flag.BoolVar(&flagDebug, flagKeyDebug, false, "Debug mode")
 }
 
@@ -101,17 +105,19 @@ func TestE2E(t *testing.T) {
 		flagExistingNetworkNodeURI,
 		existingNetworkAdminKey,
 		flagDebug,
+		flagFilter,
 	)
 	require.NoError(t, err)
 
 	testsRunner := runner.New(
 		suite.NewTest,
 		suite.Cleanup,
+		suite.TestFilter,
 	)
 	// #########################################################
 	// #### Registration of the e2e test cases is done here ####
 	// #########################################################
-	testsRunner.Register(t, "PingV1 request", tests.TestPingV1)
+	testsRunner.Register(t, "PingV1", tests.TestPingV1)
 	testsRunner.Register(t, "AccommodationV2", tests.TestAccommodationV2)
 	testsRunner.Register(t, "AccommodationV3", tests.TestAccommodationV3)
 	testsRunner.Register(t, "TransportV3", tests.TestTransportV3)

--- a/tests/e2e/runner/runner.go
+++ b/tests/e2e/runner/runner.go
@@ -4,6 +4,7 @@
 package runner
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -19,22 +20,29 @@ type (
 func New[T any](
 	beforeRun beforeRunFunc[T],
 	afterRun afterRunFunc[T],
+	filter []string,
 ) *Runner[T] {
 	return &Runner[T]{
-		beforeRun: beforeRun,
-		afterRun:  afterRun,
-		funcs:     make(map[string]runFunc[T]),
+		beforeRun:  beforeRun,
+		afterRun:   afterRun,
+		funcs:      make(map[string]runFunc[T]),
+		testFilter: filter,
 	}
 }
 
 // Not safe for concurrent use.
 type Runner[T any] struct {
-	beforeRun beforeRunFunc[T]
-	afterRun  afterRunFunc[T]
-	funcs     map[string]runFunc[T]
+	beforeRun  beforeRunFunc[T]
+	afterRun   afterRunFunc[T]
+	funcs      map[string]runFunc[T]
+	testFilter []string
 }
 
 func (r *Runner[T]) Register(t *testing.T, name string, f runFunc[T]) {
+	if len(r.testFilter) > 0 && !slices.Contains(r.testFilter, name) {
+		return
+	}
+
 	_, ok := r.funcs[name]
 	require.False(t, ok)
 	r.funcs[name] = f

--- a/tests/e2e/tests/suite.go
+++ b/tests/e2e/tests/suite.go
@@ -5,7 +5,9 @@ package tests
 
 import (
 	"context"
+	"fmt"
 	"path"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -39,6 +41,7 @@ func NewSuite(
 	existingNetworkNodeURI string,
 	existingNetworkAdminKey *secp256k1.PrivateKey,
 	debug bool,
+	filter string,
 ) (*Suite, error) {
 	zapConfig := zap.NewDevelopmentConfig()
 	zapConfig.Level.SetLevel(zap.InfoLevel)
@@ -49,6 +52,11 @@ func NewSuite(
 	if err != nil {
 		return nil, err
 	}
+	testFilterElements := strings.Split(filter, ",")
+	if len(testFilterElements) > 0 {
+		logger.Debug(fmt.Sprintf("Running only tests with the following names: %v", testFilterElements))
+	}
+
 	return &Suite{
 		logger:                  logger.Sugar(),
 		resourcesManager:        resources.NewManager(10000, 50000, 10),
@@ -60,6 +68,7 @@ func NewSuite(
 		testsDataDir:            testsDataDir,
 		existingNetworkNodeURI:  existingNetworkNodeURI,
 		existingNetworkAdminKey: existingNetworkAdminKey,
+		TestFilter:              testFilterElements,
 	}, nil
 }
 
@@ -75,6 +84,7 @@ type Suite struct {
 	existingNetworkNodeURI  string
 	existingNetworkAdminKey *secp256k1.PrivateKey
 	resourcesManager        *resources.Manager
+	TestFilter              []string
 }
 
 func (s *Suite) NewTest(t *testing.T) *Test {


### PR DESCRIPTION
Added --filter parameter (comma separated list) to the e2e.sh script which is passed through to the e2e test processing skipping the registration of tests which don't match the exact name given.

Usage example: scripts/e2e.sh --filter PingV1,AccommodationV3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new `--filter` option that lets you run a specific subset of end-to-end tests by matching test names.
  - Enhanced test execution control, enabling targeted testing sessions based on provided filter criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->