### PR TITLE
Fix bot version

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -70,7 +70,11 @@ func init() {
 }
 
 func InitProtoVersion(logger *zap.SugaredLogger, allowInvalid bool) error {
-	splittedAppVersion := strings.Split(strings.TrimPrefix(AppVersion, "v"), ".")
+	splittedAppVersion := strings.Split(AppVersion, "-")
+	if len(splittedAppVersion) < 1 {
+		return fmt.Errorf("invalid version format: %q, expected format is vMAJOR.MINOR.PATCH", AppVersion)
+	}
+	splittedAppVersion = strings.Split(strings.TrimPrefix(splittedAppVersion[0], "v"), ".")
 	if len(splittedAppVersion) != 3 {
 		if !allowInvalid {
 			err := fmt.Errorf("invalid version format: %q, expected format is vMAJOR.MINOR.PATCH", AppVersion)

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -74,10 +74,10 @@ echo "  git_commit             : $git_commit"
 echo "  protocolbuffers_release: $protocolbuffers_release"
 echo "  grpc_release           : $grpc_release"
 
-LDFLAGS="-X github.com/chain4travel/camino-messenger-bot/internal/version.AppGitCommit=$git_commit"
-LDFLAGS="$LDFLAGS -X github.com/chain4travel/camino-messenger-bot/internal/version.AppVersion=$git_tag"
-LDFLAGS="$LDFLAGS -X github.com/chain4travel/camino-messenger-bot/internal/version.BufBuildPBCMPRelease=$protocolbuffers_release"
-LDFLAGS="$LDFLAGS -X github.com/chain4travel/camino-messenger-bot/internal/version.BufBuildGRPCCMPRelease=$grpc_release"
+LDFLAGS="-X github.com/chain4travel/camino-messenger-bot/v11/internal/version.AppGitCommit=$git_commit"
+LDFLAGS="$LDFLAGS -X github.com/chain4travel/camino-messenger-bot/v11/internal/version.AppVersion=$git_tag"
+LDFLAGS="$LDFLAGS -X github.com/chain4travel/camino-messenger-bot/v11/internal/version.BufBuildPBCMPRelease=$protocolbuffers_release"
+LDFLAGS="$LDFLAGS -X github.com/chain4travel/camino-messenger-bot/v11/internal/version.BufBuildGRPCCMPRelease=$grpc_release"
 
 # Build the Go application
 echo "Building camino-messenger-bot..."


### PR DESCRIPTION
- Update version package path in build script.
- Update proto version init to allow versions like "X.X.X-xxx", which would happen, when bot is build from dirty version or without.