### PR TITLE
Update Dockerfile.plugin to use pp-mock

### DIFF
--- a/Dockerfile.plugin
+++ b/Dockerfile.plugin
@@ -4,8 +4,8 @@ RUN apk update && apk upgrade && apk add build-base
 WORKDIR /camino-messenger-bot
 
 COPY . .
-RUN go mod download
-RUN go build -o plugin  examples/rpc/partner-plugin/server.go
+RUN apk --no-cache add bash
+RUN CAMINOBOT_PATH=$(pwd) bash ./scripts/build_partner_plugin_mock.sh
 
 
 #runtime stage
@@ -14,11 +14,11 @@ FROM alpine:3.21 AS runtime-stage
 WORKDIR /
 
 ARG port=55555
-COPY --from=build-stage /camino-messenger-bot/plugin /plugin
+COPY --from=build-stage /camino-messenger-bot/pp-mock /pp-mock
 ENV PORT=$port
 
 # Run the 'env' command
 
 #EXPOSE $port
 
-ENTRYPOINT [ "./plugin" ]
+ENTRYPOINT [ "./pp-mock" ]

--- a/Dockerfile.plugin
+++ b/Dockerfile.plugin
@@ -15,7 +15,7 @@ WORKDIR /
 
 ARG port=55555
 COPY --from=build-stage /camino-messenger-bot/build/pp-mock /pp-mock
-ENV PORT=$port
+ENV CMB_PARTNER_PLUGIN_MOCK_PORT=$port
 
 # Run the 'env' command
 

--- a/Dockerfile.plugin
+++ b/Dockerfile.plugin
@@ -14,7 +14,7 @@ FROM alpine:3.21 AS runtime-stage
 WORKDIR /
 
 ARG port=55555
-COPY --from=build-stage /camino-messenger-bot/pp-mock /pp-mock
+COPY --from=build-stage /camino-messenger-bot/build/pp-mock /pp-mock
 ENV PORT=$port
 
 # Run the 'env' command


### PR DESCRIPTION
Previously, Dockerfile.plugin was using obsolete (now removed) example plugin.
PR updates Dockerfile.plugin to use pp-mock.