### PR TITLE
Improve app components start, stop and logging.

### DIFF
--- a/cmd/camino_messenger_bot.go
+++ b/cmd/camino_messenger_bot.go
@@ -18,11 +18,13 @@ import (
 )
 
 var rootCmd = &cobra.Command{
-	Use:        "camino-messenger-bot",
-	Short:      "starts camino messenger bot",
-	Version:    version.FullVersion,
-	SuggestFor: []string{"camino-messenger", "camino-messenger-bot", "camino-bot", "cmb"},
-	RunE:       rootFunc,
+	Use:           "camino-messenger-bot",
+	Short:         "starts camino messenger bot",
+	Version:       version.FullVersion,
+	SuggestFor:    []string{"camino-messenger", "camino-messenger-bot", "camino-bot", "cmb"},
+	RunE:          rootFunc,
+	SilenceErrors: true,
+	SilenceUsage:  true,
 }
 
 func rootFunc(cmd *cobra.Command, _ []string) error {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -394,9 +394,9 @@ func (a *App) Run(ctx context.Context) error {
 
 	g.Go(func() error {
 		a.logger.Info("Starting message processor...")
-		a.logger.Info("Message processor started.") // for consistency, start just runs for{} without any errors
-		close(messageProcessorStarted)
 		a.messageProcessor.Start(ctx)
+		a.logger.Info("Message processor started.")
+		close(messageProcessorStarted)
 		return nil
 	})
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -5,6 +5,7 @@ package app
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"net/url"
@@ -16,6 +17,7 @@ import (
 	"github.com/jonboulle/clockwork"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
+	"google.golang.org/grpc"
 	"maunium.net/go/mautrix/id"
 
 	"github.com/chain4travel/camino-messenger-bot/v11/config"
@@ -66,6 +68,7 @@ func NewApp(ctx context.Context, cfg *config.Config, logger *zap.SugaredLogger) 
 	var tracer tracing.Tracer
 	if cfg.Tracing.Enabled {
 		tracer, err = tracing.NewTracer(
+			ctx,
 			cfg.Tracing,
 			fmt.Sprintf("%s:%d", appName, cfg.RPCServer.Port),
 		)
@@ -113,6 +116,7 @@ func NewApp(ctx context.Context, cfg *config.Config, logger *zap.SugaredLogger) 
 		logger,
 		cmAccountsCacheSize,
 		evmClient,
+		chainID,
 	)
 	if err != nil {
 		logger.Errorf("Failed to create cm accounts service: %v", err)
@@ -222,12 +226,6 @@ func NewApp(ctx context.Context, cfg *config.Config, logger *zap.SugaredLogger) 
 		return nil, err
 	}
 
-	matrixMessenger, err := matrix.NewMessenger(cfg.Matrix, cfg.BotKey, logger)
-	if err != nil {
-		logger.Errorf("Failed to create matrix messenger: %v", err)
-		return nil, err
-	}
-
 	// get matrix hostname without schema
 	matrixHostname := cfg.Matrix.Host
 	if !strings.Contains(matrixHostname, "://") {
@@ -243,6 +241,12 @@ func NewApp(ctx context.Context, cfg *config.Config, logger *zap.SugaredLogger) 
 
 	botAddress := crypto.PubkeyToAddress(cfg.BotKey.PublicKey)
 	botUserID := matrixPkg.UserIDFromAddress(botAddress, matrixHostname)
+
+	matrixMessenger, err := matrix.NewMessenger(logger, cfg.Matrix, cfg.BotKey, botUserID)
+	if err != nil {
+		logger.Errorf("Failed to create matrix messenger: %v", err)
+		return nil, err
+	}
 
 	messageProcessor := messaging.NewMessageProcessor(
 		matrixMessenger,
@@ -295,9 +299,6 @@ func NewApp(ctx context.Context, cfg *config.Config, logger *zap.SugaredLogger) 
 	}
 
 	scheduler := scheduler.New(logger, storage, clockwork.NewRealClock())
-	scheduler.RegisterJobHandler(cashInJobName, func() {
-		_ = chequeHandler.CashIn(context.Background())
-	})
 
 	return &App{
 		cfg:              cfg,
@@ -330,12 +331,13 @@ type App struct {
 
 func (a *App) Run(ctx context.Context) error {
 	defer func() {
-		if err := a.tracer.Shutdown(); err != nil {
+		// we use background context, because we want to try to shutdown tracer gracefully regardless
+		if err := a.tracer.Shutdown(context.Background()); err != nil {
 			a.logger.Errorf("failed to shutdown tracer: %v", err)
 		}
 	}()
 
-	g, gCtx := errgroup.WithContext(ctx) // error here will call gCtx.cancel() and finish other Go-s
+	g, ctx := errgroup.WithContext(ctx) // error here will call ctx.cancel() and finish other Go-s
 
 	// run
 
@@ -346,8 +348,8 @@ func (a *App) Run(ctx context.Context) error {
 
 	g.Go(func() error {
 		a.logger.Info("Starting start-up cash-in status check...")
-		if err := a.chequeHandler.CheckCashInStatus(gCtx); err != nil {
-			return fmt.Errorf("failed to check start-up cash-in status: %w", err)
+		if err := a.chequeHandler.CheckCashInStatus(ctx); err != nil {
+			return fmt.Errorf("failed to do start-up cash-in status check: %w", err)
 		}
 		a.logger.Info("Start-up cash-in status check done.")
 		close(cashInStatusCheckDone)
@@ -357,7 +359,7 @@ func (a *App) Run(ctx context.Context) error {
 	eventListenerStarted := make(chan struct{})
 	g.Go(func() error {
 		a.logger.Info("Starting event listener...")
-		if err := a.eventListener.Start(gCtx); err != nil {
+		if err := a.eventListener.Start(ctx); err != nil {
 			return fmt.Errorf("failed to start event listener: %w", err)
 		}
 		a.logger.Info("Event listener started.")
@@ -366,18 +368,25 @@ func (a *App) Run(ctx context.Context) error {
 	})
 
 	g.Go(func() error {
-		if !awaitChan(gCtx, cashInStatusCheckDone) {
+		if !awaitChan(ctx, cashInStatusCheckDone) {
 			return nil
 		}
-
 		a.logger.Info("Starting scheduler...")
 
-		if err := a.scheduler.Schedule(gCtx, a.cfg.CashInPeriod, cashInJobName); err != nil {
+		a.scheduler.RegisterJobHandler(cashInJobName, func() {
+			if err := a.chequeHandler.CashIn(ctx); err != nil && !errors.Is(err, context.Canceled) {
+				a.logger.Errorf("Failed to do scheduled cash in: %v", err)
+				return
+			}
+		})
+
+		if err := a.scheduler.Schedule(ctx, a.cfg.CashInPeriod, cashInJobName); err != nil {
 			return fmt.Errorf("failed to schedule cash in job: %w", err)
 		}
-		if err := a.scheduler.Start(gCtx); err != nil {
+		if err := a.scheduler.Start(ctx); err != nil {
 			return fmt.Errorf("failed to start scheduler: %w", err)
 		}
+
 		a.logger.Info("Scheduler started.")
 		close(schedulerStarted)
 		return nil
@@ -385,13 +394,14 @@ func (a *App) Run(ctx context.Context) error {
 
 	g.Go(func() error {
 		a.logger.Info("Starting message processor...")
+		a.logger.Info("Message processor started.") // for consistency, start just runs for{} without any errors
 		close(messageProcessorStarted)
-		a.messageProcessor.Start(gCtx)
+		a.messageProcessor.Start(ctx)
 		return nil
 	})
 
 	g.Go(func() error {
-		if !awaitChans(gCtx,
+		if !awaitChans(ctx,
 			cashInStatusCheckDone,
 			schedulerStarted,
 			messageProcessorStarted,
@@ -399,26 +409,37 @@ func (a *App) Run(ctx context.Context) error {
 		) {
 			return nil
 		}
+
 		a.logger.Info("Starting message receiver...")
-		matrixUserID, err := a.messenger.StartReceiver()
-		if err != nil {
+
+		if err := a.messenger.StartReceiver(ctx); err != nil {
 			return fmt.Errorf("failed to start message receiver: %w", err)
 		}
-		if a.botUserID != matrixUserID {
-			return fmt.Errorf("bot user ID mismatch: expected %s, got %s", a.botUserID, matrixUserID)
-		}
+
+		a.logger.Info("Message receiver started.")
 		close(messengerReceiverStarted)
 		return nil
 	})
 
 	if a.rpcServer != nil { // rpcServer will be nil, if its disabled in config
 		g.Go(func() error {
-			if !awaitChan(gCtx, messengerReceiverStarted) {
+			if !awaitChan(ctx, messengerReceiverStarted) {
 				return nil
 			}
 
 			a.logger.Info("Starting gRPC server...")
-			return a.rpcServer.Start()
+			errChan, err := a.rpcServer.Start()
+			if err != nil {
+				return fmt.Errorf("failed to start gRPC server: %w", err)
+			}
+
+			a.logger.Info("gRPC server started.")
+
+			if err := <-errChan; err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, grpc.ErrServerStopped) {
+				a.logger.Errorf("gRPC server stopped with error: %v", err)
+				return err
+			}
+			return nil
 		})
 	}
 
@@ -426,37 +447,51 @@ func (a *App) Run(ctx context.Context) error {
 
 	if a.rpcClient != nil { // rpcClient will be nil, if its disabled in partner plugin config section
 		g.Go(func() error {
-			<-gCtx.Done()
+			<-ctx.Done()
 			a.logger.Info("Stopping gRPC client...")
-			return a.rpcClient.Shutdown()
+			if err := a.rpcClient.Shutdown(); err != nil && !errors.Is(err, context.Canceled) {
+				a.logger.Errorf("Failed to stop gRPC client: %v", err)
+				return err
+			}
+			a.logger.Info("gRPC client stopped.")
+			return nil
 		})
 	}
 
 	if a.rpcServer != nil { // rpcServer will be nil, if its disabled in config
 		g.Go(func() error {
-			<-gCtx.Done()
+			<-ctx.Done()
 			a.logger.Info("Stopping gRPC server...")
 			a.rpcServer.Stop()
+			a.logger.Info("gRPC server stopped.")
 			return nil
 		})
 	}
 
 	g.Go(func() error {
-		<-gCtx.Done()
+		<-ctx.Done()
 		a.logger.Info("Stopping message receiver...")
-		return a.messenger.StopReceiver()
+		if err := a.messenger.StopReceiver(); err != nil && !errors.Is(err, context.Canceled) {
+			a.logger.Errorf("Failed to stop message receiver: %v", err)
+			return err
+		}
+		a.logger.Info("Message receiver stopped.")
+		return nil
 	})
 
 	g.Go(func() error {
-		<-gCtx.Done()
+		<-ctx.Done()
 		a.logger.Info("Stopping scheduler...")
-		return a.scheduler.Stop()
+		a.scheduler.Stop()
+		a.logger.Info("Scheduler stopped.")
+		return nil
 	})
 
 	g.Go(func() error {
-		<-gCtx.Done()
+		<-ctx.Done()
 		a.logger.Info("Stopping event listener...")
 		a.eventListener.Stop()
+		a.logger.Info("Event listener stopped.")
 		return nil
 	})
 
@@ -464,7 +499,7 @@ func (a *App) Run(ctx context.Context) error {
 
 	err := g.Wait()
 	if err != nil {
-		a.logger.Error(err) // will log first run/stop error
+		a.logger.Errorf("App stopped with error: %v", err) // will log first run/stop error
 	}
 
 	return err

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -412,12 +412,18 @@ func (a *App) Run(ctx context.Context) error {
 
 		a.logger.Info("Starting message receiver...")
 
-		if err := a.messenger.StartReceiver(ctx); err != nil {
+		errChan, err := a.messenger.StartReceiver(ctx)
+		if err != nil {
 			return fmt.Errorf("failed to start message receiver: %w", err)
 		}
 
 		a.logger.Info("Message receiver started.")
 		close(messengerReceiverStarted)
+
+		if err := <-errChan; err != nil && !errors.Is(err, context.Canceled) {
+			a.logger.Errorf("Message receiver exited with error: %v", err)
+			return err
+		}
 		return nil
 	})
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -113,10 +113,10 @@ func NewApp(ctx context.Context, cfg *config.Config, logger *zap.SugaredLogger) 
 	// blockchain services
 
 	cmAccounts, err := cmaccounts.NewService(
+		ctx,
 		logger,
 		cmAccountsCacheSize,
 		evmClient,
-		chainID,
 	)
 	if err != nil {
 		logger.Errorf("Failed to create cm accounts service: %v", err)

--- a/internal/event_listener/event_listener.go
+++ b/internal/event_listener/event_listener.go
@@ -121,7 +121,10 @@ func (l *eventListener) Start(ctx context.Context) error {
 }
 
 func (l *eventListener) Stop() {
-	l.unsubscribeTokenBought()
-	l.stopTokenBoughtTimer()
-	l.unsubscribeCancellation()
+	if l.unsubscribeTokenBought != nil { // if eventListener started token bought subscriptions correctly
+		l.unsubscribeTokenBought()
+	}
+	if l.unsubscribeCancellation != nil { // if eventListener started cancellation subscriptions correctly
+		l.unsubscribeCancellation()
+	}
 }

--- a/internal/event_listener/subscription_token_bought.go
+++ b/internal/event_listener/subscription_token_bought.go
@@ -68,8 +68,18 @@ func (l *eventListener) startTokenBoughtSubscriptions(ctx context.Context) error
 		l.logger.Errorf("error checking token bought subscriptions: %v", err)
 		return err
 	}
-	l.unsubscribeTokenBought = l.subscriber.SubscribeTokenBought(l.tokenBoughtEventHandler)
+
+	unsubscribe := l.subscriber.SubscribeTokenBought(l.tokenBoughtEventHandler)
 	l.startTokenBoughtTimer(nextToExpireSubscription)
+
+	l.unsubscribeTokenBought = func() {
+		unsubscribe()
+
+		l.tokenBoughtTimerMutex.Lock()
+		defer l.tokenBoughtTimerMutex.Unlock()
+		l.tokenBoughtTimer.Stop()
+	}
+
 	return nil
 }
 
@@ -311,12 +321,6 @@ func (l *eventListener) resetTokenBoughtTimerFromDB(ctx context.Context) {
 		l.tokenBoughtTimerSubscription = nextToExpireSubscription
 		l.tokenBoughtTimer = time.AfterFunc(timeUntil(nextToExpireSubscription.Timeout), l.tokenBoughtTimeoutHandler)
 	}
-}
-
-func (l *eventListener) stopTokenBoughtTimer() {
-	l.tokenBoughtTimerMutex.Lock()
-	defer l.tokenBoughtTimerMutex.Unlock()
-	l.tokenBoughtTimer.Stop()
 }
 
 func timeUntil(t time.Time) time.Duration {

--- a/internal/matrix/matrix_messenger.go
+++ b/internal/matrix/matrix_messenger.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"sync"
 	"time"
 
 	"github.com/chain4travel/camino-messenger-bot/v11/config"
@@ -46,10 +45,13 @@ func NewMessenger(
 		return nil, err
 	}
 	return &messenger{
-		msgChannel:        make(chan types.Message),
-		logger:            logger,
-		tracer:            otel.GetTracerProvider().Tracer(""),
-		client:            client{Client: c},
+		msgChannel: make(chan types.Message),
+		logger:     logger,
+		tracer:     otel.GetTracerProvider().Tracer(""),
+		client: client{
+			Client:         c,
+			syncerStopChan: make(chan struct{}),
+		},
 		roomHandler:       NewRoomHandler(NewClient(c), logger),
 		msgAssembler:      NewMessageAssembler(),
 		botKey:            botKey,
@@ -74,17 +76,17 @@ type messenger struct {
 
 type client struct {
 	*mautrix.Client
-	ctx             context.Context
-	cancelSync      context.CancelFunc
-	syncerWaitGroup sync.WaitGroup
-	cryptoHelper    *cryptohelper.CryptoHelper
+	ctx            context.Context
+	cancelSync     context.CancelFunc
+	syncerStopChan chan struct{}
+	cryptoHelper   *cryptohelper.CryptoHelper
 }
 
 func (m *messenger) checkpoint() string {
 	return "messenger-gateway"
 }
 
-func (m *messenger) StartReceiver(ctx context.Context) error {
+func (m *messenger) StartReceiver(ctx context.Context) (chan error, error) {
 	syncer := m.client.Syncer.(*mautrix.DefaultSyncer)
 
 	syncer.OnEventType(matrix.EventTypeC4TMessage, func(ctx context.Context, evt *event.Event) {
@@ -135,12 +137,12 @@ func (m *messenger) StartReceiver(ctx context.Context) error {
 
 	cryptoHelper, err := cryptohelper.NewCryptoHelper(m.client.Client, []byte("meow"), m.dbPath) // TODO refactor
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	signature, message, err := SignPublicKey(m.botKey)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	cryptoHelper.LoginAs = &mautrix.ReqLogin{
@@ -150,11 +152,11 @@ func (m *messenger) StartReceiver(ctx context.Context) error {
 	}
 
 	if err = cryptoHelper.Init(ctx); err != nil {
-		return err
+		return nil, err
 	}
 
 	if m.client.Client.UserID != m.expectedBotUserID {
-		return fmt.Errorf("expected user ID %s, got %s", m.expectedBotUserID, m.client.Client.UserID)
+		return nil, fmt.Errorf("expected user ID %s, got %s", m.expectedBotUserID, m.client.Client.UserID)
 	}
 
 	// Set the wrappedClient crypto helper in order to automatically encrypt outgoing messages
@@ -162,20 +164,23 @@ func (m *messenger) StartReceiver(ctx context.Context) error {
 	m.client.cryptoHelper = cryptoHelper // nikos: we need the struct cause stop method is not available on the interface level
 
 	m.logger.Infof("Successfully logged in as: %s", m.client.UserID)
-	syncCtx, cancelSync := context.WithCancel(ctx)
-	m.client.ctx = syncCtx
-	m.client.cancelSync = cancelSync
-	m.client.syncerWaitGroup.Add(1)
+	m.client.ctx, m.client.cancelSync = context.WithCancel(ctx)
+	errChan := make(chan error)
 
 	go func() {
-		defer m.client.syncerWaitGroup.Done()
+		defer func() {
+			close(errChan)
+			close(m.client.syncerStopChan)
+		}()
 
-		if err := m.client.SyncWithContext(syncCtx); err != nil && !errors.Is(err, context.Canceled) {
-			m.logger.Errorf("matrix event syncer exited with error: %w", err)
+		if err := m.client.SyncWithContext(m.client.ctx); err != nil && !errors.Is(err, context.Canceled) {
+			err := fmt.Errorf("matrix event syncer exited with error: %w", err)
+			m.logger.Error(err)
+			errChan <- err
 		}
 	}()
 
-	return nil
+	return errChan, nil
 }
 
 func (m *messenger) StopReceiver() error {
@@ -183,7 +188,7 @@ func (m *messenger) StopReceiver() error {
 	if m.client.cancelSync != nil {
 		m.client.cancelSync()
 	}
-	m.client.syncerWaitGroup.Wait()
+	<-m.client.syncerStopChan
 	if err := m.client.cryptoHelper.Close(); err != nil {
 		m.logger.Errorf("Failed to close crypto helper: %v", err)
 	}

--- a/internal/matrix/matrix_messenger.go
+++ b/internal/matrix/matrix_messenger.go
@@ -34,31 +34,38 @@ import (
 
 var _ messaging.Messenger = (*messenger)(nil)
 
-func NewMessenger(cfg config.MatrixConfig, botKey *ecdsa.PrivateKey, logger *zap.SugaredLogger) (messaging.Messenger, error) {
+func NewMessenger(
+	logger *zap.SugaredLogger,
+	cfg config.MatrixConfig,
+	botKey *ecdsa.PrivateKey,
+	expectedBotUserID id.UserID,
+) (messaging.Messenger, error) {
 	c, err := mautrix.NewClient(cfg.Host, "", "")
 	if err != nil {
 		logger.Errorf("failed to create matrix client: %v", err)
 		return nil, err
 	}
 	return &messenger{
-		msgChannel:   make(chan types.Message),
-		logger:       logger,
-		tracer:       otel.GetTracerProvider().Tracer(""),
-		client:       client{Client: c},
-		roomHandler:  NewRoomHandler(NewClient(c), logger),
-		msgAssembler: NewMessageAssembler(),
-		botKey:       botKey,
-		dbPath:       cfg.Store,
+		msgChannel:        make(chan types.Message),
+		logger:            logger,
+		tracer:            otel.GetTracerProvider().Tracer(""),
+		client:            client{Client: c},
+		roomHandler:       NewRoomHandler(NewClient(c), logger),
+		msgAssembler:      NewMessageAssembler(),
+		botKey:            botKey,
+		expectedBotUserID: expectedBotUserID,
+		dbPath:            cfg.Store,
 	}, nil
 }
 
 type messenger struct {
 	msgChannel chan types.Message
 
-	dbPath string
-	botKey *ecdsa.PrivateKey
-	logger *zap.SugaredLogger
-	tracer trace.Tracer
+	dbPath            string
+	botKey            *ecdsa.PrivateKey
+	expectedBotUserID id.UserID
+	logger            *zap.SugaredLogger
+	tracer            trace.Tracer
 
 	client       client
 	roomHandler  RoomHandler
@@ -67,17 +74,17 @@ type messenger struct {
 
 type client struct {
 	*mautrix.Client
-	ctx          context.Context
-	cancelSync   context.CancelFunc
-	syncStopWait sync.WaitGroup
-	cryptoHelper *cryptohelper.CryptoHelper
+	ctx             context.Context
+	cancelSync      context.CancelFunc
+	syncerWaitGroup sync.WaitGroup
+	cryptoHelper    *cryptohelper.CryptoHelper
 }
 
 func (m *messenger) checkpoint() string {
 	return "messenger-gateway"
 }
 
-func (m *messenger) StartReceiver() (id.UserID, error) {
+func (m *messenger) StartReceiver(ctx context.Context) error {
 	syncer := m.client.Syncer.(*mautrix.DefaultSyncer)
 
 	syncer.OnEventType(matrix.EventTypeC4TMessage, func(ctx context.Context, evt *event.Event) {
@@ -128,12 +135,12 @@ func (m *messenger) StartReceiver() (id.UserID, error) {
 
 	cryptoHelper, err := cryptohelper.NewCryptoHelper(m.client.Client, []byte("meow"), m.dbPath) // TODO refactor
 	if err != nil {
-		return "", err
+		return err
 	}
 
 	signature, message, err := SignPublicKey(m.botKey)
 	if err != nil {
-		return "", err
+		return err
 	}
 
 	cryptoHelper.LoginAs = &mautrix.ReqLogin{
@@ -142,29 +149,33 @@ func (m *messenger) StartReceiver() (id.UserID, error) {
 		Signature: signature[2:], // removing 0x prefix
 	}
 
-	err = cryptoHelper.Init(context.TODO())
-	if err != nil {
-		return "", err
+	if err = cryptoHelper.Init(ctx); err != nil {
+		return err
 	}
+
+	if m.client.Client.UserID != m.expectedBotUserID {
+		return fmt.Errorf("expected user ID %s, got %s", m.expectedBotUserID, m.client.Client.UserID)
+	}
+
 	// Set the wrappedClient crypto helper in order to automatically encrypt outgoing messages
 	m.client.Crypto = cryptoHelper
 	m.client.cryptoHelper = cryptoHelper // nikos: we need the struct cause stop method is not available on the interface level
 
 	m.logger.Infof("Successfully logged in as: %s", m.client.UserID)
-	syncCtx, cancelSync := context.WithCancel(context.Background())
+	syncCtx, cancelSync := context.WithCancel(ctx)
 	m.client.ctx = syncCtx
 	m.client.cancelSync = cancelSync
-	m.client.syncStopWait.Add(1)
+	m.client.syncerWaitGroup.Add(1)
 
 	go func() {
-		err = m.client.SyncWithContext(syncCtx)
-		defer m.client.syncStopWait.Done()
-		if err != nil && !errors.Is(err, context.Canceled) {
-			panic(err)
+		defer m.client.syncerWaitGroup.Done()
+
+		if err := m.client.SyncWithContext(syncCtx); err != nil && !errors.Is(err, context.Canceled) {
+			m.logger.Errorf("matrix event syncer exited with error: %w", err)
 		}
 	}()
 
-	return m.client.UserID, nil
+	return nil
 }
 
 func (m *messenger) StopReceiver() error {
@@ -172,8 +183,12 @@ func (m *messenger) StopReceiver() error {
 	if m.client.cancelSync != nil {
 		m.client.cancelSync()
 	}
-	m.client.syncStopWait.Wait()
-	return m.client.cryptoHelper.Close()
+	m.client.syncerWaitGroup.Wait()
+	if err := m.client.cryptoHelper.Close(); err != nil {
+		m.logger.Errorf("Failed to close crypto helper: %v", err)
+	}
+	m.logger.Info("Matrix syncer stopped")
+	return nil
 }
 
 func (m *messenger) SendAsync(ctx context.Context, msg *types.Message, sendTo id.UserID) error {

--- a/internal/messaging/messenger.go
+++ b/internal/messaging/messenger.go
@@ -16,7 +16,7 @@ type APIMessageResponse struct {
 }
 type Messenger interface {
 	// start receiving messages.
-	StartReceiver(context.Context) error
+	StartReceiver(ctx context.Context) (chan error, error)
 
 	// stop receiving messages
 	StopReceiver() error

--- a/internal/messaging/messenger.go
+++ b/internal/messaging/messenger.go
@@ -16,7 +16,7 @@ type APIMessageResponse struct {
 }
 type Messenger interface {
 	// start receiving messages.
-	StartReceiver(ctx context.Context) error
+	StartReceiver(context.Context) error
 
 	// stop receiving messages
 	StopReceiver() error

--- a/internal/messaging/messenger.go
+++ b/internal/messaging/messenger.go
@@ -15,8 +15,8 @@ type APIMessageResponse struct {
 	Err     error
 }
 type Messenger interface {
-	// start receiving messages. Returns the user id
-	StartReceiver() (id.UserID, error)
+	// start receiving messages.
+	StartReceiver(ctx context.Context) error
 
 	// stop receiving messages
 	StopReceiver() error

--- a/internal/messaging/mock_messenger.go
+++ b/internal/messaging/mock_messenger.go
@@ -70,18 +70,17 @@ func (mr *MockMessengerMockRecorder) SendAsync(arg0, arg1, arg2 any) *gomock.Cal
 }
 
 // StartReceiver mocks base method.
-func (m *MockMessenger) StartReceiver() (id.UserID, error) {
+func (m *MockMessenger) StartReceiver(arg0 context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "StartReceiver")
-	ret0, _ := ret[0].(id.UserID)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret := m.ctrl.Call(m, "StartReceiver", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // StartReceiver indicates an expected call of StartReceiver.
-func (mr *MockMessengerMockRecorder) StartReceiver() *gomock.Call {
+func (mr *MockMessengerMockRecorder) StartReceiver(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartReceiver", reflect.TypeOf((*MockMessenger)(nil).StartReceiver))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartReceiver", reflect.TypeOf((*MockMessenger)(nil).StartReceiver), arg0)
 }
 
 // StopReceiver mocks base method.

--- a/internal/messaging/mock_messenger.go
+++ b/internal/messaging/mock_messenger.go
@@ -70,11 +70,12 @@ func (mr *MockMessengerMockRecorder) SendAsync(arg0, arg1, arg2 any) *gomock.Cal
 }
 
 // StartReceiver mocks base method.
-func (m *MockMessenger) StartReceiver(arg0 context.Context) error {
+func (m *MockMessenger) StartReceiver(arg0 context.Context) (chan error, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StartReceiver", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(chan error)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // StartReceiver indicates an expected call of StartReceiver.

--- a/internal/messaging/processor.go
+++ b/internal/messaging/processor.go
@@ -120,21 +120,24 @@ func (*messageProcessor) checkpoint() string {
 }
 
 func (p *messageProcessor) Start(ctx context.Context) {
-	for {
-		select {
-		case msgEvent := <-p.messenger.Inbound():
-			p.logger.Debug("Processing msg event of type: ", msgEvent.Type)
-			go func() {
-				if err := p.ProcessIncomingMessage(&msgEvent); err != nil {
-					p.logger.Warnf("could not process message: %v", err)
-				}
-			}()
-		case <-ctx.Done():
-			p.logger.Info("Stopping processor...")
-			p.logger.Info("Processor stopped") // for consistency
-			return
+	go func() {
+		for {
+			select {
+			case msgEvent := <-p.messenger.Inbound():
+				p.logger.Debug("Processing msg event of type: ", msgEvent.Type)
+				go func() {
+					if err := p.ProcessIncomingMessage(&msgEvent); err != nil {
+						p.logger.Warnf("could not process message: %v", err)
+					}
+				}()
+			case <-ctx.Done():
+				// for consistency with how other components log their shutdown
+				p.logger.Info("Stopping processor...")
+				p.logger.Info("Processor stopped")
+				return
+			}
 		}
-	}
+	}()
 }
 
 func (p *messageProcessor) ProcessIncomingMessage(msg *types.Message) error {

--- a/internal/messaging/processor.go
+++ b/internal/messaging/processor.go
@@ -131,6 +131,7 @@ func (p *messageProcessor) Start(ctx context.Context) {
 			}()
 		case <-ctx.Done():
 			p.logger.Info("Stopping processor...")
+			p.logger.Info("Processor stopped") // for consistency
 			return
 		}
 	}

--- a/internal/rpc/client/client.go
+++ b/internal/rpc/client/client.go
@@ -47,6 +47,5 @@ func NewClient(cfg config.PartnerPluginConfig, logger *zap.SugaredLogger) (*RPCC
 }
 
 func (rc *RPCClient) Shutdown() error {
-	rc.logger.Info("Shutting down gRPC client...")
 	return rc.ClientConn.Close()
 }

--- a/internal/rpc/server/server.go
+++ b/internal/rpc/server/server.go
@@ -5,6 +5,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 
@@ -37,7 +38,7 @@ var (
 )
 
 type Server interface {
-	Start() error
+	Start() (chan error, error)
 	Stop()
 }
 
@@ -112,12 +113,26 @@ func (*server) checkpoint() string {
 	return "request-gateway"
 }
 
-func (s *server) Start() error {
+func (s *server) Start() (chan error, error) {
 	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", s.cfg.Port))
 	if err != nil {
-		return fmt.Errorf("failed to listen: %w", err)
+		return nil, fmt.Errorf("failed to listen: %w", err)
 	}
-	return s.grpcServer.Serve(lis)
+
+	errChan := make(chan error)
+
+	go func() {
+		defer close(errChan)
+
+		s.logger.Infof("gRPC server listening on %s", lis.Addr().String())
+
+		if err := s.grpcServer.Serve(lis); err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, grpc.ErrServerStopped) {
+			s.logger.Errorf("gRPC server stopped serving with error: %w", err)
+			errChan <- err
+		}
+	}()
+
+	return errChan, nil
 }
 
 func (s *server) Stop() {

--- a/internal/tracing/exporter.go
+++ b/internal/tracing/exporter.go
@@ -21,7 +21,7 @@ const (
 	exporterInstantiationTimeout = 5 * time.Second
 )
 
-func newExporter(cfg *config.TracingConfig) (trace.SpanExporter, error) {
+func newExporter(ctx context.Context, cfg *config.TracingConfig) (trace.SpanExporter, error) {
 	var client otlptrace.Client
 	opts := []otlptracegrpc.Option{
 		otlptracegrpc.WithEndpoint(cfg.Host),
@@ -37,7 +37,7 @@ func newExporter(cfg *config.TracingConfig) (trace.SpanExporter, error) {
 		opts = append(opts, otlptracegrpc.WithTLSCredentials(creds))
 	}
 	client = otlptracegrpc.NewClient(opts...)
-	ctx, cancel := context.WithTimeout(context.Background(), exporterInstantiationTimeout)
+	ctx, cancel := context.WithTimeout(ctx, exporterInstantiationTimeout)
 	defer cancel()
 	return otlptrace.New(ctx, client)
 }

--- a/internal/tracing/nooptracer.go
+++ b/internal/tracing/nooptracer.go
@@ -27,7 +27,7 @@ func (n *noopTracer) Start(ctx context.Context, spanName string, opts ...trace.S
 	return n.TracerProvider.Tracer("").Start(ctx, spanName, opts...)
 }
 
-func (n *noopTracer) Shutdown() error {
+func (n *noopTracer) Shutdown(context.Context) error {
 	return nil // nothing to do here
 }
 

--- a/internal/tracing/tracer.go
+++ b/internal/tracing/tracer.go
@@ -23,7 +23,7 @@ var _ Tracer = (*tracer)(nil)
 type Tracer interface {
 	trace.Tracer
 	TraceIDForSpan(trace.Span) trace.TraceID // TraceIDForSpan returns the trace ID of the given span.
-	Shutdown() error
+	Shutdown(ctx context.Context) error
 }
 
 type tracer struct {
@@ -35,8 +35,8 @@ func (t *tracer) Start(ctx context.Context, spanName string, opts ...trace.SpanS
 	return t.TracerProvider.Tracer("").Start(ctx, spanName, opts...)
 }
 
-func (t *tracer) Shutdown() error {
-	ctx, cancel := context.WithTimeout(context.Background(), tracerProviderShutdownTimeout)
+func (t *tracer) Shutdown(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, tracerProviderShutdownTimeout)
 	defer cancel()
 	return t.TracerProvider.Shutdown(ctx)
 }
@@ -45,8 +45,8 @@ func (t *tracer) TraceIDForSpan(span trace.Span) trace.TraceID {
 	return span.SpanContext().TraceID()
 }
 
-func NewTracer(cfg config.TracingConfig, name string) (Tracer, error) {
-	exporter, err := newExporter(&cfg)
+func NewTracer(ctx context.Context, cfg config.TracingConfig, name string) (Tracer, error) {
+	exporter, err := newExporter(ctx, &cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/main.go
+++ b/main.go
@@ -4,13 +4,13 @@
 package main
 
 import (
-	"log"
+	"os"
 
 	"github.com/chain4travel/camino-messenger-bot/v11/cmd"
 )
 
 func main() {
 	if err := cmd.Execute(); err != nil {
-		log.Fatalln(err)
+		os.Exit(1)
 	}
 }

--- a/pkg/chequehandler/cheque_handler.go
+++ b/pkg/chequehandler/cheque_handler.go
@@ -353,7 +353,7 @@ func (ch *evmChequeHandler) CashIn(ctx context.Context) error {
 		wg.Add(1)
 		go func(txID common.Hash) {
 			defer wg.Done()
-			_ = ch.checkCashInStatus(ctx, txID)
+			_ = ch.checkCashInTxStatus(ctx, txID)
 		}(chequeRecord.TxID)
 	}
 
@@ -381,7 +381,7 @@ func (ch *evmChequeHandler) CheckCashInStatus(ctx context.Context) error {
 	for _, chequeRecord := range chequeRecords {
 		txID := chequeRecord.TxID
 		g.Go(func() (err error) {
-			return ch.checkCashInStatus(ctx, txID)
+			return ch.checkCashInTxStatus(ctx, txID)
 		})
 	}
 
@@ -392,7 +392,7 @@ func (ch *evmChequeHandler) CheckCashInStatus(ctx context.Context) error {
 	return err
 }
 
-func (ch *evmChequeHandler) checkCashInStatus(ctx context.Context, txID common.Hash) error {
+func (ch *evmChequeHandler) checkCashInTxStatus(ctx context.Context, txID common.Hash) error {
 	// TODO @evlekht timeout? what to do if timeouted?
 	res, err := ch.waitMined(ctx, txID)
 	if err != nil {

--- a/pkg/chequehandler/cheque_handler.go
+++ b/pkg/chequehandler/cheque_handler.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
 )
 
 var (
@@ -352,7 +353,7 @@ func (ch *evmChequeHandler) CashIn(ctx context.Context) error {
 		wg.Add(1)
 		go func(txID common.Hash) {
 			defer wg.Done()
-			_ = ch.checkCashInStatus(context.Background(), txID)
+			_ = ch.checkCashInStatus(ctx, txID)
 		}(chequeRecord.TxID)
 	}
 
@@ -375,19 +376,20 @@ func (ch *evmChequeHandler) CheckCashInStatus(ctx context.Context) error {
 		return err
 	}
 
-	wg := sync.WaitGroup{}
+	g := errgroup.Group{}
 
 	for _, chequeRecord := range chequeRecords {
-		wg.Add(1)
-		go func(txID common.Hash) {
-			defer wg.Done()
-			_ = ch.checkCashInStatus(ctx, txID)
-		}(chequeRecord.TxID)
+		txID := chequeRecord.TxID
+		g.Go(func() (err error) {
+			return ch.checkCashInStatus(ctx, txID)
+		})
 	}
 
-	wg.Wait()
+	if err = g.Wait(); err != nil {
+		ch.logger.Errorf("CheckCashInStatus failed with error: %v", err)
+	}
 
-	return nil
+	return err
 }
 
 func (ch *evmChequeHandler) checkCashInStatus(ctx context.Context, txID common.Hash) error {

--- a/pkg/cm_accounts/cm_accounts.go
+++ b/pkg/cm_accounts/cm_accounts.go
@@ -117,13 +117,8 @@ func NewService(
 	logger *zap.SugaredLogger,
 	cacheSize int,
 	ethClient *ethclient.Client,
+	chainID *big.Int,
 ) (Service, error) {
-	chainID, err := ethClient.ChainID(context.Background())
-	if err != nil {
-		logger.Errorf("Failed to get chain ID: %v", err)
-		return nil, err
-	}
-
 	cache, err := lru.New[common.Address, *cmaccount.Cmaccount](cacheSize)
 	if err != nil {
 		return nil, err

--- a/pkg/cm_accounts/cm_accounts.go
+++ b/pkg/cm_accounts/cm_accounts.go
@@ -119,15 +119,15 @@ func NewService(
 	cacheSize int,
 	ethClient *ethclient.Client,
 ) (Service, error) {
-	cache, err := lru.New[common.Address, *cmaccount.Cmaccount](cacheSize)
-	if err != nil {
-		return nil, err
-	}
-
 	chainID, err := ethClient.ChainID(ctx)
 	if err != nil {
 		logger.Errorf("Failed to get chain ID: %v", err)
 		return nil, fmt.Errorf("failed to get chain ID: %w", err)
+	}
+
+	cache, err := lru.New[common.Address, *cmaccount.Cmaccount](cacheSize)
+	if err != nil {
+		return nil, err
 	}
 
 	return &service{

--- a/pkg/cm_accounts/cm_accounts.go
+++ b/pkg/cm_accounts/cm_accounts.go
@@ -114,14 +114,20 @@ type service struct {
 }
 
 func NewService(
+	ctx context.Context,
 	logger *zap.SugaredLogger,
 	cacheSize int,
 	ethClient *ethclient.Client,
-	chainID *big.Int,
 ) (Service, error) {
 	cache, err := lru.New[common.Address, *cmaccount.Cmaccount](cacheSize)
 	if err != nil {
 		return nil, err
+	}
+
+	chainID, err := ethClient.ChainID(ctx)
+	if err != nil {
+		logger.Errorf("Failed to get chain ID: %v", err)
+		return nil, fmt.Errorf("failed to get chain ID: %w", err)
 	}
 
 	return &service{

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -40,7 +40,7 @@ type Session interface {
 
 type Scheduler interface {
 	Start(ctx context.Context) error
-	Stop() error
+	Stop()
 	Schedule(ctx context.Context, period time.Duration, jobName string) error
 	RegisterJobHandler(jobName string, jobHandler func())
 }
@@ -68,6 +68,7 @@ type scheduler struct {
 	registryLock sync.RWMutex
 	timersLock   sync.RWMutex
 	clock        clockwork.Clock
+	wg           sync.WaitGroup
 }
 
 // Start starts the scheduler. Jobs that are already due are executed immediately.
@@ -117,17 +118,24 @@ func (s *scheduler) Start(ctx context.Context) error {
 		onceDone := make(chan struct{})
 		timer := s.clock.NewTimer(durationUntilFirstExecution)
 		s.setJobTimer(job.Name, &timerStopper{timer})
+		s.wg.Add(1)
 		go func() {
+			defer func() {
+				close(onceDone)
+				s.wg.Done()
+			}()
+
 			select {
 			case tickTime := <-timer.Chan():
 				handler(tickTime)
 			case <-timersCtx.Done():
 			}
-			close(onceDone)
 		}()
 
 		// periodic execution
+		s.wg.Add(1)
 		go func() {
+			defer s.wg.Done()
 			<-onceDone
 			ticker := s.clock.NewTicker(period)
 			defer ticker.Stop()
@@ -146,15 +154,16 @@ func (s *scheduler) Start(ctx context.Context) error {
 	return nil
 }
 
-func (s *scheduler) Stop() error {
-	s.stopTimers()
+func (s *scheduler) Stop() {
+	if s.stopTimers != nil { // if scheduler started correctly
+		s.stopTimers()
+	}
+	s.wg.Wait()
 	s.timersLock.Lock()
 	for jobName := range s.timers {
 		delete(s.timers, jobName)
 	}
 	s.timersLock.Unlock()
-	// TODO @evlekht await all ongoing job handlers to finish ?
-	return nil
 }
 
 // Schedules a job to be executed every period.

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -212,7 +212,7 @@ func TestScheduler_Start(t *testing.T) {
 		require.Equal(step.time, clock.Now())
 	}
 
-	require.NoError(sch.Stop())
+	sch.Stop()
 
 	// checking, that all timers were stopped
 


### PR DESCRIPTION
## Internal

### Cmd & main
- Remove duplicate error logging.

### App
- Better logging.
- More consistent components start & stop.

### Event listener
- Don't call unsubscribe if its nil: thats the case, when failed to subscribe in a first place.

### Matrix
- Use parent context in StartReceiver.
- Move userID check into StartReceiver before syncer start.
- Make syncer return error via channel instead of panicking.
- Better logging.

### RPC server
- For consistency and better logging, Start() now doesn't block and returns error channel. When server failed to serve, it will feed error to this channel.

### Tracer
- Use parent context.

## PKG

### CM Accounts
- Use parent context for service creation.

### ChequeHandler
- Use parent context for CashIn checkCashInTxStatus.
- Make CheckCashInStatus fail, if one of its checkCashInTxStatus failed.

### Scheduler
- Remove always-nil scheduler.Stop() error return.
- Stop now awaits for all scheduled/running tasks to abort/finish.
- Don't call stopTimers() on Stop() if its nil: that was the case, when Scheduler failed to start. 