### PR TITLE
Add MaxAllowedServiceFee

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -33,7 +33,7 @@ type Config struct {
 	ChequeExpirationTime             *big.Int // seconds
 	MinChequeDurationUntilExpiration *big.Int // seconds
 	CashInPeriod                     time.Duration
-	MaxAllowedServiceFee             uint64 // aCAM
+	MaxAllowedServiceFee             *big.Int // aCAM
 
 	ResponseTimeout time.Duration
 
@@ -105,7 +105,7 @@ type UnparsedConfig struct {
 	ChequeExpirationTime             uint64 `mapstructure:"cheque_expiration_time"`               // seconds
 	MinChequeDurationUntilExpiration uint64 `mapstructure:"min_cheque_duration_until_expiration"` // seconds
 	CashInPeriod                     int64  `mapstructure:"cash_in_period"`                       // seconds
-	MaxAllowedServiceFee             uint64 `mapstructure:"max_allowed_service_fee"`              // aCAM
+	MaxAllowedServiceFee             string `mapstructure:"max_allowed_service_fee"`              // aCAM
 
 	ResponseTimeout int64 `mapstructure:"response_timeout"` // milliseconds
 
@@ -147,7 +147,7 @@ func (cfg *Config) unparse() *UnparsedConfig {
 		ChequeExpirationTime:                cfg.ChequeExpirationTime.Uint64(),
 		MinChequeDurationUntilExpiration:    cfg.MinChequeDurationUntilExpiration.Uint64(),
 		CashInPeriod:                        int64(cfg.CashInPeriod / time.Second),
-		MaxAllowedServiceFee:                cfg.MaxAllowedServiceFee,
+		MaxAllowedServiceFee:                cfg.MaxAllowedServiceFee.String(),
 		ResponseTimeout:                     int64(cfg.ResponseTimeout / time.Millisecond),
 		RecordExpiration:                    cfg.RecordExpiration,
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -33,6 +33,7 @@ type Config struct {
 	ChequeExpirationTime             *big.Int // seconds
 	MinChequeDurationUntilExpiration *big.Int // seconds
 	CashInPeriod                     time.Duration
+	MaxAllowedServiceFee             uint64 // aCAM
 
 	ResponseTimeout time.Duration
 
@@ -104,6 +105,7 @@ type UnparsedConfig struct {
 	ChequeExpirationTime             uint64 `mapstructure:"cheque_expiration_time"`               // seconds
 	MinChequeDurationUntilExpiration uint64 `mapstructure:"min_cheque_duration_until_expiration"` // seconds
 	CashInPeriod                     int64  `mapstructure:"cash_in_period"`                       // seconds
+	MaxAllowedServiceFee             uint64 `mapstructure:"max_allowed_service_fee"`              // aCAM
 
 	ResponseTimeout int64 `mapstructure:"response_timeout"` // milliseconds
 
@@ -145,6 +147,7 @@ func (cfg *Config) unparse() *UnparsedConfig {
 		ChequeExpirationTime:                cfg.ChequeExpirationTime.Uint64(),
 		MinChequeDurationUntilExpiration:    cfg.MinChequeDurationUntilExpiration.Uint64(),
 		CashInPeriod:                        int64(cfg.CashInPeriod / time.Second),
+		MaxAllowedServiceFee:                cfg.MaxAllowedServiceFee,
 		ResponseTimeout:                     int64(cfg.ResponseTimeout / time.Millisecond),
 		RecordExpiration:                    cfg.RecordExpiration,
 	}

--- a/config/config_reader.go
+++ b/config/config_reader.go
@@ -121,6 +121,18 @@ func (cr *reader) parseConfig(cfg *UnparsedConfig) (*Config, error) {
 		return nil, err
 	}
 
+	maxAllowedServiceFee, ok := new(big.Int).SetString(cfg.MaxAllowedServiceFee, 10)
+	if !ok {
+		err := fmt.Errorf("invalid max allowed service fee: %s", cfg.MaxAllowedServiceFee)
+		cr.logger.Error(err)
+		return nil, err
+	}
+	if maxAllowedServiceFee.Sign() < 0 {
+		err := errors.New("max allowed service fee must be non-negative")
+		cr.logger.Error(err)
+		return nil, err
+	}
+
 	return &Config{
 		DB: SQLiteDBConfig{
 			Common: cfg.DB,
@@ -152,7 +164,7 @@ func (cr *reader) parseConfig(cfg *UnparsedConfig) (*Config, error) {
 		ChequeExpirationTime:                big.NewInt(0).SetUint64(cfg.ChequeExpirationTime),
 		MinChequeDurationUntilExpiration:    big.NewInt(0).SetUint64(cfg.MinChequeDurationUntilExpiration),
 		CashInPeriod:                        time.Duration(cfg.CashInPeriod) * time.Second,
-		MaxAllowedServiceFee:                cfg.MaxAllowedServiceFee,
+		MaxAllowedServiceFee:                maxAllowedServiceFee,
 		ResponseTimeout:                     time.Duration(cfg.ResponseTimeout) * time.Millisecond,
 		RecordExpiration:                    cfg.RecordExpiration,
 	}, nil

--- a/config/config_reader.go
+++ b/config/config_reader.go
@@ -152,6 +152,7 @@ func (cr *reader) parseConfig(cfg *UnparsedConfig) (*Config, error) {
 		ChequeExpirationTime:                big.NewInt(0).SetUint64(cfg.ChequeExpirationTime),
 		MinChequeDurationUntilExpiration:    big.NewInt(0).SetUint64(cfg.MinChequeDurationUntilExpiration),
 		CashInPeriod:                        time.Duration(cfg.CashInPeriod) * time.Second,
+		MaxAllowedServiceFee:                cfg.MaxAllowedServiceFee,
 		ResponseTimeout:                     time.Duration(cfg.ResponseTimeout) * time.Millisecond,
 		RecordExpiration:                    cfg.RecordExpiration,
 	}, nil

--- a/config/flags.go
+++ b/config/flags.go
@@ -30,6 +30,7 @@ func Flags() *pflag.FlagSet {
 	flags.Uint64("cheque_expiration_time", 3600*24*30*7, "Cheque expiration time (in seconds).")
 	flags.Uint64("min_cheque_duration_until_expiration", 3600*24*30*6, "Minimum valid duration until cheque expiration (in seconds).")
 	flags.Int64("cash_in_period", 3600*24, "Cash-in period (in seconds).")
+	flags.Uint64("max_allowed_service_fee", 1000000000000000000, "Maximum allowed service fee (in aCAM).")
 	flags.Int64("response_timeout", 3000, "The messenger timeout (in milliseconds).")
 
 	// DB config flags

--- a/config/flags.go
+++ b/config/flags.go
@@ -30,7 +30,7 @@ func Flags() *pflag.FlagSet {
 	flags.Uint64("cheque_expiration_time", 3600*24*30*7, "Cheque expiration time (in seconds).")
 	flags.Uint64("min_cheque_duration_until_expiration", 3600*24*30*6, "Minimum valid duration until cheque expiration (in seconds).")
 	flags.Int64("cash_in_period", 3600*24, "Cash-in period (in seconds).")
-	flags.Uint64("max_allowed_service_fee", 1000000000000000000, "Maximum allowed service fee (in aCAM).")
+	flags.String("max_allowed_service_fee", "1000000000000000000", "Maximum allowed service fee (in aCAM).")
 	flags.Int64("response_timeout", 3000, "The messenger timeout (in milliseconds).")
 
 	// DB config flags

--- a/config/test_config.yaml
+++ b/config/test_config.yaml
@@ -10,6 +10,7 @@ developer_mode: true
 e2e_test_mode: false
 matrix:
     host: messenger.chain4travel.com
+max_allowed_service_fee: 1000000000000000000
 min_cheque_duration_until_expiration: 15552000
 network_fee_recipient_bot_address: 0xff6BAC3d972680515cbB59fCB6Db6deB13Eb0E91
 network_fee_recipient_cm_account: 0xF6bA5c68A505559c170dC7a30448Ed64D8b9Bc3B

--- a/config/test_config.yaml
+++ b/config/test_config.yaml
@@ -10,7 +10,7 @@ developer_mode: true
 e2e_test_mode: false
 matrix:
     host: messenger.chain4travel.com
-max_allowed_service_fee: 1000000000000000000
+max_allowed_service_fee: "1000000000000000000"
 min_cheque_duration_until_expiration: 15552000
 network_fee_recipient_bot_address: 0xff6BAC3d972680515cbB59fCB6Db6deB13Eb0E91
 network_fee_recipient_cm_account: 0xF6bA5c68A505559c170dC7a30448Ed64D8b9Bc3B

--- a/examples/config/camino-messenger-bot-distributor-camino.yaml
+++ b/examples/config/camino-messenger-bot-distributor-camino.yaml
@@ -44,6 +44,8 @@ network_fee_recipient_bot_address: 0xbeb027D2f439805E17EAA16Da26c1FCa68a30232
 # matrix application service cm account address
 network_fee_recipient_cm_account: 0x16DFfB3911BB0b1B53eF4d774804381f0B38B5d7
 
+max_allowed_service_fee: 1000000000000000000 # 1 CAM
+
 
 
 ### Database

--- a/examples/config/camino-messenger-bot-distributor-columbus.yaml
+++ b/examples/config/camino-messenger-bot-distributor-columbus.yaml
@@ -44,6 +44,8 @@ network_fee_recipient_bot_address: 0xff6BAC3d972680515cbB59fCB6Db6deB13Eb0E91
 # matrix application service cm account address
 network_fee_recipient_cm_account: 0xF6bA5c68A505559c170dC7a30448Ed64D8b9Bc3B
 
+max_allowed_service_fee: 1000000000000000000 # 1 CAM
+
 
 
 ### Database

--- a/examples/config/camino-messenger-bot-supplier-camino.yaml
+++ b/examples/config/camino-messenger-bot-supplier-camino.yaml
@@ -47,6 +47,8 @@ network_fee_recipient_bot_address: 0xbeb027D2f439805E17EAA16Da26c1FCa68a30232
 # matrix application service cm account address
 network_fee_recipient_cm_account: 0x16DFfB3911BB0b1B53eF4d774804381f0B38B5d7
 
+max_allowed_service_fee: 1000000000000000000 # 1 CAM
+
 
 
 ### Database

--- a/examples/config/camino-messenger-bot-supplier-columbus.yaml
+++ b/examples/config/camino-messenger-bot-supplier-columbus.yaml
@@ -47,6 +47,8 @@ network_fee_recipient_bot_address: 0xff6BAC3d972680515cbB59fCB6Db6deB13Eb0E91
 # matrix application service cm account address
 network_fee_recipient_cm_account: 0xF6bA5c68A505559c170dC7a30448Ed64D8b9Bc3B
 
+max_allowed_service_fee: 1000000000000000000 # 1 CAM
+
 
 
 ### Database

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -259,6 +259,7 @@ func NewApp(ctx context.Context, cfg *config.Config, logger *zap.SugaredLogger) 
 		messaging.NewCompressor(compression.MaxChunkSize),
 		cmAccounts,
 		responseHeaderHandler,
+		cfg.MaxAllowedServiceFee,
 	)
 
 	cancellationService := cancellation.NewService(

--- a/internal/messaging/processor.go
+++ b/internal/messaging/processor.go
@@ -66,6 +66,7 @@ func NewMessageProcessor(
 	compressor compression.Compressor[*types.Message, [][]byte],
 	cmAccounts cmaccounts.Service,
 	responseHeaderHandler common.ResponseHeaderHandler,
+	maxAllowedServiceFee uint64,
 ) MessageProcessor {
 	return &messageProcessor{
 		messenger:                           messenger,
@@ -86,6 +87,7 @@ func NewMessageProcessor(
 		networkFeeRecipientBotAddress:       networkFeeRecipientBotAddress,
 		networkFeeRecipientCMAccountAddress: networkFeeRecipientCMAccountAddress,
 		responseHeaderHandler:               responseHeaderHandler,
+		maxAllowedServiceFee:                big.NewInt(0).SetUint64(maxAllowedServiceFee),
 	}
 }
 
@@ -97,6 +99,7 @@ type messageProcessor struct {
 	cmAccountAddress                    ethCommon.Address
 	networkFeeRecipientBotAddress       ethCommon.Address
 	networkFeeRecipientCMAccountAddress ethCommon.Address
+	maxAllowedServiceFee                *big.Int
 
 	messenger             Messenger
 	logger                *zap.SugaredLogger
@@ -185,6 +188,12 @@ func (p *messageProcessor) SendRequestMessage(ctx context.Context, requestMsg *t
 	serviceFee, err := p.cmAccounts.GetServiceFee(ctx, recipientCMAccAddr, requestMsg.Type.ToServiceName())
 	if err != nil {
 		// TODO @evlekht explicitly say if service is not supported and its not just some network error
+		return nil, err
+	}
+
+	if serviceFee.Cmp(p.maxAllowedServiceFee) > 0 {
+		err = fmt.Errorf("%s service fee %s exceeds maximum allowed service fee %d", requestMsg.Type.ToServiceName(), serviceFee.String(), p.maxAllowedServiceFee)
+		p.logger.Error(err)
 		return nil, err
 	}
 

--- a/internal/messaging/processor.go
+++ b/internal/messaging/processor.go
@@ -192,7 +192,7 @@ func (p *messageProcessor) SendRequestMessage(ctx context.Context, requestMsg *t
 	}
 
 	if serviceFee.Cmp(p.maxAllowedServiceFee) > 0 {
-		err = fmt.Errorf("%s service fee %s exceeds maximum allowed service fee %d", requestMsg.Type.ToServiceName(), serviceFee.String(), p.maxAllowedServiceFee)
+		err = fmt.Errorf("%s service fee %s exceeds maximum allowed service fee %s", requestMsg.Type.ToServiceName(), serviceFee.String(), p.maxAllowedServiceFee.String())
 		p.logger.Error(err)
 		return nil, err
 	}

--- a/internal/messaging/processor.go
+++ b/internal/messaging/processor.go
@@ -66,7 +66,7 @@ func NewMessageProcessor(
 	compressor compression.Compressor[*types.Message, [][]byte],
 	cmAccounts cmaccounts.Service,
 	responseHeaderHandler common.ResponseHeaderHandler,
-	maxAllowedServiceFee uint64,
+	maxAllowedServiceFee *big.Int,
 ) MessageProcessor {
 	return &messageProcessor{
 		messenger:                           messenger,
@@ -87,7 +87,7 @@ func NewMessageProcessor(
 		networkFeeRecipientBotAddress:       networkFeeRecipientBotAddress,
 		networkFeeRecipientCMAccountAddress: networkFeeRecipientCMAccountAddress,
 		responseHeaderHandler:               responseHeaderHandler,
-		maxAllowedServiceFee:                big.NewInt(0).SetUint64(maxAllowedServiceFee),
+		maxAllowedServiceFee:                maxAllowedServiceFee,
 	}
 }
 

--- a/internal/messaging/processor_test.go
+++ b/internal/messaging/processor_test.go
@@ -218,6 +218,7 @@ func TestProcessIncomingMessage(t *testing.T) {
 				tt.fields.compressor,
 				tt.fields.cmAccounts,
 				tt.fields.responseHeaderHandler,
+				0,
 			)
 			if tt.prepare != nil {
 				tt.prepare(p.(*messageProcessor))
@@ -255,6 +256,7 @@ func TestSendRequestMessage(t *testing.T) {
 		compressor            compression.Compressor[*types.Message, [][]byte]
 		cmAccounts            cmaccounts.Service
 		responseHeaderHandler common.ResponseHeaderHandler
+		maxAllowedServiceFee  *big.Int
 	}
 	type args struct {
 		msg *types.Message
@@ -307,6 +309,7 @@ func TestSendRequestMessage(t *testing.T) {
 				compressor:            &noopCompressor{},
 				cmAccounts:            mockCMAccounts,
 				responseHeaderHandler: mockResponseHeaderHandler,
+				maxAllowedServiceFee:  big.NewInt(1),
 			},
 			args: args{
 				msg: &types.Message{
@@ -333,6 +336,7 @@ func TestSendRequestMessage(t *testing.T) {
 				compressor:            &noopCompressor{},
 				cmAccounts:            mockCMAccounts,
 				responseHeaderHandler: mockResponseHeaderHandler,
+				maxAllowedServiceFee:  big.NewInt(1),
 			},
 			args: args{
 				msg: &types.Message{
@@ -361,6 +365,7 @@ func TestSendRequestMessage(t *testing.T) {
 				compressor:            &noopCompressor{},
 				cmAccounts:            mockCMAccounts,
 				responseHeaderHandler: mockResponseHeaderHandler,
+				maxAllowedServiceFee:  big.NewInt(1),
 			},
 			args: args{
 				msg: &types.Message{
@@ -412,6 +417,7 @@ func TestSendRequestMessage(t *testing.T) {
 				tt.fields.compressor,
 				tt.fields.cmAccounts,
 				tt.fields.responseHeaderHandler,
+				1,
 			)
 			if tt.prepare != nil {
 				tt.prepare()
@@ -489,6 +495,7 @@ func TestStart(t *testing.T) {
 		&noopCompressor{},
 		mockCMAccounts,
 		mockResponseHeaderHandler,
+		1,
 	)
 
 	go p.Start(ctx)

--- a/internal/messaging/processor_test.go
+++ b/internal/messaging/processor_test.go
@@ -218,7 +218,7 @@ func TestProcessIncomingMessage(t *testing.T) {
 				tt.fields.compressor,
 				tt.fields.cmAccounts,
 				tt.fields.responseHeaderHandler,
-				0,
+				big.NewInt(0),
 			)
 			if tt.prepare != nil {
 				tt.prepare(p.(*messageProcessor))
@@ -417,7 +417,7 @@ func TestSendRequestMessage(t *testing.T) {
 				tt.fields.compressor,
 				tt.fields.cmAccounts,
 				tt.fields.responseHeaderHandler,
-				1,
+				big.NewInt(1),
 			)
 			if tt.prepare != nil {
 				tt.prepare()
@@ -495,7 +495,7 @@ func TestStart(t *testing.T) {
 		&noopCompressor{},
 		mockCMAccounts,
 		mockResponseHeaderHandler,
-		1,
+		big.NewInt(1),
 	)
 
 	go p.Start(ctx)

--- a/tests/e2e/bot/factory.go
+++ b/tests/e2e/bot/factory.go
@@ -166,11 +166,11 @@ func (f *Factory) CreateBot(
 		BookingTokenAddress:                 f.networkClient.BookingTokenContractAddress().Hex(),
 		NetworkFeeRecipientBotAddress:       f.asb.NetworkFeeRecipientBotAddress().Hex(),
 		NetworkFeeRecipientCMAccountAddress: f.asb.NetworkFeeRecipientCMAccountAddress().Hex(),
-		ChequeExpirationTime:                3600 * 24 * 30 * 7,  // 7 months
-		MinChequeDurationUntilExpiration:    3600 * 24 * 30 * 6,  // 6 months
-		CashInPeriod:                        3600,                // 1h
-		MaxAllowedServiceFee:                1000000000000000000, // 1 CAM
-		ResponseTimeout:                     30000,               // 30s
+		ChequeExpirationTime:                3600 * 24 * 30 * 7,    // 7 months
+		MinChequeDurationUntilExpiration:    3600 * 24 * 30 * 6,    // 6 months
+		CashInPeriod:                        3600,                  // 1h
+		MaxAllowedServiceFee:                "1000000000000000000", // 1 CAM
+		ResponseTimeout:                     30000,                 // 30s
 		PartnerPlugin: config.PartnerPluginConfig{
 			Enabled:     partnerPlugin != nil,
 			Host:        partnerPlugin.Host(),

--- a/tests/e2e/bot/factory.go
+++ b/tests/e2e/bot/factory.go
@@ -166,10 +166,11 @@ func (f *Factory) CreateBot(
 		BookingTokenAddress:                 f.networkClient.BookingTokenContractAddress().Hex(),
 		NetworkFeeRecipientBotAddress:       f.asb.NetworkFeeRecipientBotAddress().Hex(),
 		NetworkFeeRecipientCMAccountAddress: f.asb.NetworkFeeRecipientCMAccountAddress().Hex(),
-		ChequeExpirationTime:                3600 * 24 * 30 * 7, // 7 months
-		MinChequeDurationUntilExpiration:    3600 * 24 * 30 * 6, // 6 months
-		CashInPeriod:                        3600,               // 1h
-		ResponseTimeout:                     30000,              // 30s
+		ChequeExpirationTime:                3600 * 24 * 30 * 7,  // 7 months
+		MinChequeDurationUntilExpiration:    3600 * 24 * 30 * 6,  // 6 months
+		CashInPeriod:                        3600,                // 1h
+		MaxAllowedServiceFee:                1000000000000000000, // 1 CAM
+		ResponseTimeout:                     30000,               // 30s
 		PartnerPlugin: config.PartnerPluginConfig{
 			Enabled:     partnerPlugin != nil,
 			Host:        partnerPlugin.Host(),


### PR DESCRIPTION
Add configurable maxAllowedServiceFee value.
If requested service has fee bigger, than this value, bot will abort sending request and return an error.