### PR TITLE
Small cleanup

### DIFF
--- a/internal/event_listener/storage/sqlite/storage.go
+++ b/internal/event_listener/storage/sqlite/storage.go
@@ -17,7 +17,7 @@ import (
 	"go.uber.org/zap"
 )
 
-const dbName = "scheduler"
+const dbName = "event_listener"
 
 //go:embed migrations/*.sql
 var embedMigrations embed.FS

--- a/pkg/chequehandler/cheque_handler.go
+++ b/pkg/chequehandler/cheque_handler.go
@@ -195,7 +195,8 @@ func (ch *evmChequeHandler) IssueCheque(
 			ch.logger.Errorf("failed to verify cheque with smart contract after getting last cash-in: %v", err)
 			return nil, fmt.Errorf("failed to verify cheque with smart contract: %w", err)
 		} else if !isChequeValid {
-			ch.logger.Errorf("failed to issue valid cheque")
+			b, _ := signedCheque.MarshalJSON()
+			ch.logger.Errorf("failed to issue valid cheque: %s", string(b))
 			return nil, fmt.Errorf("failed to issue valid cheque")
 		}
 	}
@@ -348,10 +349,13 @@ func (ch *evmChequeHandler) CashIn(ctx context.Context) error {
 			continue
 		}
 
+		wg.Add(1)
 		go func(txID common.Hash) {
 			_ = ch.checkCashInStatus(context.Background(), txID)
 		}(chequeRecord.TxID)
 	}
+
+	wg.Wait()
 
 	return nil
 }
@@ -370,11 +374,16 @@ func (ch *evmChequeHandler) CheckCashInStatus(ctx context.Context) error {
 		return err
 	}
 
+	wg := sync.WaitGroup{}
+
 	for _, chequeRecord := range chequeRecords {
+		wg.Add(1)
 		go func(txID common.Hash) {
 			_ = ch.checkCashInStatus(ctx, txID)
 		}(chequeRecord.TxID)
 	}
+
+	wg.Wait()
 
 	return nil
 }

--- a/pkg/chequehandler/cheque_handler.go
+++ b/pkg/chequehandler/cheque_handler.go
@@ -351,6 +351,7 @@ func (ch *evmChequeHandler) CashIn(ctx context.Context) error {
 
 		wg.Add(1)
 		go func(txID common.Hash) {
+			defer wg.Done()
 			_ = ch.checkCashInStatus(context.Background(), txID)
 		}(chequeRecord.TxID)
 	}
@@ -379,6 +380,7 @@ func (ch *evmChequeHandler) CheckCashInStatus(ctx context.Context) error {
 	for _, chequeRecord := range chequeRecords {
 		wg.Add(1)
 		go func(txID common.Hash) {
+			defer wg.Done()
 			_ = ch.checkCashInStatus(ctx, txID)
 		}(chequeRecord.TxID)
 	}

--- a/tests/e2e/blockchain/network.go
+++ b/tests/e2e/blockchain/network.go
@@ -280,13 +280,13 @@ func (n *Network) startNewNode(
 	if err := os.MkdirAll(nodeDir, 0o755); err != nil {
 		return nil, nil, fmt.Errorf("failed to create node directory: %w", err)
 	}
-	logfile, err := os.OpenFile(path.Join(nodeDir, fmt.Sprintf("node-%d.log", nodeIndex)), os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o600)
+	logFile, err := os.OpenFile(path.Join(nodeDir, fmt.Sprintf("node-%d.log", nodeIndex)), os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o600)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create node log file: %w", err)
 	}
 
-	cmd.Stdout = logfile
-	cmd.Stderr = logfile
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
 
 	if err := cmd.Start(); err != nil {
 		return nil, nil, fmt.Errorf("failed to start node (%d): %w", cmd.Process.Pid, err)
@@ -296,7 +296,7 @@ func (n *Network) startNewNode(
 		logger:  n.logger,
 		pid:     cmd.Process.Pid,
 		nodeURI: fmt.Sprintf("localhost:%d", httpPort),
-		logfile: logfile,
+		logFile: logFile,
 	}
 
 	// health check will fail if its 1 node network, so we're doing bootstrap check

--- a/tests/e2e/blockchain/node.go
+++ b/tests/e2e/blockchain/node.go
@@ -22,7 +22,7 @@ type Node struct {
 	pid     int
 	client  *Client
 	nodeURI string
-	logfile *os.File
+	logFile *os.File
 }
 
 func (n *Node) Stop(ctx context.Context) error {
@@ -30,8 +30,8 @@ func (n *Node) Stop(ctx context.Context) error {
 		return fmt.Errorf("failed to stop node process with pid %d: %w", n.pid, err)
 	}
 	n.logger.Debugf("Blockchain node (pid %d) stopped", n.pid)
-	if err := n.logfile.Close(); err != nil {
-		return fmt.Errorf("failed to close node logfile: %w", err)
+	if err := n.logFile.Close(); err != nil {
+		return fmt.Errorf("failed to close node logFile: %w", err)
 	}
 	return nil
 }

--- a/tests/e2e/bot/bot.go
+++ b/tests/e2e/bot/bot.go
@@ -25,7 +25,7 @@ type Bot struct {
 	logger           *zap.SugaredLogger
 	pid              int
 	cmAccountAddress common.Address
-	logfile          *os.File
+	logFile          *os.File
 
 	*rpcClient
 }
@@ -38,8 +38,8 @@ func (b *Bot) Stop(ctx context.Context) error {
 		return fmt.Errorf("failed to stop cmb process with pid %d: %w", b.pid, err)
 	}
 	b.logger.Debugf("Bot (pid %d) stopped", b.pid)
-	if err := b.logfile.Close(); err != nil {
-		return fmt.Errorf("failed to close partner plugin logfile: %w", err)
+	if err := b.logFile.Close(); err != nil {
+		return fmt.Errorf("failed to close partner plugin logFile: %w", err)
 	}
 	return nil
 }

--- a/tests/e2e/bot/bot.go
+++ b/tests/e2e/bot/bot.go
@@ -39,7 +39,7 @@ func (b *Bot) Stop(ctx context.Context) error {
 	}
 	b.logger.Debugf("Bot (pid %d) stopped", b.pid)
 	if err := b.logFile.Close(); err != nil {
-		return fmt.Errorf("failed to close partner plugin logFile: %w", err)
+		return fmt.Errorf("failed to close cmb logFile: %w", err)
 	}
 	return nil
 }

--- a/tests/e2e/bot/factory.go
+++ b/tests/e2e/bot/factory.go
@@ -17,11 +17,9 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/go-viper/mapstructure/v2"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
-	"gopkg.in/yaml.v3"
 
 	"github.com/chain4travel/camino-messenger-bot/v11/config"
 	"github.com/chain4travel/camino-messenger-bot/v11/proto/pb/readiness"
@@ -194,19 +192,9 @@ func (f *Factory) CreateBot(
 		return nil, nil, fmt.Errorf("failed to create bot data dir: %w", err)
 	}
 
-	unparsedMap := &map[string]any{}
-	if err := mapstructure.Decode(config, unparsedMap); err != nil {
-		return nil, nil, fmt.Errorf("failed to parse config into map: %w", err)
-	}
-	configBytes, err := yaml.Marshal(unparsedMap)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to marshal config map into yaml: %w", err)
-	}
-
 	configPath := path.Join(botDir, "config.yaml")
-
-	if err := os.WriteFile(configPath, configBytes, 0o600); err != nil {
-		return nil, nil, fmt.Errorf("failed to write config file: %w", err)
+	if err := e2eCommon.WriteYAMLConfig(config, configPath); err != nil {
+		return nil, nil, fmt.Errorf("failed to write bot config file: %w", err)
 	}
 
 	// Prepare grpc client for bot
@@ -223,12 +211,12 @@ func (f *Factory) CreateBot(
 
 	cmd := exec.Command(f.binPath, "--config", configPath) //nolint:gosec // this is a cmb binary, not some injection.
 
-	logfile, err := os.OpenFile(path.Join(botDir, "bot.log"), os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o600)
+	logFile, err := os.OpenFile(path.Join(botDir, "bot.log"), os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o600)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to open bot log file: %w", err)
 	}
-	cmd.Stdout = logfile
-	cmd.Stderr = logfile
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
 
 	if err := cmd.Start(); err != nil {
 		return nil, nil, fmt.Errorf("failed to start bot (%d): %w", cmd.Process.Pid, err)
@@ -242,7 +230,7 @@ func (f *Factory) CreateBot(
 			Client:                 e2eGenerated.NewClient(clientConnection),
 		},
 		cmAccountAddress: cmAccountAddress,
-		logfile:          logfile,
+		logFile:          logFile,
 	}
 
 	// Await bot readiness

--- a/tests/e2e/common/yaml-config.go
+++ b/tests/e2e/common/yaml-config.go
@@ -1,0 +1,29 @@
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package common
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/go-viper/mapstructure/v2"
+	"gopkg.in/yaml.v3"
+)
+
+func WriteYAMLConfig(config any, configPath string) error {
+	unparsedMap := &map[string]any{}
+	if err := mapstructure.Decode(config, unparsedMap); err != nil {
+		return fmt.Errorf("failed to parse config into map: %w", err)
+	}
+	configBytes, err := yaml.Marshal(unparsedMap)
+	if err != nil {
+		return fmt.Errorf("failed to marshal config map into yaml: %w", err)
+	}
+
+	if err := os.WriteFile(configPath, configBytes, 0o600); err != nil {
+		return fmt.Errorf("failed to write config file: %w", err)
+	}
+
+	return nil
+}

--- a/tests/e2e/matrix/conduit.go
+++ b/tests/e2e/matrix/conduit.go
@@ -83,13 +83,13 @@ func StartNewMatrixServer(
 		"CONDUIT_PORT="+strconv.Itoa(int(port)),
 	)
 
-	logfile, err := os.OpenFile(matrixDir+"/conduit-server.log", os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o600)
+	logFile, err := os.OpenFile(matrixDir+"/conduit-server.log", os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o600)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create conduit server log file: %w", err)
 	}
 
-	cmd.Stdout = logfile
-	cmd.Stderr = logfile
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
 	if err := cmd.Start(); err != nil {
 		return nil, nil, fmt.Errorf("failed to start matrix server (%d): %w", cmd.Process.Pid, err)
 	}
@@ -100,7 +100,7 @@ func StartNewMatrixServer(
 		matrixDir:            matrixDir,
 		client:               client,
 		networkFeeBotAddress: crypto.PubkeyToAddress(networkFeeKey.PublicKey),
-		logfile:              logfile,
+		logFile:              logFile,
 	}
 
 	if err := m.awaitReady(ctx); err != nil {
@@ -144,7 +144,7 @@ type Server struct {
 	client                     *mautrix.Client
 	networkFeeBotAddress       common.Address
 	networkFeeCMAccountAddress common.Address
-	logfile                    *os.File
+	logFile                    *os.File
 }
 
 func (m *Server) Host() *url.URL {
@@ -159,8 +159,8 @@ func (m *Server) Stop(ctx context.Context) error {
 	if err := process.StopProcess(ctx, m.pid); err != nil {
 		return fmt.Errorf("failed to stop matrix server process with pid %d: %w", m.pid, err)
 	}
-	if err := m.logfile.Close(); err != nil {
-		return fmt.Errorf("failed to close matrix server logfile: %w", err)
+	if err := m.logFile.Close(); err != nil {
+		return fmt.Errorf("failed to close matrix server logFile: %w", err)
 	}
 	m.logger.Debugf("Matrix server (pid %d) stopped", m.pid)
 	return nil

--- a/tests/e2e/partner_plugin/partner_plugin.go
+++ b/tests/e2e/partner_plugin/partner_plugin.go
@@ -49,7 +49,7 @@ func (pp *PartnerPlugin) Stop(ctx context.Context) error {
 	}
 	pp.logger.Debugf("Partner plugin (pid %d) stopped", pp.pid)
 	if err := pp.logFile.Close(); err != nil {
-		return fmt.Errorf("failed to close partner plugin logfile: %w", err)
+		return fmt.Errorf("failed to close partner plugin logFile: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
- Naming cleanup
- Improve cheque handler logging
- Make cheque handler cash-in related methods wait for all operations to complete before return.
- Fix event listener migration db name
- Extract e2e test bot yaml-config writing into its own general method (will be reused later)