### PR TITLE
Add build deps to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apk add olm-dev
 
 # build
 COPY . .
-RUN apk --no-cache add git bash
+RUN apk --no-cache add git bash grep curl jq
 RUN git submodule update --init
 RUN CAMINOBOT_PATH=$(pwd) bash ./scripts/build.sh
 


### PR DESCRIPTION
This PR adds missing build dependencies to the Docker file. This fixes the issue with the `scripts/resolve_protocol_release.sh` script not getting the correct protocol release info.