### PR TITLE
Improve e2e tests stop-cleanup

### DIFF
--- a/tests/e2e/blockchain/network.go
+++ b/tests/e2e/blockchain/network.go
@@ -6,6 +6,7 @@ package blockchain
 import (
 	"context"
 	"crypto/ecdsa"
+	"errors"
 	"fmt"
 	"math/big"
 	"os"
@@ -329,13 +330,29 @@ func (n *Network) Stop(ctx context.Context) error {
 	if n == nil {
 		return nil
 	}
+
+	var errs []error
+	errsMx := sync.Mutex{}
+	wg := sync.WaitGroup{}
+
 	for _, node := range n.nodes {
-		if err := node.Stop(ctx); err != nil {
-			return fmt.Errorf("failed to stop node: %w", err)
-		}
+		wg.Add(1)
+		go func(node *Node) {
+			defer wg.Done()
+			if err := node.Stop(ctx); err != nil {
+				errsMx.Lock()
+				errs = append(errs, fmt.Errorf("failed to stop node: %w", err))
+				errsMx.Unlock()
+			}
+		}(node)
 	}
-	n.logger.Debug("Blockchain network stopped")
-	return nil
+
+	wg.Wait()
+
+	if len(errs) == 0 {
+		n.logger.Debug("Blockchain network stopped successfully")
+	}
+	return errors.Join(errs...)
 }
 
 func combineErrChannels(errChans ...chan error) chan error {

--- a/tests/e2e/bot/factory.go
+++ b/tests/e2e/bot/factory.go
@@ -14,6 +14,7 @@ import (
 	"os/exec"
 	"path"
 	"strconv"
+	"sync"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -267,16 +268,21 @@ func (f *Factory) CreateBot(
 
 func (f *Factory) StopBots(ctx context.Context) error {
 	var errs []error
+	errsMx := sync.Mutex{}
+	wg := sync.WaitGroup{}
 
 	for _, bot := range f.bots {
-		if err := bot.Stop(ctx); err != nil {
-			errs = append(errs, fmt.Errorf("failed to stop bot (%d): %w", bot.pid, err))
-		}
+		wg.Add(1)
+		go func(bot *Bot) {
+			defer wg.Done()
+			if err := bot.Stop(ctx); err != nil {
+				errsMx.Lock()
+				errs = append(errs, fmt.Errorf("failed to stop bot (%d): %w", bot.pid, err))
+				errsMx.Unlock()
+			}
+		}(bot)
 	}
 
-	if len(errs) > 0 {
-		return errors.Join(errs...)
-	}
-
-	return nil
+	wg.Wait()
+	return errors.Join(errs...)
 }

--- a/tests/e2e/partner_plugin/factory.go
+++ b/tests/e2e/partner_plugin/factory.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"sync"
 
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
@@ -122,10 +123,21 @@ func (f *Factory) CreatePartnerPlugin(ctx context.Context) (*PartnerPlugin, chan
 
 func (f *Factory) StopPartnerPlugins(ctx context.Context) error {
 	var errs []error
+	errsMx := sync.Mutex{}
+	wg := sync.WaitGroup{}
+
 	for _, pp := range f.partnerPlugins {
-		if err := pp.Stop(ctx); err != nil {
-			errs = append(errs, fmt.Errorf("failed to stop partner plugin (%d): %w", pp.pid, err))
-		}
+		wg.Add(1)
+		go func(pp *PartnerPlugin) {
+			defer wg.Done()
+			if err := pp.Stop(ctx); err != nil {
+				errsMx.Lock()
+				errs = append(errs, fmt.Errorf("failed to stop partner plugin (%d): %w", pp.pid, err))
+				errsMx.Unlock()
+			}
+		}(pp)
 	}
+
+	wg.Wait()
 	return errors.Join(errs...)
 }

--- a/tests/e2e/process/process.go
+++ b/tests/e2e/process/process.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	processTickerInterval = 50 * time.Millisecond
-	killTimeout           = 2 * time.Second
+	killTimeout           = 5 * time.Second
 )
 
 func ListenForProcessError(cmd *exec.Cmd) chan error {
@@ -78,8 +78,6 @@ func waitKillProcess(ctx context.Context, pid int) error {
 				}
 				return fmt.Errorf("failed to send SIGKILL to process with pid %d: %w", pid, err)
 			}
-			// The timeout is done - prevent it from triggering again
-			cancelKillTimeout()
 		case <-ticker.C:
 		}
 	}

--- a/tests/e2e/tests/suite.go
+++ b/tests/e2e/tests/suite.go
@@ -171,10 +171,15 @@ func (s *Suite) NewTest(t *testing.T) *Test {
 }
 
 func (s *Suite) Cleanup(t *testing.T, tt *Test) {
-	ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout*10)
+	ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
 	defer cancel()
 
 	var wg sync.WaitGroup
+
+	// Components stopped without respecting the order, so they might stop with errors.
+	// That will be most likely reflected in their logs, but we don't care about that at this point.
+	// E.g. if network is stopped before bots, while bots have active event subscriptions,
+	// bots might log errors about failed subscriptions.
 
 	tt.logger.Debug("Stopping all services")
 	wg.Add(1)


### PR DESCRIPTION
- Parallel bots, partner-plugins and blockchain nodes stopping
- Fix cleanup timeout
- Clarify parallel components stopping order disrespecting with comment