### PR TITLE
Fix matrix syncer shutdown deadlock

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -108,6 +108,8 @@ func NewApp(ctx context.Context, cfg *config.Config, logger *zap.SugaredLogger) 
 			rpcClient,
 			cfg.ResponseTimeout,
 		)
+	} else {
+		logger.Info("Partner plugin is disabled in config, skipping partner plugin (gRPC client) initialization.")
 	}
 
 	// blockchain services
@@ -447,6 +449,8 @@ func (a *App) Run(ctx context.Context) error {
 			}
 			return nil
 		})
+	} else {
+		a.logger.Info("gRPC server is disabled in config, skipping gRPC server start.")
 	}
 
 	// stop

--- a/internal/matrix/matrix_messenger.go
+++ b/internal/matrix/matrix_messenger.go
@@ -186,9 +186,13 @@ func (m *messenger) StartReceiver(ctx context.Context) (chan error, error) {
 func (m *messenger) StopReceiver() error {
 	m.logger.Info("Stopping matrix syncer...")
 	if m.client.cancelSync != nil {
+		// if cancelSync is not nil, it means that the syncer is running
 		m.client.cancelSync()
+		// we only wait for the syncer to stop if it was running,
+		// otherwise no one will close syncerStopChan
+		// and the goroutine will block forever
+		<-m.client.syncerStopChan
 	}
-	<-m.client.syncerStopChan
 	if err := m.client.cryptoHelper.Close(); err != nil {
 		m.logger.Errorf("Failed to close crypto helper: %v", err)
 	}


### PR DESCRIPTION
When bot stopped, before matrix message receiver syncer context was created, it lead to messenger receiver Stop func deadlocking awaiting for syncer stop chan to be closed, which never happens.
PR fixes that. It also adds a bit more logging for rpc server/client being skipped because of config.