### PR TITLE
Remove matrix room encryption

### DIFF
--- a/internal/matrix/client/client.go
+++ b/internal/matrix/client/client.go
@@ -114,22 +114,6 @@ func (c *client) CreateRoomForUser(ctx context.Context, recipient id.UserID) (id
 	return resp.RoomID, nil
 }
 
-func (c *client) EnableRoomEncryption(ctx context.Context, roomID id.RoomID) error {
-	c.logger.Debugf("Enabling encryption for room %s", roomID)
-	if _, err := c.client.SendStateEvent(
-		ctx,
-		roomID,
-		event.StateEncryption,
-		"",
-		event.EncryptionEventContent{Algorithm: id.AlgorithmMegolmV1},
-	); err != nil {
-		c.logger.Errorf("Failed to enable encryption for room %s: %v", roomID, err)
-		return err
-	}
-	c.logger.Debugf("Encryption enabled for room %s", roomID)
-	return nil
-}
-
 func (c *client) JoinRoom(ctx context.Context, roomID id.RoomID) error {
 	c.logger.Debugf("Joining room %s", roomID)
 	if _, err := c.client.JoinRoomByID(ctx, roomID); err != nil {
@@ -137,6 +121,26 @@ func (c *client) JoinRoom(ctx context.Context, roomID id.RoomID) error {
 		return err
 	}
 	c.logger.Debugf("Joined room %s", roomID)
+	return nil
+}
+
+func (c *client) LeaveRoom(ctx context.Context, roomID id.RoomID) error {
+	c.logger.Debugf("Leaving room %s", roomID)
+	if _, err := c.client.LeaveRoom(ctx, roomID); err != nil {
+		c.logger.Errorf("Failed to leave room %s: %v", roomID, err)
+		return err
+	}
+	c.logger.Debugf("Left room %s", roomID)
+	return nil
+}
+
+func (c *client) ForgetRoom(ctx context.Context, roomID id.RoomID) error {
+	c.logger.Debugf("Forgetting room %s", roomID)
+	if _, err := c.client.ForgetRoom(ctx, roomID); err != nil {
+		c.logger.Errorf("Failed to forget room %s: %v", roomID, err)
+		return err
+	}
+	c.logger.Debugf("Forgot room %s", roomID)
 	return nil
 }
 

--- a/internal/matrix/messenger/client.go
+++ b/internal/matrix/messenger/client.go
@@ -15,8 +15,9 @@ type Client interface {
 	SetEventHandler(eventType event.Type, handler func(ctx context.Context, evt *event.Event))
 	IsRoomEncrypted(ctx context.Context, roomID id.RoomID) (bool, error)
 	CreateRoomForUser(ctx context.Context, recipient id.UserID) (id.RoomID, error)
-	EnableRoomEncryption(ctx context.Context, roomID id.RoomID) error
 	JoinRoom(ctx context.Context, roomID id.RoomID) error
+	LeaveRoom(ctx context.Context, roomID id.RoomID) error
+	ForgetRoom(ctx context.Context, roomID id.RoomID) error
 	JoinedRooms(ctx context.Context) ([]id.RoomID, error)
 	IsUserJoinedRoom(ctx context.Context, roomID id.RoomID, userID id.UserID) (bool, error)
 	SendMessageEvent(ctx context.Context, roomID id.RoomID, eventType event.Type, event matrix.CaminoMatrixMessageEventContent) error

--- a/internal/matrix/messenger/messenger.go
+++ b/internal/matrix/messenger/messenger.go
@@ -94,6 +94,14 @@ func (m *messenger) checkpoint() string {
 }
 
 func (m *messenger) Start(ctx context.Context) (chan error, error) {
+	// Initially, messenger used matrix e2e encryption. Starting from v12, messenger will use its own e2e encryption.
+	// Because of that, we need to remove all encrypted rooms and only use unencrypted rooms from now on.
+	if err := m.removeEncryptedRooms(ctx); err != nil {
+		err := fmt.Errorf("failed to remove encrypted rooms: %w", err)
+		m.logger.Error(err)
+		return nil, err
+	}
+
 	// Start syncer, that will listen for incoming events
 
 	syncCtx, cancelSync := context.WithCancel(ctx)

--- a/internal/matrix/messenger/mock_client.go
+++ b/internal/matrix/messenger/mock_client.go
@@ -71,18 +71,18 @@ func (mr *MockClientMockRecorder) CreateRoomForUser(arg0, arg1 any) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRoomForUser", reflect.TypeOf((*MockClient)(nil).CreateRoomForUser), arg0, arg1)
 }
 
-// EnableRoomEncryption mocks base method.
-func (m *MockClient) EnableRoomEncryption(arg0 context.Context, arg1 id.RoomID) error {
+// ForgetRoom mocks base method.
+func (m *MockClient) ForgetRoom(arg0 context.Context, arg1 id.RoomID) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnableRoomEncryption", arg0, arg1)
+	ret := m.ctrl.Call(m, "ForgetRoom", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// EnableRoomEncryption indicates an expected call of EnableRoomEncryption.
-func (mr *MockClientMockRecorder) EnableRoomEncryption(arg0, arg1 any) *gomock.Call {
+// ForgetRoom indicates an expected call of ForgetRoom.
+func (mr *MockClientMockRecorder) ForgetRoom(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnableRoomEncryption", reflect.TypeOf((*MockClient)(nil).EnableRoomEncryption), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ForgetRoom", reflect.TypeOf((*MockClient)(nil).ForgetRoom), arg0, arg1)
 }
 
 // IsRoomEncrypted mocks base method.
@@ -142,6 +142,20 @@ func (m *MockClient) JoinedRooms(arg0 context.Context) ([]id.RoomID, error) {
 func (mr *MockClientMockRecorder) JoinedRooms(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "JoinedRooms", reflect.TypeOf((*MockClient)(nil).JoinedRooms), arg0)
+}
+
+// LeaveRoom mocks base method.
+func (m *MockClient) LeaveRoom(arg0 context.Context, arg1 id.RoomID) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LeaveRoom", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// LeaveRoom indicates an expected call of LeaveRoom.
+func (mr *MockClientMockRecorder) LeaveRoom(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LeaveRoom", reflect.TypeOf((*MockClient)(nil).LeaveRoom), arg0, arg1)
 }
 
 // SendMessageEvent mocks base method.

--- a/internal/matrix/messenger/rooms.go
+++ b/internal/matrix/messenger/rooms.go
@@ -21,7 +21,6 @@ func (m *messenger) stateMemberEventHandler(ctx context.Context, evt *event.Even
 	m.logger.Debugf("Received %s event %s from %s in room %s", event.StateMember.Type, evt.ID, evt.Sender, evt.RoomID)
 
 	if evt.GetStateKey() == m.botUserID.String() && evt.Content.AsMember().Membership == event.MembershipInvite {
-		// TODO@ what if room encryption will be enabled later? we can listen for encryption events or check if room is encrypted before messaging - both are bad
 		if encrypted, err := m.client.IsRoomEncrypted(ctx, evt.RoomID); err != nil {
 			m.logger.Errorf("Failed to check if room %s is encrypted: %v", evt.RoomID, err)
 			return

--- a/internal/matrix/messenger/rooms.go
+++ b/internal/matrix/messenger/rooms.go
@@ -7,6 +7,7 @@ import (
 	"context"
 
 	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
 	"maunium.net/go/mautrix/event"
 	"maunium.net/go/mautrix/id"
 )
@@ -20,7 +21,8 @@ func (m *messenger) stateMemberEventHandler(ctx context.Context, evt *event.Even
 	m.logger.Debugf("Received %s event %s from %s in room %s", event.StateMember.Type, evt.ID, evt.Sender, evt.RoomID)
 
 	if evt.GetStateKey() == m.botUserID.String() && evt.Content.AsMember().Membership == event.MembershipInvite {
-		if encrypted, err := m.client.IsRoomEncrypted(ctx, evt.RoomID); err != nil { // TODO@ what if room encryption will be enabled later?
+		// TODO@ what if room encryption will be enabled later? we can listen for encryption events or check if room is encrypted before messaging - both are bad
+		if encrypted, err := m.client.IsRoomEncrypted(ctx, evt.RoomID); err != nil {
 			m.logger.Errorf("Failed to check if room %s is encrypted: %v", evt.RoomID, err)
 			return
 		} else if encrypted {
@@ -48,25 +50,35 @@ func (m *messenger) removeEncryptedRooms(ctx context.Context) error {
 		return err
 	}
 
+	g := errgroup.Group{}
 	for _, roomID := range rooms {
-		if encrypted, err := m.client.IsRoomEncrypted(ctx, roomID); err != nil {
-			m.logger.Errorf("failed to check if room %s is encrypted: %v", roomID, err)
-			return err
-		} else if !encrypted {
-			continue
-		}
+		roomID := roomID
+		g.Go(func() error {
+			if encrypted, err := m.client.IsRoomEncrypted(ctx, roomID); err != nil {
+				m.logger.Errorf("failed to check if room %s is encrypted: %v", roomID, err)
+				return err
+			} else if !encrypted {
+				return nil
+			}
 
-		if err := m.client.LeaveRoom(ctx, roomID); err != nil {
-			m.logger.Errorf("failed to leave room %s: %v", roomID, err)
-			return err
-		}
+			if err := m.client.LeaveRoom(ctx, roomID); err != nil {
+				m.logger.Errorf("failed to leave room %s: %v", roomID, err)
+				return err
+			}
 
-		if err := m.client.ForgetRoom(ctx, roomID); err != nil {
-			m.logger.Errorf("failed to forget room %s: %v", roomID, err)
-			return err
-		}
+			if err := m.client.ForgetRoom(ctx, roomID); err != nil {
+				m.logger.Errorf("failed to forget room %s: %v", roomID, err)
+				return err
+			}
+
+			return nil
+		})
 	}
-	return nil
+
+	if err = g.Wait(); err != nil {
+		m.logger.Errorf("failed to remove all encrypted rooms: %v", err)
+	}
+	return err
 }
 
 func (m *messenger) getRoomForRecipient(ctx context.Context, recipient id.UserID) (id.RoomID, error) {

--- a/internal/matrix/messenger/rooms.go
+++ b/internal/matrix/messenger/rooms.go
@@ -20,7 +20,7 @@ func (m *messenger) stateMemberEventHandler(ctx context.Context, evt *event.Even
 	m.logger.Debugf("Received %s event %s from %s in room %s", event.StateMember.Type, evt.ID, evt.Sender, evt.RoomID)
 
 	if evt.GetStateKey() == m.botUserID.String() && evt.Content.AsMember().Membership == event.MembershipInvite {
-		if encrypted, err := m.client.IsRoomEncrypted(ctx, evt.RoomID); err != nil {
+		if encrypted, err := m.client.IsRoomEncrypted(ctx, evt.RoomID); err != nil { // TODO@ what if room encryption will be enabled later?
 			m.logger.Errorf("Failed to check if room %s is encrypted: %v", evt.RoomID, err)
 			return
 		} else if encrypted {

--- a/internal/matrix/messenger/rooms.go
+++ b/internal/matrix/messenger/rooms.go
@@ -52,7 +52,6 @@ func (m *messenger) removeEncryptedRooms(ctx context.Context) error {
 
 	g := errgroup.Group{}
 	for _, roomID := range rooms {
-		roomID := roomID
 		g.Go(func() error {
 			if encrypted, err := m.client.IsRoomEncrypted(ctx, roomID); err != nil {
 				m.logger.Errorf("failed to check if room %s is encrypted: %v", roomID, err)

--- a/internal/matrix/messenger/rooms.go
+++ b/internal/matrix/messenger/rooms.go
@@ -60,7 +60,7 @@ func (m *messenger) removeEncryptedRooms(ctx context.Context) error {
 			m.logger.Errorf("failed to leave room %s: %v", roomID, err)
 			return err
 		}
-		// TODO@ what if forget fails? we already left room. how can we recover?
+
 		if err := m.client.ForgetRoom(ctx, roomID); err != nil {
 			m.logger.Errorf("failed to forget room %s: %v", roomID, err)
 			return err

--- a/internal/matrix/messenger/rooms.go
+++ b/internal/matrix/messenger/rooms.go
@@ -20,6 +20,14 @@ func (m *messenger) stateMemberEventHandler(ctx context.Context, evt *event.Even
 	m.logger.Debugf("Received %s event %s from %s in room %s", event.StateMember.Type, evt.ID, evt.Sender, evt.RoomID)
 
 	if evt.GetStateKey() == m.botUserID.String() && evt.Content.AsMember().Membership == event.MembershipInvite {
+		if encrypted, err := m.client.IsRoomEncrypted(ctx, evt.RoomID); err != nil {
+			m.logger.Errorf("Failed to check if room %s is encrypted: %v", evt.RoomID, err)
+			return
+		} else if encrypted {
+			m.logger.Infof("Room %s is encrypted, ignoring invite event", evt.RoomID)
+			return
+		}
+
 		if err := m.client.JoinRoom(ctx, evt.RoomID); err != nil {
 			m.logger.Error("Failed to join room after invite",
 				zap.String("room_id", evt.RoomID.String()),
@@ -33,6 +41,34 @@ func (m *messenger) stateMemberEventHandler(ctx context.Context, evt *event.Even
 	}
 }
 
+func (m *messenger) removeEncryptedRooms(ctx context.Context) error {
+	rooms, err := m.client.JoinedRooms(ctx)
+	if err != nil {
+		m.logger.Errorf("failed to get joined rooms: %v", err)
+		return err
+	}
+
+	for _, roomID := range rooms {
+		if encrypted, err := m.client.IsRoomEncrypted(ctx, roomID); err != nil {
+			m.logger.Errorf("failed to check if room %s is encrypted: %v", roomID, err)
+			return err
+		} else if !encrypted {
+			continue
+		}
+
+		if err := m.client.LeaveRoom(ctx, roomID); err != nil {
+			m.logger.Errorf("failed to leave room %s: %v", roomID, err)
+			return err
+		}
+		// TODO@ what if forget fails? we already left room. how can we recover?
+		if err := m.client.ForgetRoom(ctx, roomID); err != nil {
+			m.logger.Errorf("failed to forget room %s: %v", roomID, err)
+			return err
+		}
+	}
+	return nil
+}
+
 func (m *messenger) getRoomForRecipient(ctx context.Context, recipient id.UserID) (id.RoomID, error) {
 	roomID, found := m.findExistingRoomForRecipient(ctx, recipient)
 	if found {
@@ -41,11 +77,6 @@ func (m *messenger) getRoomForRecipient(ctx context.Context, recipient id.UserID
 
 	roomID, err := m.client.CreateRoomForUser(ctx, recipient)
 	if err != nil {
-		return "", err
-	}
-
-	if err := m.client.EnableRoomEncryption(ctx, roomID); err != nil {
-		m.logger.Errorf("failed to enable encryption for room %s: %v", roomID, err)
 		return "", err
 	}
 
@@ -67,13 +98,6 @@ func (m *messenger) findExistingRoomForRecipient(ctx context.Context, recipient 
 	}
 
 	for _, roomID := range rooms {
-		if encrypted, err := m.client.IsRoomEncrypted(ctx, roomID); err != nil {
-			m.logger.Errorf("failed to check if room %s is encrypted: %v", roomID, err)
-			return "", false
-		} else if !encrypted {
-			continue
-		}
-
 		if joined, err := m.client.IsUserJoinedRoom(ctx, roomID, recipient); err != nil {
 			m.logger.Errorf("failed to check if user %s is joined to room %s: %v", recipient, roomID, err)
 			return "", false

--- a/internal/matrix/messenger/rooms_test.go
+++ b/internal/matrix/messenger/rooms_test.go
@@ -48,17 +48,6 @@ func TestGetRoomForRecipient(t *testing.T) {
 			recipient:   recipientUserID,
 			expectedErr: testErr,
 		},
-		"Encrypt room fails": {
-			client: func(ctrl *gomock.Controller) *MockClient {
-				c := NewMockClient(ctrl)
-				c.EXPECT().JoinedRooms(ctx).Return([]id.RoomID{}, nil)
-				c.EXPECT().CreateRoomForUser(ctx, recipientUserID).Return(roomID1, nil)
-				c.EXPECT().EnableRoomEncryption(ctx, roomID1).Return(testErr)
-				return c
-			},
-			recipient:   recipientUserID,
-			expectedErr: testErr,
-		},
 		"OK: room already established and cached": {
 			roomsCache: map[id.UserID]id.RoomID{
 				recipientUserID: roomID1,
@@ -70,8 +59,7 @@ func TestGetRoomForRecipient(t *testing.T) {
 			client: func(ctrl *gomock.Controller) *MockClient {
 				c := NewMockClient(ctrl)
 				c.EXPECT().JoinedRooms(ctx).Return([]id.RoomID{roomID1, roomID2}, nil)
-				c.EXPECT().IsRoomEncrypted(ctx, roomID1).Return(false, nil)
-				c.EXPECT().IsRoomEncrypted(ctx, roomID2).Return(true, nil)
+				c.EXPECT().IsUserJoinedRoom(ctx, roomID1, recipientUserID).Return(false, nil)
 				c.EXPECT().IsUserJoinedRoom(ctx, roomID2, recipientUserID).Return(true, nil)
 				return c
 			},
@@ -82,10 +70,8 @@ func TestGetRoomForRecipient(t *testing.T) {
 			client: func(ctrl *gomock.Controller) *MockClient {
 				c := NewMockClient(ctrl)
 				c.EXPECT().JoinedRooms(ctx).Return([]id.RoomID{roomID1}, nil)
-				c.EXPECT().IsRoomEncrypted(ctx, roomID1).Return(true, nil)
 				c.EXPECT().IsUserJoinedRoom(ctx, roomID1, recipientUserID).Return(false, nil)
 				c.EXPECT().CreateRoomForUser(ctx, recipientUserID).Return(roomID2, nil)
-				c.EXPECT().EnableRoomEncryption(ctx, roomID2).Return(nil)
 				return c
 			},
 			recipient:      recipientUserID,


### PR DESCRIPTION
Initially, messenger used matrix rooms encryption as e2e encryption. Because of that, ASB was not able to read even public part of message events like network fee cheque.

Starting from v12, messenger will use its own e2e encryption and we need to remove all encrypted rooms and only use not encrypted rooms in future.

PR adds startup encrypted rooms removal.