### PR TITLE
Panic handing

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -348,7 +348,7 @@ func (a *App) Run(ctx context.Context) error {
 	schedulerStarted := make(chan struct{})
 	messageProcessorStarted := make(chan struct{})
 
-	g.Go(func() error {
+	a.safeGo(g, func() error {
 		a.logger.Info("Starting start-up cash-in status check...")
 		if err := a.chequeHandler.CheckCashInStatus(ctx); err != nil {
 			return fmt.Errorf("failed to do start-up cash-in status check: %w", err)
@@ -359,17 +359,23 @@ func (a *App) Run(ctx context.Context) error {
 	})
 
 	eventListenerStarted := make(chan struct{})
-	g.Go(func() error {
+	a.safeGo(g, func() error {
 		a.logger.Info("Starting event listener...")
-		if err := a.eventListener.Start(ctx); err != nil {
+		errChan, err := a.eventListener.Start(ctx)
+		if err != nil {
 			return fmt.Errorf("failed to start event listener: %w", err)
 		}
 		a.logger.Info("Event listener started.")
 		close(eventListenerStarted)
+
+		if err := <-errChan; err != nil && !errors.Is(err, context.Canceled) {
+			a.logger.Errorf("Event listener failed with error: %v", err)
+			return err
+		}
 		return nil
 	})
 
-	g.Go(func() error {
+	a.safeGo(g, func() error {
 		if !awaitChan(ctx, cashInStatusCheckDone) {
 			return nil
 		}
@@ -391,10 +397,11 @@ func (a *App) Run(ctx context.Context) error {
 
 		a.logger.Info("Scheduler started.")
 		close(schedulerStarted)
+
 		return nil
 	})
 
-	g.Go(func() error {
+	a.safeGo(g, func() error {
 		a.logger.Info("Starting message processor...")
 		a.messageProcessor.Start(ctx)
 		a.logger.Info("Message processor started.")
@@ -402,7 +409,7 @@ func (a *App) Run(ctx context.Context) error {
 		return nil
 	})
 
-	g.Go(func() error {
+	a.safeGo(g, func() error {
 		if !awaitChans(ctx,
 			cashInStatusCheckDone,
 			schedulerStarted,
@@ -430,7 +437,7 @@ func (a *App) Run(ctx context.Context) error {
 	})
 
 	if a.rpcServer != nil { // rpcServer will be nil, if its disabled in config
-		g.Go(func() error {
+		a.safeGo(g, func() error {
 			if !awaitChan(ctx, messengerReceiverStarted) {
 				return nil
 			}
@@ -456,7 +463,7 @@ func (a *App) Run(ctx context.Context) error {
 	// stop
 
 	if a.rpcClient != nil { // rpcClient will be nil, if its disabled in partner plugin config section
-		g.Go(func() error {
+		a.safeGo(g, func() error {
 			<-ctx.Done()
 			a.logger.Info("Stopping gRPC client...")
 			if err := a.rpcClient.Shutdown(); err != nil && !errors.Is(err, context.Canceled) {
@@ -469,7 +476,7 @@ func (a *App) Run(ctx context.Context) error {
 	}
 
 	if a.rpcServer != nil { // rpcServer will be nil, if its disabled in config
-		g.Go(func() error {
+		a.safeGo(g, func() error {
 			<-ctx.Done()
 			a.logger.Info("Stopping gRPC server...")
 			a.rpcServer.Stop()
@@ -478,7 +485,7 @@ func (a *App) Run(ctx context.Context) error {
 		})
 	}
 
-	g.Go(func() error {
+	a.safeGo(g, func() error {
 		<-ctx.Done()
 		a.logger.Info("Stopping message receiver...")
 		if err := a.messenger.StopReceiver(); err != nil && !errors.Is(err, context.Canceled) {
@@ -489,7 +496,7 @@ func (a *App) Run(ctx context.Context) error {
 		return nil
 	})
 
-	g.Go(func() error {
+	a.safeGo(g, func() error {
 		<-ctx.Done()
 		a.logger.Info("Stopping scheduler...")
 		a.scheduler.Stop()
@@ -497,7 +504,7 @@ func (a *App) Run(ctx context.Context) error {
 		return nil
 	})
 
-	g.Go(func() error {
+	a.safeGo(g, func() error {
 		<-ctx.Done()
 		a.logger.Info("Stopping event listener...")
 		a.eventListener.Stop()
@@ -515,6 +522,18 @@ func (a *App) Run(ctx context.Context) error {
 	}
 
 	return err
+}
+
+func (a *App) safeGo(g *errgroup.Group, fn func() error) {
+	g.Go(func() (err error) {
+		defer func() {
+			if panicErr := recover(); panicErr != nil {
+				err = fmt.Errorf("panic: %v", panicErr) // err will be returned
+				a.logger.Errorf("recovered from panic: %v", err)
+			}
+		}()
+		return fn()
+	})
 }
 
 func awaitChan(ctx context.Context, ch <-chan struct{}) bool {

--- a/internal/event_listener/event_listener.go
+++ b/internal/event_listener/event_listener.go
@@ -48,7 +48,7 @@ type Session interface {
 }
 
 type EventListener interface {
-	Start(context.Context) error
+	Start(context.Context) (<-chan error, error)
 	Stop()
 	TokenBoughtSubscriber
 	CancellationSubscriber
@@ -106,18 +106,25 @@ func New(
 	}, nil
 }
 
-func (l *eventListener) Start(ctx context.Context) error {
+func (l *eventListener) Start(ctx context.Context) (<-chan error, error) {
 	if err := l.startTokenBoughtSubscriptions(ctx); err != nil {
 		l.logger.Errorf("failed to start token bought subscriptions: %v", err)
-		return err
+		return nil, err
 	}
 
 	if err := l.startCancellationSubscriptions(ctx); err != nil {
 		l.logger.Errorf("failed to start cancellation subscriptions: %v", err)
-		return err
+		return nil, err
 	}
 
-	return nil
+	errChan := make(chan error)
+	go func() {
+		errChan <- <-l.subscriber.ErrChan()
+		close(errChan)
+		l.subscriber.Stop()
+	}()
+
+	return errChan, nil
 }
 
 func (l *eventListener) Stop() {

--- a/internal/event_listener/subscriber/subscriber.go
+++ b/internal/event_listener/subscriber/subscriber.go
@@ -5,6 +5,8 @@ package subscriber
 
 import (
 	"context"
+	"fmt"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -23,6 +25,9 @@ const backoffMax = 2 * time.Minute // Maximum backoff time between subscribe ret
 var _ Subscriber = (*subscriber)(nil)
 
 type Subscriber interface {
+	ErrChan() <-chan error
+	Stop()
+
 	SubscribeServiceAdded(
 		cmAccountAddr common.Address,
 		handler func(*cmaccount.CmaccountServiceAdded) uint64,
@@ -55,6 +60,10 @@ type subscriber struct {
 	bookingToken *bookingtoken.Bookingtoken
 	cmAccounts   cmaccounts.Service
 	blockNumber  *atomic.Uint64
+	errChan      chan error
+	stopChan     chan struct{}
+	once         sync.Once
+	wg           sync.WaitGroup
 }
 
 func New(
@@ -79,7 +88,17 @@ func New(
 		bookingToken: bookingToken,
 		cmAccounts:   cmAccounts,
 		blockNumber:  blockNumberAtomic,
+		errChan:      make(chan error),
+		stopChan:     make(chan struct{}),
 	}, nil
+}
+
+func (s *subscriber) ErrChan() <-chan error {
+	return s.errChan
+}
+
+func (s *subscriber) Stop() {
+	close(s.stopChan)
 }
 
 // Subscribes to the ServiceAdded event.
@@ -182,7 +201,20 @@ func startResubscriber[T any](
 	eventType := new(T) // for logging purposes
 
 	eventChan := make(chan T)
+	s.wg.Add(1)
 	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				err := fmt.Errorf("%T event handler panic: %v", eventType, r)
+				s.logger.Errorf("recovered from panic: %v", err)
+				select {
+				case s.errChan <- err:
+				case <-s.stopChan:
+				}
+			}
+			s.wg.Done()
+		}()
+
 		for event := range eventChan {
 			if successfullyProcessedBlockNumber := handler(event); successfullyProcessedBlockNumber != 0 {
 				s.blockNumber.Store(successfullyProcessedBlockNumber)
@@ -204,10 +236,15 @@ func startResubscriber[T any](
 		return sub, nil
 	})
 
+	s.once.Do(func() {
+		go func() {
+			s.wg.Wait()
+			close(s.errChan)
+		}()
+	})
+
 	return func() {
 		resubscriber.Unsubscribe()
-		if eventChan != nil {
-			close(eventChan)
-		}
+		close(eventChan)
 	}
 }

--- a/internal/matrix/matrix_messenger.go
+++ b/internal/matrix/matrix_messenger.go
@@ -90,6 +90,11 @@ func (m *messenger) StartReceiver(ctx context.Context) (chan error, error) {
 	syncer := m.client.Syncer.(*mautrix.DefaultSyncer)
 
 	syncer.OnEventType(matrix.EventTypeC4TMessage, func(ctx context.Context, evt *event.Event) {
+		defer func() {
+			if r := recover(); r != nil {
+				m.logger.Errorf("failed to process %s event, recovered from panic: %v", matrix.EventTypeC4TMessage.Type, r)
+			}
+		}()
 		m.logger.Debugf("Received %s event %s from %s in room %s", matrix.EventTypeC4TMessage.Type, evt.ID, evt.Sender, evt.RoomID)
 
 		if evt.Sender == m.client.UserID { // ignore own messages
@@ -123,6 +128,11 @@ func (m *messenger) StartReceiver(ctx context.Context) (chan error, error) {
 		}
 	})
 	syncer.OnEventType(event.StateMember, func(ctx context.Context, evt *event.Event) {
+		defer func() {
+			if r := recover(); r != nil {
+				m.logger.Errorf("failed to process %s event, recovered from panic: %v", event.StateMember.Type, r)
+			}
+		}()
 		m.logger.Debugf("Received %s event %s from %s in room %s", event.StateMember.Type, evt.ID, evt.Sender, evt.RoomID)
 
 		if evt.GetStateKey() == m.client.UserID.String() && evt.Content.AsMember().Membership == event.MembershipInvite {
@@ -173,6 +183,11 @@ func (m *messenger) StartReceiver(ctx context.Context) (chan error, error) {
 
 	go func() {
 		defer func() {
+			if r := recover(); r != nil {
+				err := fmt.Errorf("matrix event syncer panicked: %v", r)
+				m.logger.Errorf("recovered from panic: %v", err)
+				errChan <- err
+			}
 			close(errChan)
 			close(m.client.syncerStopChan)
 		}()

--- a/internal/messaging/processor.go
+++ b/internal/messaging/processor.go
@@ -124,7 +124,13 @@ func (p *messageProcessor) Start(ctx context.Context) {
 			select {
 			case msg := <-p.messenger.Inbound():
 				go func() {
+					defer func() {
+						if r := recover(); r != nil {
+							p.logger.Errorf("Recovered from panic while processing message: %v", r)
+						}
+					}()
 					p.logger.Debugf("Processing incoming message (%s): %s", msg.Type, msg.Metadata.RequestID)
+
 					if err := p.ProcessIncomingMessage(&msg); err != nil {
 						p.logger.Warnf("could not process message: %v", err)
 					}

--- a/internal/rpc/server/server.go
+++ b/internal/rpc/server/server.go
@@ -75,7 +75,8 @@ func NewServer(
 		serviceRegistry:       serviceRegistry,
 	}
 
-	opts = append(opts, grpc.UnaryInterceptor(
+	opts = append(opts, grpc.ChainUnaryInterceptor(
+		s.unaryRecoverInterceptor,
 		selector.UnaryServerInterceptor( // for all cancellationv1grpc methods
 			s.errorHandlingInterceptor,
 			selector.MatchFunc(func(_ context.Context, callMeta interceptors.CallMeta) bool {
@@ -121,7 +122,14 @@ func (s *server) Start() (chan error, error) {
 	errChan := make(chan error)
 
 	go func() {
-		defer close(errChan)
+		defer func() {
+			if r := recover(); r != nil {
+				err := fmt.Errorf("gRPC server panicked: %v", r)
+				s.logger.Errorf("recovered from panic: %v", err)
+				errChan <- err
+			}
+			close(errChan)
+		}()
 
 		s.logger.Infof("gRPC server listening on %s", lis.Addr().String())
 
@@ -184,4 +192,19 @@ func (s *server) errorHandlingInterceptor(
 		s.responseHeaderHandler.AddError(responseProtoMessage, err.Error())
 	}
 	return response, nil
+}
+
+func (s *server) unaryRecoverInterceptor(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (response any, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			md := &metadata.Metadata{}
+			if err := md.ExtractMetadata(ctx); err != nil {
+				s.logger.Error("error extracting metadata from context", zap.Error(err))
+			}
+			err = fmt.Errorf("gRPC %s (request %s) handler panicked: %v", info.FullMethod, md.RequestID, r) // we return this error to the client
+			s.logger.Errorf("recovered from panic: %v", err)
+		}
+	}()
+
+	return handler(ctx, req)
 }

--- a/pkg/chequehandler/cheque_handler.go
+++ b/pkg/chequehandler/cheque_handler.go
@@ -354,7 +354,7 @@ func (ch *evmChequeHandler) CashIn(ctx context.Context) error {
 		go func(txID common.Hash) {
 			defer func() {
 				if r := recover(); r != nil {
-					ch.logger.Errorf("recovered from panic while checking cash in status for txID %s: %v", txID.Hex(), r)
+					ch.logger.Errorf("recovered from panic: checkCashInTxStatus for tx %s panicked: %v", txID.Hex(), r)
 				}
 				wg.Done()
 			}()
@@ -387,8 +387,8 @@ func (ch *evmChequeHandler) CheckCashInStatus(ctx context.Context) error {
 		txID := chequeRecord.TxID
 		g.Go(func() (err error) {
 			defer func() {
-				if panicErr := recover(); panicErr != nil {
-					err = fmt.Errorf("checkCashInTxStatus for tx %s panicked: %v", txID.Hex(), panicErr) // err will be returned
+				if r := recover(); r != nil {
+					err = fmt.Errorf("checkCashInTxStatus for tx %s panicked: %v", txID.Hex(), r) // err will be returned
 					ch.logger.Errorf("recovered from panic: %v", err)
 				}
 			}()

--- a/pkg/chequehandler/cheque_handler.go
+++ b/pkg/chequehandler/cheque_handler.go
@@ -352,7 +352,12 @@ func (ch *evmChequeHandler) CashIn(ctx context.Context) error {
 
 		wg.Add(1)
 		go func(txID common.Hash) {
-			defer wg.Done()
+			defer func() {
+				if r := recover(); r != nil {
+					ch.logger.Errorf("recovered from panic while checking cash in status for txID %s: %v", txID.Hex(), r)
+				}
+				wg.Done()
+			}()
 			_ = ch.checkCashInTxStatus(ctx, txID)
 		}(chequeRecord.TxID)
 	}
@@ -381,6 +386,12 @@ func (ch *evmChequeHandler) CheckCashInStatus(ctx context.Context) error {
 	for _, chequeRecord := range chequeRecords {
 		txID := chequeRecord.TxID
 		g.Go(func() (err error) {
+			defer func() {
+				if panicErr := recover(); panicErr != nil {
+					err = fmt.Errorf("checkCashInTxStatus for tx %s panicked: %v", txID.Hex(), panicErr) // err will be returned
+					ch.logger.Errorf("recovered from panic: %v", err)
+				}
+			}()
 			return ch.checkCashInTxStatus(ctx, txID)
 		})
 	}

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -89,6 +89,20 @@ func (s *scheduler) Start(ctx context.Context) error {
 	timersCtx, cancel := context.WithCancel(ctx)
 	s.stopTimers = cancel
 
+	safeGo := func(handler func()) {
+		s.wg.Add(1)
+		go func() {
+			defer func() {
+				if r := recover(); r != nil {
+					err := fmt.Errorf("scheduler panicked: %v", r)
+					s.logger.Errorf("recovered from panic: %v", err)
+				}
+				s.wg.Done()
+			}()
+			handler()
+		}()
+	}
+
 	for _, job := range jobs {
 		jobHandler, err := s.getJobHandler(job.Name)
 		if err != nil {
@@ -103,7 +117,6 @@ func (s *scheduler) Start(ctx context.Context) error {
 		durationUntilFirstExecution := max(job.LastExecutedAt.Add(job.Period).Sub(now), 0)
 
 		handler := func(tickTime time.Time) {
-			// TODO @evlekht panic handling?
 			if err := s.updateJobExecutionTime(ctx, jobName, tickTime); err != nil {
 				s.logger.Errorf("failed to update job execution time: %v", err)
 				return
@@ -115,24 +128,17 @@ func (s *scheduler) Start(ctx context.Context) error {
 		onceDone := make(chan struct{})
 		timer := s.clock.NewTimer(durationUntilFirstExecution)
 		s.setJobTimer(job.Name, &timerStopper{timer})
-		s.wg.Add(1)
-		go func() {
-			defer func() {
-				close(onceDone)
-				s.wg.Done()
-			}()
-
+		safeGo(func() {
+			defer close(onceDone)
 			select {
 			case tickTime := <-timer.Chan():
 				handler(tickTime)
 			case <-timersCtx.Done():
 			}
-		}()
+		})
 
 		// periodic execution
-		s.wg.Add(1)
-		go func() {
-			defer s.wg.Done()
+		safeGo(func() {
 			<-onceDone
 			ticker := s.clock.NewTicker(period)
 			defer ticker.Stop()
@@ -145,7 +151,7 @@ func (s *scheduler) Start(ctx context.Context) error {
 					return
 				}
 			}
-		}()
+		})
 	}
 
 	return nil


### PR DESCRIPTION
Cover all goroutines with recover:
- Startup and blockchain event panic handling results in error that will shut down bot.
- Message processing, cash-in, grpc request handling panic will just abort.

Was tested manually with adding panic in code, running cancellationV1 e2e test and then inspecting bot logs.