### PR TITLE
Make setup failure fail whole test

### DIFF
--- a/tests/e2e/tests/test_accommodation_v2.go
+++ b/tests/e2e/tests/test_accommodation_v2.go
@@ -544,12 +544,9 @@ func testAccommodationV2VerifyBlockchainState(
 func TestAccommodationV2(t *testing.T, tt *Test) {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
-	var supplierBot *bot.Bot
-	var distributorBot *bot.Bot
 
-	t.Run("Setup", func(t *testing.T) {
-		_, supplierBot, distributorBot = testAccommodationV2Setup(ctx, t, tt)
-	})
+	_, supplierBot, distributorBot := testAccommodationV2Setup(ctx, t, tt)
+
 	t.Run("Product list", func(t *testing.T) {
 		// Happy path: will just return all the properties
 		testAccommodationV2ProductListService(ctx, t, tt, distributorBot, supplierBot)

--- a/tests/e2e/tests/test_accommodation_v3.go
+++ b/tests/e2e/tests/test_accommodation_v3.go
@@ -547,12 +547,9 @@ func testAccommodationV3VerifyBlockchainState(
 func TestAccommodationV3(t *testing.T, tt *Test) {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
-	var supplierBot *bot.Bot
-	var distributorBot *bot.Bot
 
-	t.Run("Setup", func(t *testing.T) {
-		_, supplierBot, distributorBot = testAccommodationV3Setup(ctx, t, tt)
-	})
+	_, supplierBot, distributorBot := testAccommodationV3Setup(ctx, t, tt)
+
 	t.Run("Product list", func(t *testing.T) {
 		// Happy path: will just return all the properties
 		testAccommodationV3ProductListService(ctx, t, tt, distributorBot, supplierBot)

--- a/tests/e2e/tests/test_bot_sanity.go
+++ b/tests/e2e/tests/test_bot_sanity.go
@@ -169,13 +169,7 @@ func testBotSanityVerify(ctx context.Context, t *testing.T, services *botSanityS
 func TestBotSanity(t *testing.T, tt *Test) {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
-	var services *botSanityServices
 
-	t.Run("Startup and sanity checks", func(t *testing.T) {
-		services = testBotSanitySetupWithSanityChecks(ctx, t, tt)
-	})
-
-	t.Run("Verification", func(t *testing.T) {
-		testBotSanityVerify(ctx, t, services)
-	})
+	services := testBotSanitySetupWithSanityChecks(ctx, t, tt)
+	testBotSanityVerify(ctx, t, services)
 }

--- a/tests/e2e/tests/test_cancellation_v1.go
+++ b/tests/e2e/tests/test_cancellation_v1.go
@@ -379,23 +379,13 @@ func testCheckCancellationV1(
 func TestCancellationV1(t *testing.T, tt *Test) {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
-	var (
-		supplierBot              *bot.Bot
-		distributorBot           *bot.Bot
-		supplierPartnerPlugin    *partnerplugin.PartnerPlugin
-		distributorPartnerPlugin *partnerplugin.PartnerPlugin
-		supplierPPEventStream    events.EventsService_SubscribeClient
-		distributorPPEventStream events.EventsService_SubscribeClient
-		err                      error
-	)
 
-	t.Run("Setup", func(t *testing.T) {
-		supplierPartnerPlugin, supplierBot, distributorPartnerPlugin, distributorBot = testCancellationV1Setup(ctx, t, tt)
-		supplierPPEventStream, err = supplierPartnerPlugin.SubscribeForEvents(ctx)
-		require.NoError(t, err)
-		distributorPPEventStream, err = distributorPartnerPlugin.SubscribeForEvents(ctx)
-		require.NoError(t, err)
-	})
+	supplierPartnerPlugin, supplierBot, distributorPartnerPlugin, distributorBot := testCancellationV1Setup(ctx, t, tt)
+	supplierPPEventStream, err := supplierPartnerPlugin.SubscribeForEvents(ctx)
+	require.NoError(t, err)
+	distributorPPEventStream, err := distributorPartnerPlugin.SubscribeForEvents(ctx)
+	require.NoError(t, err)
+
 	t.Run("CheckCancellationV1", func(t *testing.T) {
 		testCheckCancellationV1(ctx, t, tt, distributorBot, supplierBot, supplierPPEventStream)
 	})

--- a/tests/e2e/tests/test_mint_v2.go
+++ b/tests/e2e/tests/test_mint_v2.go
@@ -183,20 +183,10 @@ func testMintV2TokenExpiredCase(ctx context.Context, t *testing.T, tt *Test, ppE
 func TestMintV2(t *testing.T, tt *Test) {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
-	var (
-		supplierBot                *bot.Bot
-		distributorBot             *bot.Bot
-		distributorBotWithoutFunds *bot.Bot
-		supplierPartnerPlugin      *partnerplugin.PartnerPlugin
-		ppEventStream              events.EventsService_SubscribeClient
-		err                        error
-	)
 
-	t.Run("Setup", func(t *testing.T) {
-		supplierPartnerPlugin, supplierBot, distributorBot, distributorBotWithoutFunds = testMintV2Setup(ctx, t, tt)
-		ppEventStream, err = supplierPartnerPlugin.SubscribeForEvents(ctx)
-		require.NoError(t, err)
-	})
+	supplierPartnerPlugin, supplierBot, distributorBot, distributorBotWithoutFunds := testMintV2Setup(ctx, t, tt)
+	ppEventStream, err := supplierPartnerPlugin.SubscribeForEvents(ctx)
+	require.NoError(t, err)
 
 	t.Run("Search->Validate->Mint->TokenBoughtNotification", func(t *testing.T) {
 		// We're doing this > 1 times to make sure that even with multiple

--- a/tests/e2e/tests/test_ping.go
+++ b/tests/e2e/tests/test_ping.go
@@ -60,12 +60,9 @@ func testPingV1Service(ctx context.Context, t *testing.T, tt *Test, distributorB
 func TestPingV1(t *testing.T, tt *Test) {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
-	var supplierBot *bot.Bot
-	var distributorBot *bot.Bot
 
-	t.Run("Setup", func(t *testing.T) {
-		_, supplierBot, distributorBot = testPingV1Setup(ctx, t, tt)
-	})
+	_, supplierBot, distributorBot := testPingV1Setup(ctx, t, tt)
+
 	t.Run("Ping", func(t *testing.T) {
 		testPingV1Service(ctx, t, tt, distributorBot, supplierBot)
 	})

--- a/tests/e2e/tests/test_transport_v3.go
+++ b/tests/e2e/tests/test_transport_v3.go
@@ -818,14 +818,10 @@ func testTransportV3VerifyBlockchainState(
 func TestTransportV3(t *testing.T, tt *Test) {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
-	var supplierBot *bot.Bot
-	var distributorBot *bot.Bot
 
+	_, supplierBot, distributorBot := testTransportV3Setup(ctx, t, tt)
 	var productListResponse *transportv3.TransportProductListResponse
 
-	t.Run("Setup", func(t *testing.T) {
-		_, supplierBot, distributorBot = testTransportV3Setup(ctx, t, tt)
-	})
 	t.Run("Product list", func(t *testing.T) {
 		// Happy path: will just return all the products
 		productListResponse = testTransportV3ProductListService(ctx, t, tt, distributorBot, supplierBot)


### PR DESCRIPTION
Currently, e2e tests setup runs in its own t.Run. Because of that, its failur will only fail its own t.Run, not parent or siblings.
And because of that, after failed setup, other test cases are still trying to run resulting in panic.
PR moves setup from its own t.Run to parents scope.