### PR TITLE
Update dates in Transport tests; Update e2e README.md

### DIFF
--- a/pp-mock/services/data/tripsv3_basic.json
+++ b/pp-mock/services/data/tripsv3_basic.json
@@ -14,13 +14,13 @@
 				},
 				"departure": {
 					"date_time": {
-						"seconds": 1715775600,
+						"seconds": 1747329600,
 						"nanos": 0
 					}
 				},
 				"arrival": {
 					"date_time": {
-						"seconds": 1715779200,
+						"seconds": 1747315200,
 						"nanos": 0
 					}
 				}
@@ -48,13 +48,13 @@
 				},
 				"departure": {
 					"date_time": {
-						"seconds": 1715782800,
+						"seconds": 1747318800,
 						"nanos": 0
 					}
 				},
 				"arrival": {
 					"date_time": {
-						"seconds": 1715786400,
+						"seconds": 1747322400,
 						"nanos": 0
 					}
 				}
@@ -68,13 +68,13 @@
 				},
 				"departure": {
 					"date_time": {
-						"seconds": 1715790000,
+						"seconds": 1747326000,
 						"nanos": 0
 					}
 				},
 				"arrival": {
 					"date_time": {
-						"seconds": 1715793600,
+						"seconds": 1747329600,
 						"nanos": 0
 					}
 				}

--- a/pp-mock/services/data/tripsv3_extended.json
+++ b/pp-mock/services/data/tripsv3_extended.json
@@ -19,13 +19,13 @@
 					},
 					"departure": {
 						"date_time": {
-							"seconds": 1715775600,
+							"seconds": 1747329600,
 							"nanos": 0
 						}
 					},
 					"arrival": {
 						"date_time": {
-							"seconds": 1715779200,
+							"seconds": 1747315200,
 							"nanos": 0
 						}
 					}
@@ -55,13 +55,13 @@
 					},
 					"departure": {
 						"date_time": {
-							"seconds": 1715782800,
+							"seconds": 1747318800,
 							"nanos": 0
 						}
 					},
 					"arrival": {
 						"date_time": {
-							"seconds": 1715786400,
+							"seconds": 1747322400,
 							"nanos": 0
 						}
 					}
@@ -77,13 +77,13 @@
 					},
 					"departure": {
 						"date_time": {
-							"seconds": 1715790000,
+							"seconds": 1747326000,
 							"nanos": 0
 						}
 					},
 					"arrival": {
 						"date_time": {
-							"seconds": 1715793600,
+							"seconds": 1747329600,
 							"nanos": 0
 						}
 					}

--- a/tests/e2e/README.MD
+++ b/tests/e2e/README.MD
@@ -2,7 +2,7 @@
 
 ```sh
 ./scripts/build.sh
-./scripts/build_partner_plugin.sh
+./scripts/build_partner_plugin_mock.sh
 ```
 
 ## Running tests
@@ -11,8 +11,8 @@
 
 The e2e.sh script does:
 
-* Download the latest released dependencies
-* Build and execute the end2end tests
+- Download the latest released dependencies
+- Build and execute the end2end tests
 
 Usage:
 
@@ -22,11 +22,11 @@ Usage:
 
 Flags (All optional):
 
-* `--clean` Always re-download dependencies instead of re-using already existing ones
-* `--debug` Adds extensive log output for the end-to-end tests, including JSON requests and responses for each test-case
-* `--filter` Comma-separated list of top-level test names to execute instead of all e.g. "PingV1,AccommodationV3".
-* `--caminogo` Overrides the version to download; if unspecified, the latest version will be used.
-* `--camino-conduit` Overrides the version to download; if unspecified, the latest version will be used.
+- `--clean` Always re-download dependencies instead of re-using already existing ones
+- `--debug` Adds extensive log output for the end-to-end tests, including JSON requests and responses for each test-case
+- `--filter` Comma-separated list of top-level test names to execute instead of all e.g. "PingV1,AccommodationV3".
+- `--caminogo` Overrides the version to download; if unspecified, the latest version will be used.
+- `--camino-conduit` Overrides the version to download; if unspecified, the latest version will be used.
 
 ### Running from VS Code
 


### PR DESCRIPTION
- Updates dates from 2024. to 2025. in Transport examples 
- Updates the e2e README.md with the correct script name for building mock plugin.