### PR TITLE
[E2E] Introduction of new bot sanity check 

### DIFF
--- a/pkg/cm_accounts/cm_accounts.go
+++ b/pkg/cm_accounts/cm_accounts.go
@@ -6,6 +6,7 @@ package cmaccounts
 import (
 	"context"
 	"crypto/ecdsa"
+	"errors"
 	"fmt"
 	"math/big"
 
@@ -34,6 +35,9 @@ var (
 	bigZero                            = big.NewInt(0)
 	chequeOperatorRole                 = crypto.Keccak256Hash([]byte("CHEQUE_OPERATOR_ROLE"))
 	managerCMAccountImplementationSlot = common.HexToHash(managerCMAccountImplementationSlotString)
+
+	ErrorNoChequeOperators        = errors.New("no cheque operators found (no bots found in cmAccount)")
+	ErrorUnableToObtainServiceFee = errors.New("unable to obtain service fee")
 )
 
 type Service interface {
@@ -135,8 +139,8 @@ func (s *service) GetFirstChequeOperator(ctx context.Context, cmAccountAddress c
 	}
 
 	if countBig.Cmp(bigZero) <= 0 { // count <= 0
-		s.logger.Error("no cheque operators found (no bots found in cmAccount)")
-		return common.Address{}, fmt.Errorf("no cheque operators found (no bots found in cmAccount)")
+		s.logger.Error(ErrorNoChequeOperators)
+		return common.Address{}, ErrorNoChequeOperators
 	}
 
 	botsAddress, err := cmAccount.GetRoleMember(&bind.CallOpts{Context: ctx}, chequeOperatorRole, big.NewInt(0))
@@ -223,7 +227,7 @@ func (s *service) GetServiceFee(
 		serviceFullName,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get service fee: %w", err)
+		return nil, fmt.Errorf("%w: %w", ErrorUnableToObtainServiceFee, err)
 	}
 	return serviceFee, nil
 }

--- a/pkg/cm_accounts/cm_accounts.go
+++ b/pkg/cm_accounts/cm_accounts.go
@@ -135,8 +135,8 @@ func (s *service) GetFirstChequeOperator(ctx context.Context, cmAccountAddress c
 	}
 
 	if countBig.Cmp(bigZero) <= 0 { // count <= 0
-		s.logger.Error("No cheque operators found")
-		return common.Address{}, nil
+		s.logger.Error("no cheque operators found (no bots found in cmAccount)")
+		return common.Address{}, fmt.Errorf("no cheque operators found (no bots found in cmAccount)")
 	}
 
 	botsAddress, err := cmAccount.GetRoleMember(&bind.CallOpts{Context: ctx}, chequeOperatorRole, big.NewInt(0))

--- a/tests/e2e/blockchain/client.go
+++ b/tests/e2e/blockchain/client.go
@@ -6,6 +6,7 @@ package blockchain
 import (
 	"context"
 	"crypto/ecdsa"
+	"errors"
 	"fmt"
 	"math/big"
 	"regexp"
@@ -27,7 +28,11 @@ import (
 
 const bookingTokenOperatorLibName = "12bd2f62b73a470fe0f6e02c33045f3191" //nolint:gosec // this is not credentials.
 
-var kycAdminRole = big.NewInt(0b100)
+var (
+	kycAdminRole = big.NewInt(0b100)
+
+	ErrorAddServiceTxFailed = errors.New("failed to issue AddService tx")
+)
 
 func newClient(
 	ctx context.Context,
@@ -182,7 +187,7 @@ func (c *Client) AddCMService(
 		[]string{},
 	)
 	if err != nil {
-		return fmt.Errorf("failed to issue AddService tx: %w", err)
+		return fmt.Errorf("%w: %w", ErrorAddServiceTxFailed, err)
 	}
 
 	if _, err := c.waitTxSucceed(ctx, tx); err != nil {

--- a/tests/e2e/bot/factory.go
+++ b/tests/e2e/bot/factory.go
@@ -97,6 +97,9 @@ func (f *Factory) CreateBot(
 	services []CMService,
 	skips *IntentionalSkip,
 ) (*Bot, chan error, error) {
+	if skips == nil {
+		skips = &IntentionalSkip{}
+	}
 	var err error
 	var cmAccountAddress common.Address
 

--- a/tests/e2e/bot/factory.go
+++ b/tests/e2e/bot/factory.go
@@ -83,10 +83,10 @@ type IntentionalSkip struct {
 	// Requires CMAccountCreation to be false.
 	PrefundBot bool
 	// Skips the registration of the bot in the cm-account.
-	// Requires CMAccountCreation to be false.
+	// Requires CMAccountCreation and PrefundOwner to be false.
 	BotRegistration bool
 	// Skips the registration of services in the cm-account.
-	// Requires CMAccountCreation to be false.
+	// Requires CMAccountCreation and PrefundOwner to be false.
 	ServiceRegistration bool
 }
 

--- a/tests/e2e/bot/factory.go
+++ b/tests/e2e/bot/factory.go
@@ -15,6 +15,7 @@ import (
 	"path"
 	"strconv"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/go-viper/mapstructure/v2"
 	"go.uber.org/zap"
@@ -70,37 +71,77 @@ type Factory struct {
 	bots                   []*Bot
 }
 
+// Intentionally skip some steps in bot creation.
+// Only used for very specific testing purposes.
+type IntentionalSkip struct {
+	// Skips the creation of the cm-account when setting up the bot.
+	CMAccountCreation bool
+	// Skips the transfer of funds to the cm-account owner.
+	// Requires CMAccountCreation to be false.
+	PrefundOwner bool
+	// Skips the transfer of funds to the bot.
+	// Requires CMAccountCreation to be false.
+	PrefundBot bool
+	// Skips the registration of the bot in the cm-account.
+	// Requires CMAccountCreation to be false.
+	BotRegistration bool
+	// Skips the registration of services in the cm-account.
+	// Requires CMAccountCreation to be false.
+	ServiceRegistration bool
+}
+
 func (f *Factory) CreateBot(
 	ctx context.Context,
 	enableRPCServer bool,
 	partnerPlugin *partnerplugin.PartnerPlugin,
 	services []CMService,
+	skips *IntentionalSkip,
 ) (*Bot, chan error, error) {
-	key, err := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
+	var err error
+	var cmAccountAddress common.Address
+
+	cmAccountOwnerKey, err := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to generate key: %w", err)
 	}
 
-	// Prepare CM account
-
-	ownerAddr := crypto.PubkeyToAddress(key.PublicKey)
-
-	cmAccountAddress, _, err := f.networkClient.CreateCMAccount(ctx, key)
+	botKey, err := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create CM account: %w", err)
+		return nil, nil, fmt.Errorf("failed to generate key: %w", err)
 	}
 
-	if err := f.networkClient.Transfer(ctx, f.networkClient.PrefundedKeys()[0], ownerAddr, e2eCommon.DefaultCMAccountOwnerFunds); err != nil {
-		return nil, nil, fmt.Errorf("failed to transfer funds to cm account owner: %w", err)
-	}
+	if !skips.CMAccountCreation {
+		botAddr := crypto.PubkeyToAddress(botKey.PublicKey)
+		cmAccountOwnerAddress := crypto.PubkeyToAddress(cmAccountOwnerKey.PublicKey)
+		cmAccountAddress, _, err = f.networkClient.CreateCMAccount(ctx, cmAccountOwnerKey)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to create CM account: %w", err)
+		}
 
-	if err := f.networkClient.AddBotToCMAccount(ctx, cmAccountAddress, key, ownerAddr); err != nil {
-		return nil, nil, fmt.Errorf("failed to add bot to CM account: %w", err)
-	}
+		if !skips.PrefundOwner {
+			if err := f.networkClient.Transfer(ctx, f.networkClient.PrefundedKeys()[0], cmAccountOwnerAddress, e2eCommon.DefaultCMAccountOwnerFunds); err != nil {
+				return nil, nil, fmt.Errorf("failed to transfer funds to cm account owner: %w", err)
+			}
 
-	for _, service := range services {
-		if err := f.networkClient.AddCMService(ctx, cmAccountAddress, key, service.Name, service.Fee); err != nil {
-			return nil, nil, fmt.Errorf("failed to add %s service to CM account: %w", service.Name, err)
+			if !skips.BotRegistration {
+				if err := f.networkClient.AddBotToCMAccount(ctx, cmAccountAddress, cmAccountOwnerKey, botAddr); err != nil {
+					return nil, nil, fmt.Errorf("failed to add bot to CM account: %w", err)
+				}
+			}
+
+			if !skips.ServiceRegistration {
+				for _, service := range services {
+					if err := f.networkClient.AddCMService(ctx, cmAccountAddress, cmAccountOwnerKey, service.Name, service.Fee); err != nil {
+						return nil, nil, fmt.Errorf("failed to add %s service to CM account: %w", service.Name, err)
+					}
+				}
+			}
+		}
+
+		if !skips.PrefundBot {
+			if err := f.networkClient.Transfer(ctx, f.networkClient.PrefundedKeys()[0], botAddr, e2eCommon.DefaultCMAccountOwnerFunds); err != nil {
+				return nil, nil, fmt.Errorf("failed to transfer funds to bot: %w", err)
+			}
 		}
 	}
 
@@ -118,7 +159,7 @@ func (f *Factory) CreateBot(
 
 	config := config.UnparsedConfig{
 		DeveloperMode:                       true,
-		BotKey:                              hex.EncodeToString(crypto.FromECDSA(key)),
+		BotKey:                              hex.EncodeToString(crypto.FromECDSA(botKey)),
 		CMAccountAddress:                    cmAccountAddress.Hex(),
 		ChainRPCURL:                         f.networkClient.ChainRPCURL(),
 		BookingTokenAddress:                 f.networkClient.BookingTokenContractAddress().Hex(),

--- a/tests/e2e/bot/factory.go
+++ b/tests/e2e/bot/factory.go
@@ -73,7 +73,7 @@ type Factory struct {
 
 // Intentionally skip some steps in bot creation.
 // Only used for very specific testing purposes.
-type IntentionalSkip struct {
+type Skip struct {
 	// Skips the creation of the cm-account when setting up the bot.
 	CMAccountCreation bool
 	// Skips the transfer of funds to the cm-account owner.
@@ -95,12 +95,11 @@ func (f *Factory) CreateBot(
 	enableRPCServer bool,
 	partnerPlugin *partnerplugin.PartnerPlugin,
 	services []CMService,
-	skips *IntentionalSkip,
+	skips *Skip,
 ) (*Bot, chan error, error) {
 	if skips == nil {
-		skips = &IntentionalSkip{}
+		skips = &Skip{}
 	}
-	var err error
 	var cmAccountAddress common.Address
 
 	cmAccountOwnerKey, err := ecdsa.GenerateKey(crypto.S256(), rand.Reader)

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -120,6 +120,7 @@ func TestE2E(t *testing.T) {
 	testsRunner.Register(t, "AccommodationV2", tests.TestAccommodationV2)
 	testsRunner.Register(t, "AccommodationV3", tests.TestAccommodationV3)
 	testsRunner.Register(t, "TransportV3", tests.TestTransportV3)
+	testsRunner.Register(t, "BotSanity", tests.TestBotSanity)
 
 	maxParallelRuns := 0
 	flagTestParallel := flag.Lookup("test.parallel")

--- a/tests/e2e/tests/test.go
+++ b/tests/e2e/tests/test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -37,7 +38,7 @@ func (tt *Test) CreateBot(
 	services []bot.CMService,
 ) *bot.Bot {
 	t.Helper()
-	bot, errChan, err := tt.botFactory.CreateBot(ctx, enableRPCServer, partnerPlugin, services)
+	bot, errChan, err := tt.botFactory.CreateBot(ctx, enableRPCServer, partnerPlugin, services, &bot.IntentionalSkip{})
 	require.NoError(t, err)
 	expectNoErrorAsync(t, errChan)
 	return bot
@@ -52,6 +53,18 @@ func (tt *Test) CreatePartnerPlugin(
 	require.NoError(t, err)
 	expectNoErrorAsync(t, errChan)
 	return partnerPlugin
+}
+
+func expectChannelErrorWithTimeout(t *testing.T, errChan chan error, errContent string, timeout time.Duration) {
+	t.Helper()
+
+	select {
+	case err := <-errChan:
+		require.Error(t, err)
+		require.Contains(t, err.Error(), errContent)
+	case <-time.After(timeout):
+		require.Fail(t, "timeout waiting for channel error with content: "+errContent)
+	}
 }
 
 func expectNoErrorAsync(t *testing.T, errChan chan error) {

--- a/tests/e2e/tests/test.go
+++ b/tests/e2e/tests/test.go
@@ -38,7 +38,7 @@ func (tt *Test) CreateBot(
 	services []bot.CMService,
 ) *bot.Bot {
 	t.Helper()
-	bot, errChan, err := tt.botFactory.CreateBot(ctx, enableRPCServer, partnerPlugin, services, &bot.IntentionalSkip{})
+	bot, errChan, err := tt.botFactory.CreateBot(ctx, enableRPCServer, partnerPlugin, services, &bot.Skip{})
 	require.NoError(t, err)
 	expectNoErrorAsync(t, errChan)
 	return bot

--- a/tests/e2e/tests/test_bot_sanity.go
+++ b/tests/e2e/tests/test_bot_sanity.go
@@ -1,0 +1,178 @@
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package tests
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	pingv1 "buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go/cmp/services/ping/v1"
+	typesv1 "buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go/cmp/types/v1"
+	"github.com/chain4travel/camino-messenger-bot/internal/metadata"
+	botGenerated "github.com/chain4travel/camino-messenger-bot/internal/rpc/generated"
+	"github.com/chain4travel/camino-messenger-bot/tests/e2e/bot"
+	partnerplugin "github.com/chain4travel/camino-messenger-bot/tests/e2e/partner_plugin"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+type botSanityServices struct {
+	supplierPartnerPlugin             *partnerplugin.PartnerPlugin
+	distributorBot                    *bot.Bot
+	supplierBotUnregistered           *bot.Bot
+	supplierBotUnregisteredNoServices *bot.Bot
+	supplierBotNoServices             *bot.Bot
+	supplierBotDifferentServices      *bot.Bot
+}
+
+func testBotSanitySetupWithSanityChecks(ctx context.Context, t *testing.T, tt *Test) (services *botSanityServices) {
+	services = &botSanityServices{}
+	services.supplierPartnerPlugin = tt.CreatePartnerPlugin(ctx, t)
+	var errChan chan error
+	var err error
+
+	t.Run("Missing CM-Account", func(t *testing.T) {
+		_, errChan, err = tt.botFactory.CreateBot(ctx, false, services.supplierPartnerPlugin,
+			[]bot.CMService{{Name: botGenerated.PingServiceV1, Fee: 100}},
+			&bot.IntentionalSkip{CMAccountCreation: true},
+		)
+
+		// This should fail already when the bot starts up as there is no
+		// CM-Account to use - we check that accordingly with the return value
+		require.NoError(t, err)
+		expectChannelErrorWithTimeout(t, errChan, "exit status 1", 5*time.Second)
+	})
+
+	t.Run("Missing CM-Account owner funds", func(t *testing.T) {
+		services.supplierBotUnregisteredNoServices, errChan, err = tt.botFactory.CreateBot(ctx, false, services.supplierPartnerPlugin,
+			[]bot.CMService{{Name: botGenerated.PingServiceV1, Fee: 100}},
+			&bot.IntentionalSkip{PrefundOwner: true},
+		)
+
+		// This bot skips the bot registration and the service registration
+		// But the CM-Account is created - therefore the creation in the context
+		// of the test should work but later when trying to use the bot it should fail
+		require.NoError(t, err)
+		expectNoErrorAsync(t, errChan)
+	})
+
+	t.Run("Missing global CM-Account-Manager services", func(t *testing.T) {
+		_, errChan, err = tt.botFactory.CreateBot(ctx, false, services.supplierPartnerPlugin,
+			[]bot.CMService{{Name: botGenerated.PingServiceV1, Fee: 100}},
+			&bot.IntentionalSkip{},
+		)
+
+		// This should fail already before the bot is even started up
+		// as the CM-Account-Manager services are not registered yet and the
+		// factory tries to register a service which is not available
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to issue AddService tx")
+	})
+
+	require.NoError(t, tt.caminoNetwork.Client.RegisterCMServices(ctx,
+		botGenerated.PingServiceV1,
+		botGenerated.MintServiceV3,
+	))
+
+	t.Run("Missing Bot-Registration", func(t *testing.T) {
+		services.supplierBotUnregistered, errChan, err = tt.botFactory.CreateBot(ctx, false, services.supplierPartnerPlugin,
+			[]bot.CMService{{Name: botGenerated.PingServiceV1, Fee: 100}},
+			&bot.IntentionalSkip{BotRegistration: true},
+		)
+
+		// This bot does actually have the CM-Account and prefunding of the owner
+		// But only the bot registration is missing in the CM-Account
+		// With that the distributor bot should not be able to find the supplier bot
+		// and fail with an error in a later test
+		require.NoError(t, err)
+		expectNoErrorAsync(t, errChan)
+	})
+
+	t.Run("Missing Bot service registration", func(t *testing.T) {
+		services.supplierBotNoServices, errChan, err = tt.botFactory.CreateBot(ctx, false, services.supplierPartnerPlugin,
+			[]bot.CMService{{Name: botGenerated.PingServiceV1, Fee: 100}},
+			&bot.IntentionalSkip{ServiceRegistration: true},
+		)
+
+		// This bot does actually have the CM-Account and prefunding of the owner
+		// and is also registered in the CM-Account **BUT** the service registration
+		// is missing - therefore the bot should already fail at startup trying
+		// to check the registered services in the CM-Account
+		require.NoError(t, err)
+		expectNoErrorAsync(t, errChan)
+	})
+
+	t.Run("Different services", func(t *testing.T) {
+		services.supplierBotDifferentServices, errChan, err = tt.botFactory.CreateBot(ctx, false, services.supplierPartnerPlugin,
+			[]bot.CMService{{Name: botGenerated.MintServiceV3, Fee: 100}},
+			&bot.IntentionalSkip{},
+		)
+
+		// All good here - just a different service used which should then
+		// fail in the later test
+		require.NoError(t, err)
+		expectNoErrorAsync(t, errChan)
+	})
+
+	// bot without partnerPlugin and with rpc server (distributor)
+	services.distributorBot = tt.CreateBot(ctx, t, true, nil, nil)
+
+	return services
+}
+
+func testBotSanitySendCommonRequest(ctx context.Context, pingMessage string, distributorBot *bot.Bot, supplierBot *bot.Bot) error {
+	req := &pingv1.PingRequest{
+		Header:      &typesv1.RequestHeader{BaseHeader: &typesv1.Header{}},
+		PingMessage: pingMessage,
+		Timestamp:   timestamppb.Now(),
+	}
+	_, err := distributorBot.PingServiceV1.Ping(
+		requestContext(ctx, &metadata.Metadata{
+			Recipient: supplierBot.CMAccountAddress().Hex(),
+		}),
+		req,
+	)
+	return err
+}
+
+func testBotSanityVerify(ctx context.Context, t *testing.T, services *botSanityServices) {
+	t.Run("Supplier bot: unregistered / no services", func(t *testing.T) {
+		err := testBotSanitySendCommonRequest(ctx, "unregistered / no services", services.distributorBot, services.supplierBotUnregisteredNoServices)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "no cheque operators found (no bots found in cmAccount)")
+	})
+
+	t.Run("Supplier bot: unregistered / with services", func(t *testing.T) {
+		err := testBotSanitySendCommonRequest(ctx, "unregistered / with services", services.distributorBot, services.supplierBotUnregistered)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "no cheque operators found (no bots found in cmAccount)")
+	})
+
+	t.Run("Supplier bot: registered / no services", func(t *testing.T) {
+		err := testBotSanitySendCommonRequest(ctx, "registered / no services", services.distributorBot, services.supplierBotNoServices)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to get service fee: execution reverted")
+	})
+
+	t.Run("Supplier bot: registered / different services", func(t *testing.T) {
+		err := testBotSanitySendCommonRequest(ctx, "registered / different services", services.distributorBot, services.supplierBotDifferentServices)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to get service fee: execution reverted")
+	})
+}
+
+func TestBotSanity(t *testing.T, tt *Test) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	var services *botSanityServices
+
+	t.Run("Startup and sanity checks", func(t *testing.T) {
+		services = testBotSanitySetupWithSanityChecks(ctx, t, tt)
+	})
+
+	t.Run("Verification", func(t *testing.T) {
+		testBotSanityVerify(ctx, t, services)
+	})
+}

--- a/tests/e2e/tests/test_bot_sanity.go
+++ b/tests/e2e/tests/test_bot_sanity.go
@@ -98,8 +98,9 @@ func testBotSanitySetupWithSanityChecks(ctx context.Context, t *testing.T, tt *T
 
 		// This bot does actually have the CM-Account and prefunding of the owner
 		// and is also registered in the CM-Account **BUT** the service registration
-		// is missing - therefore the bot should already fail at startup trying
-		// to check the registered services in the CM-Account
+		// is missing - this is checked by the bot but results only in a warning
+		// inside of the logs. We can later use this bot to check if the distributor
+		// bot acts correctly by rejecting this supplier bot as the required service is missing
 		require.NoError(t, err)
 		expectNoErrorAsync(t, errChan)
 	})

--- a/tests/e2e/tests/test_bot_sanity.go
+++ b/tests/e2e/tests/test_bot_sanity.go
@@ -12,6 +12,8 @@ import (
 	typesv1 "buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go/cmp/types/v1"
 	"github.com/chain4travel/camino-messenger-bot/internal/metadata"
 	botGenerated "github.com/chain4travel/camino-messenger-bot/internal/rpc/generated"
+	cmaccounts "github.com/chain4travel/camino-messenger-bot/pkg/cm_accounts"
+	"github.com/chain4travel/camino-messenger-bot/tests/e2e/blockchain"
 	"github.com/chain4travel/camino-messenger-bot/tests/e2e/bot"
 	partnerplugin "github.com/chain4travel/camino-messenger-bot/tests/e2e/partner_plugin"
 	"github.com/stretchr/testify/require"
@@ -36,7 +38,7 @@ func testBotSanitySetupWithSanityChecks(ctx context.Context, t *testing.T, tt *T
 	t.Run("Missing CM-Account", func(t *testing.T) {
 		_, errChan, err = tt.botFactory.CreateBot(ctx, false, services.supplierPartnerPlugin,
 			[]bot.CMService{{Name: botGenerated.PingServiceV1, Fee: 100}},
-			&bot.IntentionalSkip{CMAccountCreation: true},
+			&bot.Skip{CMAccountCreation: true},
 		)
 
 		// This should fail already when the bot starts up as there is no
@@ -48,7 +50,7 @@ func testBotSanitySetupWithSanityChecks(ctx context.Context, t *testing.T, tt *T
 	t.Run("Missing CM-Account owner funds", func(t *testing.T) {
 		services.supplierBotUnregisteredNoServices, errChan, err = tt.botFactory.CreateBot(ctx, false, services.supplierPartnerPlugin,
 			[]bot.CMService{{Name: botGenerated.PingServiceV1, Fee: 100}},
-			&bot.IntentionalSkip{PrefundOwner: true},
+			&bot.Skip{PrefundOwner: true},
 		)
 
 		// This bot skips the bot registration and the service registration
@@ -61,14 +63,14 @@ func testBotSanitySetupWithSanityChecks(ctx context.Context, t *testing.T, tt *T
 	t.Run("Missing global CM-Account-Manager services", func(t *testing.T) {
 		_, errChan, err = tt.botFactory.CreateBot(ctx, false, services.supplierPartnerPlugin,
 			[]bot.CMService{{Name: botGenerated.PingServiceV1, Fee: 100}},
-			&bot.IntentionalSkip{},
+			&bot.Skip{},
 		)
 
 		// This should fail already before the bot is even started up
 		// as the CM-Account-Manager services are not registered yet and the
 		// factory tries to register a service which is not available
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "failed to issue AddService tx")
+		require.Contains(t, err.Error(), blockchain.ErrorAddServiceTxFailed.Error())
 	})
 
 	require.NoError(t, tt.caminoNetwork.Client.RegisterCMServices(ctx,
@@ -79,7 +81,7 @@ func testBotSanitySetupWithSanityChecks(ctx context.Context, t *testing.T, tt *T
 	t.Run("Missing Bot-Registration", func(t *testing.T) {
 		services.supplierBotUnregistered, errChan, err = tt.botFactory.CreateBot(ctx, false, services.supplierPartnerPlugin,
 			[]bot.CMService{{Name: botGenerated.PingServiceV1, Fee: 100}},
-			&bot.IntentionalSkip{BotRegistration: true},
+			&bot.Skip{BotRegistration: true},
 		)
 
 		// This bot does actually have the CM-Account and prefunding of the owner
@@ -93,7 +95,7 @@ func testBotSanitySetupWithSanityChecks(ctx context.Context, t *testing.T, tt *T
 	t.Run("Missing Bot service registration", func(t *testing.T) {
 		services.supplierBotNoServices, errChan, err = tt.botFactory.CreateBot(ctx, false, services.supplierPartnerPlugin,
 			[]bot.CMService{{Name: botGenerated.PingServiceV1, Fee: 100}},
-			&bot.IntentionalSkip{ServiceRegistration: true},
+			&bot.Skip{ServiceRegistration: true},
 		)
 
 		// This bot does actually have the CM-Account and prefunding of the owner
@@ -108,7 +110,7 @@ func testBotSanitySetupWithSanityChecks(ctx context.Context, t *testing.T, tt *T
 	t.Run("Different services", func(t *testing.T) {
 		services.supplierBotDifferentServices, errChan, err = tt.botFactory.CreateBot(ctx, false, services.supplierPartnerPlugin,
 			[]bot.CMService{{Name: botGenerated.MintServiceV3, Fee: 100}},
-			&bot.IntentionalSkip{},
+			&bot.Skip{},
 		)
 
 		// All good here - just a different service used which should then
@@ -142,25 +144,25 @@ func testBotSanityVerify(ctx context.Context, t *testing.T, services *botSanityS
 	t.Run("Supplier bot: unregistered / no services", func(t *testing.T) {
 		err := testBotSanitySendCommonRequest(ctx, "unregistered / no services", services.distributorBot, services.supplierBotUnregisteredNoServices)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "no cheque operators found (no bots found in cmAccount)")
+		require.Contains(t, err.Error(), cmaccounts.ErrorNoChequeOperators.Error())
 	})
 
 	t.Run("Supplier bot: unregistered / with services", func(t *testing.T) {
 		err := testBotSanitySendCommonRequest(ctx, "unregistered / with services", services.distributorBot, services.supplierBotUnregistered)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "no cheque operators found (no bots found in cmAccount)")
+		require.Contains(t, err.Error(), cmaccounts.ErrorNoChequeOperators.Error())
 	})
 
 	t.Run("Supplier bot: registered / no services", func(t *testing.T) {
 		err := testBotSanitySendCommonRequest(ctx, "registered / no services", services.distributorBot, services.supplierBotNoServices)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "failed to get service fee: execution reverted")
+		require.Contains(t, err.Error(), cmaccounts.ErrorUnableToObtainServiceFee.Error())
 	})
 
 	t.Run("Supplier bot: registered / different services", func(t *testing.T) {
 		err := testBotSanitySendCommonRequest(ctx, "registered / different services", services.distributorBot, services.supplierBotDifferentServices)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "failed to get service fee: execution reverted")
+		require.Contains(t, err.Error(), cmaccounts.ErrorUnableToObtainServiceFee.Error())
 	})
 }
 

--- a/tests/e2e/tests/test_ping.go
+++ b/tests/e2e/tests/test_ping.go
@@ -34,13 +34,9 @@ func testPingV1Setup(ctx context.Context, t *testing.T, tt *Test) (*partnerplugi
 	return supplierPartnerPlugin, supplierBot, distributorBot
 }
 
-func TestPingV1(t *testing.T, tt *Test) {
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
-	defer cancel()
-	_, supplierBot, distributorBot := testPingV1Setup(ctx, t, tt)
-
+func testPingV1Service(ctx context.Context, t *testing.T, tt *Test, distributorBot *bot.Bot, supplierBot *bot.Bot) {
 	pingMessage := "ping"
-	expectedResponceMessageSubString := fmt.Sprintf("Ping response to [%s] with request ID:", pingMessage)
+	expectedResponseMessageSubString := fmt.Sprintf("Ping response to [%s] with request ID:", pingMessage)
 
 	req := &pingv1.PingRequest{
 		Header:      &typesv1.RequestHeader{BaseHeader: &typesv1.Header{}},
@@ -58,5 +54,19 @@ func TestPingV1(t *testing.T, tt *Test) {
 	debugPrintRequestResponse(tt, getCurrentFuncName(), req, resp)
 	require.Equal(t, typesv1.StatusType_STATUS_TYPE_SUCCESS, resp.Header.Status, "unexpected response status")
 	require.Empty(t, resp.Header.Alerts, "unexpected response alerts")
-	require.Contains(t, resp.PingMessage, expectedResponceMessageSubString, "unexpected response message")
+	require.Contains(t, resp.PingMessage, expectedResponseMessageSubString, "unexpected response message")
+}
+
+func TestPingV1(t *testing.T, tt *Test) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	var supplierBot *bot.Bot
+	var distributorBot *bot.Bot
+
+	t.Run("Setup", func(t *testing.T) {
+		_, supplierBot, distributorBot = testPingV1Setup(ctx, t, tt)
+	})
+	t.Run("Ping", func(t *testing.T) {
+		testPingV1Service(ctx, t, tt, distributorBot, supplierBot)
+	})
 }


### PR DESCRIPTION
* Introduction of new bot sanity check which checks potential startup issues of a supplier bot and handling of misconfiguration of a supplier bot against a distributor bot via p2p messages. 
* Fixed an issue in the bot where a not found bot in the cm-account raised no error. 
* Minor cleanup of the PingV1 test making it more uniform to the other tests.