### PR TITLE
E2E tests bot restart

### DIFF
--- a/tests/e2e/bot/bot.go
+++ b/tests/e2e/bot/bot.go
@@ -108,7 +108,7 @@ func (b *Bot) Start(ctx context.Context) (chan error, error) {
 		defer close(errChan)
 		err := <-process.ListenForProcessError(cmd)
 		if err != nil {
-			errChan <- fmt.Errorf("bot (pid %d) failed: %w", b.pid, err)
+			errChan <- fmt.Errorf("bot (pid %d) failed: %w", cmd.Process.Pid, err)
 		}
 	}()
 

--- a/tests/e2e/bot/bot.go
+++ b/tests/e2e/bot/bot.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/protobuf/types/known/emptypb"
@@ -122,28 +123,53 @@ func (b *Bot) Stop(ctx context.Context) error {
 		return nil
 	}
 
-	oldPID := b.pid
-	if err := process.StopProcess(ctx, b.pid); err != nil {
-		return fmt.Errorf("failed to stop cmb process with pid %d: %w", b.pid, err)
-	}
-	b.pid = 0
-	b.logger.Debugf("Bot (pid %d) stopped", oldPID)
+	g := errgroup.Group{}
+	processStopped := make(chan struct{})
+	pid := b.pid
+
+	g.Go(func() error {
+		defer close(processStopped)
+		if err := process.StopProcess(ctx, b.pid); err != nil {
+			err := fmt.Errorf("failed to stop bot process: %w", err)
+			b.logger.Error(err)
+			return err
+		}
+		b.pid = 0
+		b.logger.Debugf("Bot process (pid %d) stopped", pid)
+		return nil
+	})
 
 	if b.logFile != nil {
-		if err := b.logFile.Close(); err != nil {
-			return fmt.Errorf("failed to close cmb logFile: %w", err)
-		}
-		b.logFile = nil
+		g.Go(func() error {
+			select {
+			case <-processStopped:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+			if err := b.logFile.Close(); err != nil {
+				return fmt.Errorf("failed to close bot logFile: %w", err)
+			}
+			b.logFile = nil
+			return nil
+		})
 	}
 
 	if b.rpcClient != nil {
-		if err := b.rpcClient.close(); err != nil {
-			return fmt.Errorf("failed to close rpc client: %w", err)
-		}
-		b.rpcClient = nil
+		g.Go(func() error {
+			if err := b.rpcClient.close(); err != nil {
+				return fmt.Errorf("failed to close rpc client: %w", err)
+			}
+			b.rpcClient = nil
+			return nil
+		})
 	}
 
-	return nil
+	err := g.Wait()
+	if err != nil {
+		err = fmt.Errorf("failed to stop bot (pid %d) or close its resources: %w", b.pid, err)
+		b.logger.Error(err)
+	}
+	return err
 }
 
 func (b *Bot) Restart(ctx context.Context) (chan error, error) {
@@ -152,7 +178,7 @@ func (b *Bot) Restart(ctx context.Context) (chan error, error) {
 	oldPID := b.pid
 
 	if err := b.Stop(ctx); err != nil {
-		return nil, fmt.Errorf("failed to stop bot (pid %d): %w", b.pid, err)
+		return nil, err
 	}
 
 	errChan, err := b.Start(ctx)

--- a/tests/e2e/bot/bot.go
+++ b/tests/e2e/bot/bot.go
@@ -7,9 +7,12 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/exec"
 	"time"
 
 	"go.uber.org/zap"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/chain4travel/camino-messenger-bot/v11/internal/rpc/server"
@@ -21,27 +24,144 @@ import (
 
 const requestTickerInterval = 500 * time.Millisecond
 
+func newBot(
+	logger *zap.SugaredLogger,
+	cmAccountAddress common.Address,
+	binPath string,
+	configPath string,
+	logPath string,
+	rpcConnectionString string,
+) *Bot {
+	return &Bot{
+		logger:              logger,
+		cmAccountAddress:    cmAccountAddress,
+		binPath:             binPath,
+		configPath:          configPath,
+		logPath:             logPath,
+		rpcConnectionString: rpcConnectionString,
+	}
+}
+
 type Bot struct {
-	logger           *zap.SugaredLogger
-	pid              int
-	cmAccountAddress common.Address
-	logFile          *os.File
+	logger              *zap.SugaredLogger
+	pid                 int
+	cmAccountAddress    common.Address
+	logFile             *os.File
+	binPath             string
+	configPath          string
+	logPath             string
+	rpcConnectionString string
 
 	*rpcClient
+}
+
+func (b *Bot) Start(ctx context.Context) (chan error, error) {
+	// Prepare log file for bot
+
+	logFile, err := os.OpenFile(b.logPath, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open bot log file: %w", err)
+	}
+	b.logFile = logFile
+
+	// Prepare cmd and start bot process
+
+	cmd := exec.Command(b.binPath, "--config", b.configPath) //nolint:gosec // this is a cmb binary, not some injection.
+	cmd.Stdout = b.logFile
+	cmd.Stderr = b.logFile
+
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("failed to start bot (%d): %w", cmd.Process.Pid, err)
+	}
+
+	b.pid = cmd.Process.Pid
+
+	// Prepare RPC client
+
+	if b.rpcConnectionString != "" {
+		rpcClientConnection, err := grpc.NewClient(b.rpcConnectionString, grpc.WithTransportCredentials(insecure.NewCredentials()))
+		if err != nil {
+			return nil, fmt.Errorf("failed to create grpc client: %w", err)
+		}
+		b.rpcClient = &rpcClient{
+			connection:             rpcClientConnection,
+			ReadinessServiceClient: readiness.NewReadinessServiceClient(rpcClientConnection),
+			Client:                 generated.NewClient(rpcClientConnection),
+		}
+	}
+
+	// Await bot readiness if RPC client is set
+
+	if b.rpcClient != nil {
+		if err := b.awaitReady(ctx); err != nil {
+			return nil, fmt.Errorf("failed to await bot readiness (pid %d): %w", b.pid, err)
+		}
+	} else {
+		b.logger.Debugf("bot (pid %d) started without RPC server: no readiness check", cmd.Process.Pid)
+	}
+
+	// Await bot process error async
+
+	errChan := make(chan error)
+	go func() {
+		defer close(errChan)
+		err := <-process.ListenForProcessError(cmd)
+		if err != nil {
+			errChan <- fmt.Errorf("bot (pid %d) failed: %w", b.pid, err)
+		}
+	}()
+
+	// Successfully started bot
+
+	b.logger.Debugf("bot (pid %d) started", cmd.Process.Pid)
+	return errChan, nil
 }
 
 func (b *Bot) Stop(ctx context.Context) error {
 	if b == nil {
 		return nil
 	}
+
+	oldPID := b.pid
 	if err := process.StopProcess(ctx, b.pid); err != nil {
 		return fmt.Errorf("failed to stop cmb process with pid %d: %w", b.pid, err)
 	}
-	b.logger.Debugf("Bot (pid %d) stopped", b.pid)
-	if err := b.logFile.Close(); err != nil {
-		return fmt.Errorf("failed to close cmb logFile: %w", err)
+	b.pid = 0
+	b.logger.Debugf("Bot (pid %d) stopped", oldPID)
+
+	if b.logFile != nil {
+		if err := b.logFile.Close(); err != nil {
+			return fmt.Errorf("failed to close cmb logFile: %w", err)
+		}
+		b.logFile = nil
 	}
+
+	if b.rpcClient != nil {
+		if err := b.rpcClient.close(); err != nil {
+			return fmt.Errorf("failed to close rpc client: %w", err)
+		}
+		b.rpcClient = nil
+	}
+
 	return nil
+}
+
+func (b *Bot) Restart(ctx context.Context) (chan error, error) {
+	b.logger.Debugf("Restarting bot (pid %d)", b.pid)
+
+	oldPID := b.pid
+
+	if err := b.Stop(ctx); err != nil {
+		return nil, fmt.Errorf("failed to stop bot (pid %d): %w", b.pid, err)
+	}
+
+	errChan, err := b.Start(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to start bot (old pid %d, new pid %d): %w", oldPID, b.pid, err)
+	}
+
+	b.logger.Debugf("Bot (old pid %d, new pid %d) restarted", oldPID, b.pid)
+	return errChan, nil
 }
 
 func (b *Bot) CMAccountAddress() common.Address {
@@ -67,6 +187,12 @@ func (b *Bot) awaitReady(ctx context.Context) error {
 }
 
 type rpcClient struct {
+	connection *grpc.ClientConn
+
 	readiness.ReadinessServiceClient
 	*generated.Client
+}
+
+func (c *rpcClient) close() error {
+	return c.connection.Close()
 }

--- a/tests/e2e/bot/factory.go
+++ b/tests/e2e/bot/factory.go
@@ -196,6 +196,11 @@ func (f *Factory) CreateBot(
 		return nil, nil, fmt.Errorf("failed to write bot config file: %w", err)
 	}
 
+	rpcClientConnectionString := ""
+	if config.RPCServer.Enabled {
+		rpcClientConnectionString = fmt.Sprintf("localhost:%d", config.RPCServer.Port) // rpc client connection string
+	}
+
 	// Start bot
 
 	bot := newBot(
@@ -204,7 +209,7 @@ func (f *Factory) CreateBot(
 		f.binPath,
 		configPath,
 		path.Join(botDir, "bot.log"), // log file path
-		fmt.Sprintf("localhost:%d", config.RPCServer.Port), // rpc client connection string
+		rpcClientConnectionString,
 	)
 	f.bots = append(f.bots, bot)
 

--- a/tests/e2e/bot/factory.go
+++ b/tests/e2e/bot/factory.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"path"
 	"strconv"
 	"sync"
@@ -19,17 +18,12 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"go.uber.org/zap"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/chain4travel/camino-messenger-bot/v11/config"
-	"github.com/chain4travel/camino-messenger-bot/v11/proto/pb/readiness"
 	"github.com/chain4travel/camino-messenger-bot/v11/tests/e2e/blockchain"
-	e2eGenerated "github.com/chain4travel/camino-messenger-bot/v11/tests/e2e/bot/generated"
 	e2eCommon "github.com/chain4travel/camino-messenger-bot/v11/tests/e2e/common"
 	"github.com/chain4travel/camino-messenger-bot/v11/tests/e2e/matrix"
 	partnerplugin "github.com/chain4travel/camino-messenger-bot/v11/tests/e2e/partner_plugin"
-	"github.com/chain4travel/camino-messenger-bot/v11/tests/e2e/process"
 	"github.com/chain4travel/camino-messenger-bot/v11/tests/e2e/resources"
 )
 
@@ -158,7 +152,7 @@ func (f *Factory) CreateBot(
 
 	botDir := path.Join(f.dir, strconv.Itoa(len(f.bots)))
 
-	config := config.UnparsedConfig{
+	config := &config.UnparsedConfig{
 		DeveloperMode:                       true,
 		E2ETestMode:                         true,
 		BotKey:                              hex.EncodeToString(crypto.FromECDSA(botKey)),
@@ -202,66 +196,22 @@ func (f *Factory) CreateBot(
 		return nil, nil, fmt.Errorf("failed to write bot config file: %w", err)
 	}
 
-	// Prepare grpc client for bot
-
-	clientConnection, err := grpc.NewClient(
-		fmt.Sprintf("localhost:%d", config.RPCServer.Port),
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-	)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create grpc client: %w", err)
-	}
-
 	// Start bot
 
-	cmd := exec.Command(f.binPath, "--config", configPath) //nolint:gosec // this is a cmb binary, not some injection.
-
-	logFile, err := os.OpenFile(path.Join(botDir, "bot.log"), os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o600)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to open bot log file: %w", err)
-	}
-	cmd.Stdout = logFile
-	cmd.Stderr = logFile
-
-	if err := cmd.Start(); err != nil {
-		return nil, nil, fmt.Errorf("failed to start bot (%d): %w", cmd.Process.Pid, err)
-	}
-
-	bot := &Bot{
-		logger: f.logger,
-		pid:    cmd.Process.Pid,
-		rpcClient: &rpcClient{
-			ReadinessServiceClient: readiness.NewReadinessServiceClient(clientConnection),
-			Client:                 e2eGenerated.NewClient(clientConnection),
-		},
-		cmAccountAddress: cmAccountAddress,
-		logFile:          logFile,
-	}
-
-	// Await bot readiness
-
-	if config.RPCServer.Enabled {
-		if err := bot.awaitReady(ctx); err != nil {
-			return bot, nil, fmt.Errorf("failed to await bot readiness: %w", err)
-		}
-	} else {
-		f.logger.Debugf("bot (pid %d) started without RPC server: no readiness check", cmd.Process.Pid)
-	}
-
-	f.logger.Debugf("bot (pid %d) started", cmd.Process.Pid)
-
+	bot := newBot(
+		f.logger,
+		cmAccountAddress,
+		f.binPath,
+		configPath,
+		path.Join(botDir, "bot.log"), // log file path
+		fmt.Sprintf("localhost:%d", config.RPCServer.Port), // rpc client connection string
+	)
 	f.bots = append(f.bots, bot)
 
-	// Await bot process error async
-
-	errChan := make(chan error)
-	go func() {
-		err := <-process.ListenForProcessError(cmd)
-		if err != nil {
-			errChan <- fmt.Errorf("bot (pid %d) failed: %w", bot.pid, err)
-		}
-		close(errChan)
-	}()
+	errChan, err := bot.Start(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to start bot: %w", err)
+	}
 
 	return bot, errChan, nil
 }

--- a/tests/e2e/tests/test.go
+++ b/tests/e2e/tests/test.go
@@ -45,6 +45,18 @@ func (tt *Test) createBot(
 	return bot
 }
 
+func (tt *Test) restartBot( //nolint:unused
+	ctx context.Context,
+	t *testing.T,
+	bot *bot.Bot,
+) *bot.Bot {
+	t.Helper()
+	errChan, err := bot.Restart(ctx)
+	require.NoError(t, err)
+	expectNoErrorAsync(t, errChan)
+	return bot
+}
+
 func (tt *Test) createPartnerPlugin(
 	ctx context.Context,
 	t *testing.T,


### PR DESCRIPTION
Refactors e2e tests bot & factory to allow restarting bots.
This feature is not used in current build, but it was actively used in local debug-testing for other PRs and seems very reasonable and usable to have in e2e tests.