### PR TITLE
Split matrix event into message with metadata and chunk

### DIFF
--- a/internal/matrix/client/client.go
+++ b/internal/matrix/client/client.go
@@ -163,14 +163,25 @@ func (c *client) IsUserJoinedRoom(ctx context.Context, roomID id.RoomID, userID 
 	return joined, nil
 }
 
-func (c *client) SendMessageEvent(ctx context.Context, roomID id.RoomID, eventType event.Type, event matrix.CaminoMatrixMessageEventContent) error {
-	c.logger.Debugf("Sending message event of type %s to room %s", eventType.Type, roomID)
-	_, err := c.client.SendMessageEvent(ctx, roomID, eventType, event)
+func (c *client) SendMessageEvent(ctx context.Context, roomID id.RoomID, event matrix.MessageEventContent) error {
+	c.logger.Debugf("Sending message event of type %s to room %s", matrix.EventTypeMessage.Type, roomID)
+	_, err := c.client.SendMessageEvent(ctx, roomID, matrix.EventTypeMessage, event)
 	if err != nil {
-		c.logger.Errorf("Failed to send message event of type %s to room %s: %v", eventType.Type, roomID, err)
+		c.logger.Errorf("Failed to send message event of type %s to room %s: %v", matrix.EventTypeMessage.Type, roomID, err)
 		return err
 	}
-	c.logger.Debugf("Sent message event of type %s to room %s", eventType.Type, roomID)
+	c.logger.Debugf("Sent message event of type %s to room %s", matrix.EventTypeMessage.Type, roomID)
+	return nil
+}
+
+func (c *client) SendMessageChunkEvent(ctx context.Context, roomID id.RoomID, event matrix.MessageChunkEventContent) error {
+	c.logger.Debugf("Sending message event of type %s to room %s", matrix.EventTypeMessageChunk.Type, roomID)
+	_, err := c.client.SendMessageEvent(ctx, roomID, matrix.EventTypeMessageChunk, event)
+	if err != nil {
+		c.logger.Errorf("Failed to send message event of type %s to room %s: %v", matrix.EventTypeMessageChunk.Type, roomID, err)
+		return err
+	}
+	c.logger.Debugf("Sent message event of type %s to room %s", matrix.EventTypeMessageChunk.Type, roomID)
 	return nil
 }
 

--- a/internal/matrix/messenger/client.go
+++ b/internal/matrix/messenger/client.go
@@ -20,7 +20,8 @@ type Client interface {
 	ForgetRoom(ctx context.Context, roomID id.RoomID) error
 	JoinedRooms(ctx context.Context) ([]id.RoomID, error)
 	IsUserJoinedRoom(ctx context.Context, roomID id.RoomID, userID id.UserID) (bool, error)
-	SendMessageEvent(ctx context.Context, roomID id.RoomID, eventType event.Type, event matrix.CaminoMatrixMessageEventContent) error
+	SendMessageEvent(ctx context.Context, roomID id.RoomID, event matrix.MessageEventContent) error
+	SendMessageChunkEvent(ctx context.Context, roomID id.RoomID, event matrix.MessageChunkEventContent) error
 	SyncWithContext(ctx context.Context) error
 	Close() error
 }

--- a/internal/matrix/messenger/messages.go
+++ b/internal/matrix/messenger/messages.go
@@ -1,0 +1,185 @@
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package messenger
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/chain4travel/camino-messenger-bot/v11/internal/messaging/types"
+	"github.com/chain4travel/camino-messenger-bot/v11/internal/rpc/generated"
+	"github.com/chain4travel/camino-messenger-bot/v11/pkg/matrix"
+	"github.com/chain4travel/camino-messenger-bot/v11/pkg/metadata"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+	"maunium.net/go/mautrix/event"
+	"maunium.net/go/mautrix/id"
+)
+
+func (m *messenger) SendMessage(ctx context.Context, msg *types.Message, sendTo id.UserID) error {
+	m.logger.Infof("Sending message (requestID %s) to %s", msg.Metadata.RequestID, sendTo)
+
+	ctx, span := m.tracer.Start(ctx, "messenger.SendMessage", trace.WithSpanKind(trace.SpanKindProducer), trace.WithAttributes(attribute.String("type", string(msg.Type))))
+	defer span.End()
+
+	ctx, roomSpan := m.tracer.Start(ctx, "messenger.getRoomForRecipient", trace.WithAttributes(attribute.String("type", string(msg.Type))))
+	roomID, err := m.getRoomForRecipient(ctx, sendTo)
+	if err != nil {
+		return err
+	}
+	roomSpan.End()
+
+	return m.sendMessageEvents(ctx, roomID, matrix.EventTypeC4TMessage, createMessageEventContents(msg))
+}
+
+func (m *messenger) sendMessageEvents(ctx context.Context, roomID id.RoomID, eventType event.Type, messageEvents []matrix.CaminoMatrixMessageEventContent) error {
+	// TODO @nikos add retry logic?
+	for _, msg := range messageEvents {
+		if err := m.client.SendMessageEvent(ctx, roomID, eventType, msg); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m *messenger) c4tMessageEventHandler(ctx context.Context, evt *event.Event) {
+	defer func() {
+		if r := recover(); r != nil {
+			m.logger.Errorf("failed to process %s event, recovered from panic: %v", matrix.EventTypeC4TMessage.Type, r)
+		}
+	}()
+	m.logger.Debugf("Received %s event %s from %s in room %s", matrix.EventTypeC4TMessage.Type, evt.ID, evt.Sender, evt.RoomID)
+
+	if evt.Sender == m.botUserID { // ignore own messages
+		m.logger.Debugf("Ignoring own message from %s in room %s", evt.Sender, evt.RoomID)
+		return
+	}
+
+	msgEventContent := evt.Content.Parsed.(*matrix.CaminoMatrixMessageEventContent)
+
+	traceID, err := trace.TraceIDFromHex(msgEventContent.Metadata.RequestID)
+	if err != nil {
+		m.logger.Warnf("failed to parse traceID from hex [requestID:%s]: %v", msgEventContent.Metadata.RequestID, err)
+	}
+	ctx = trace.ContextWithRemoteSpanContext(ctx, trace.NewSpanContext(trace.SpanContextConfig{TraceID: traceID}))
+
+	_, span := m.tracer.Start(ctx, "messenger.OnC4TMessageReceive", trace.WithSpanKind(trace.SpanKindConsumer), trace.WithAttributes(attribute.String("type", evt.Type.Type)))
+	defer span.End()
+
+	receivedAt := time.Now()
+
+	msg, completed, err := m.tryAssembleMessage(msgEventContent)
+	if err != nil {
+		m.logger.Errorf("failed to assemble message: %v", err)
+		return
+	}
+	if !completed {
+		m.logger.Debugf("Received partial message with requestID %s, waiting for more chunks", msgEventContent.Metadata.RequestID)
+		return // partial messages are not passed down to the msgChannel
+	}
+
+	msg.SenderBotUserID = evt.Sender
+
+	msg.Metadata.StampOn(fmt.Sprintf("matrix-sent-%s", msgEventContent.MsgType), evt.Timestamp)
+	msg.Metadata.StampOn(fmt.Sprintf("%s-%s-%s", m.checkpoint(), "received", msgEventContent.MsgType), receivedAt.UnixMilli())
+
+	m.msgChannel <- msg
+}
+
+func (m *messenger) tryAssembleMessage(msgEventContent *matrix.CaminoMatrixMessageEventContent) (types.Message, bool, error) {
+	// if the message is not chunked, we can assemble it immediately
+	if msgEventContent.Metadata.NumberOfChunks == 1 {
+		msg, err := m.assembleMessage(
+			msgEventContent.CompressedContent,
+			msgEventContent.Metadata,
+			types.MessageType(msgEventContent.MsgType),
+		)
+		return msg, err == nil, err
+	}
+
+	msgEventContents, complete := m.tryCompleteChunks(msgEventContent)
+	if !complete {
+		return types.Message{}, false, nil
+	}
+
+	// assemble payload from all chunks
+	sort.Sort(matrix.ByChunkIndex(msgEventContents))
+	compressedPayloads := make([][]byte, 0, len(msgEventContents))
+	for _, msg := range msgEventContents {
+		compressedPayloads = append(compressedPayloads, msg.CompressedContent)
+	}
+	payload := bytes.Join(compressedPayloads, nil)
+
+	msg, err := m.assembleMessage(
+		payload,
+		msgEventContents[0].Metadata,
+		types.MessageType(msgEventContents[0].MsgType),
+	)
+	return msg, err == nil, err
+}
+
+func (m *messenger) tryCompleteChunks(msgEventContent *matrix.CaminoMatrixMessageEventContent) ([]*matrix.CaminoMatrixMessageEventContent, bool) {
+	m.messagesMutex.Lock()
+	defer m.messagesMutex.Unlock()
+
+	id := msgEventContent.Metadata.RequestID
+
+	msgEventContents := append(m.messages[id], msgEventContent) //nolint:gocritic
+
+	if uint64(len(msgEventContents)) != msgEventContent.Metadata.NumberOfChunks {
+		// don't have all chunks yet, store for later assembly and return
+		m.messages[id] = msgEventContents
+		return nil, false
+	}
+
+	delete(m.messages, id)
+
+	return msgEventContents, true
+}
+
+func (m *messenger) assembleMessage(payload []byte, metadata metadata.Metadata, msgType types.MessageType) (types.Message, error) {
+	contentBytes, err := m.decompressor.Decompress(payload)
+	if err != nil {
+		return types.Message{}, fmt.Errorf("%w: %w", errDecompressFailed, err)
+	}
+
+	msg := types.Message{
+		Metadata: metadata,
+		Type:     msgType,
+	}
+
+	if err := generated.UnmarshalContent(contentBytes, msgType, &msg.Content); err != nil {
+		return types.Message{}, fmt.Errorf("%w: %w %v", errUnmarshalContent, err, msgType)
+	}
+
+	return msg, nil
+}
+
+func createMessageEventContents(msg *types.Message) []matrix.CaminoMatrixMessageEventContent {
+	messages := make([]matrix.CaminoMatrixMessageEventContent, 0, len(msg.CompressedContent))
+
+	// add first chunk to messages slice
+	caminoMatrixMsg := matrix.CaminoMatrixMessageEventContent{
+		MessageEventContent: event.MessageEventContent{MsgType: event.MessageType(msg.Type)},
+		Metadata:            msg.Metadata,
+	}
+	caminoMatrixMsg.Metadata.NumberOfChunks = uint64(len(msg.CompressedContent))
+	caminoMatrixMsg.Metadata.ChunkIndex = 0
+	caminoMatrixMsg.CompressedContent = msg.CompressedContent[0]
+	messages = append(messages, caminoMatrixMsg)
+
+	// if multiple chunks were produced upon compression, add them to messages slice
+	for i, chunk := range msg.CompressedContent[1:] {
+		messages = append(messages, matrix.CaminoMatrixMessageEventContent{
+			MessageEventContent: event.MessageEventContent{MsgType: event.MessageType(msg.Type)},
+			Metadata:            metadata.Metadata{RequestID: msg.Metadata.RequestID, NumberOfChunks: uint64(len(msg.CompressedContent)), ChunkIndex: uint64(i + 1)},
+			CompressedContent:   chunk,
+		})
+	}
+
+	return messages
+}

--- a/internal/matrix/messenger/messages.go
+++ b/internal/matrix/messenger/messages.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/chain4travel/camino-messenger-bot/v11/internal/messaging/types"
 	"github.com/chain4travel/camino-messenger-bot/v11/internal/rpc/generated"
+	"github.com/chain4travel/camino-messenger-bot/v11/pkg/conversion"
 	"github.com/chain4travel/camino-messenger-bot/v11/pkg/matrix"
 	"github.com/chain4travel/camino-messenger-bot/v11/pkg/metadata"
 	"go.opentelemetry.io/otel/attribute"
@@ -20,8 +21,25 @@ import (
 	"maunium.net/go/mautrix/id"
 )
 
+type chunkedMessage struct {
+	msgType  types.MessageType
+	metadata metadata.Metadata
+	chunks   []messageChunk
+}
+
+type messageChunk struct {
+	index uint32
+	data  []byte
+}
+
+type byChunkIndex []messageChunk
+
+func (b byChunkIndex) Len() int           { return len(b) }
+func (b byChunkIndex) Less(i, j int) bool { return b[i].index < b[j].index }
+func (b byChunkIndex) Swap(i, j int)      { b[i], b[j] = b[j], b[i] }
+
 func (m *messenger) SendMessage(ctx context.Context, msg *types.Message, sendTo id.UserID) error {
-	m.logger.Infof("Sending message (requestID %s) to %s", msg.Metadata.RequestID, sendTo)
+	m.logger.Debugf("Sending message (id %s) to %s", msg.Metadata.RequestID, sendTo)
 
 	ctx, span := m.tracer.Start(ctx, "messenger.SendMessage", trace.WithSpanKind(trace.SpanKindProducer), trace.WithAttributes(attribute.String("type", string(msg.Type))))
 	defer span.End()
@@ -33,112 +51,213 @@ func (m *messenger) SendMessage(ctx context.Context, msg *types.Message, sendTo 
 	}
 	roomSpan.End()
 
-	return m.sendMessageEvents(ctx, roomID, matrix.EventTypeC4TMessage, createMessageEventContents(msg))
-}
+	messageEvent := matrix.MessageEventContent{
+		MsgType:  msg.Type,
+		Metadata: msg.Metadata,
+		Data:     msg.CompressedContent[0],
+	}
 
-func (m *messenger) sendMessageEvents(ctx context.Context, roomID id.RoomID, eventType event.Type, messageEvents []matrix.CaminoMatrixMessageEventContent) error {
+	messageEvent.Metadata.NumberOfChunks = uint64(len(msg.CompressedContent))
+
+	var chunkEvents []matrix.MessageChunkEventContent
+	if msg.Metadata.NumberOfChunks > 1 {
+		chunkEvents = make([]matrix.MessageChunkEventContent, 0, msg.Metadata.NumberOfChunks-1)
+		for i, chunk := range msg.CompressedContent[1:] {
+			chunkEvents = append(chunkEvents, matrix.MessageChunkEventContent{
+				RequestID:  msg.Metadata.RequestID,
+				ChunkIndex: conversion.MustIntToUInt32(i + 1),
+				Data:       chunk,
+			})
+		}
+	}
+
 	// TODO @nikos add retry logic?
-	for _, msg := range messageEvents {
-		if err := m.client.SendMessageEvent(ctx, roomID, eventType, msg); err != nil {
+	if err := m.client.SendMessageEvent(ctx, roomID, messageEvent); err != nil {
+		return err
+	}
+
+	for _, chunkEvent := range chunkEvents {
+		if err := m.client.SendMessageChunkEvent(ctx, roomID, chunkEvent); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (m *messenger) c4tMessageEventHandler(ctx context.Context, evt *event.Event) {
+func (m *messenger) messageEventHandler(ctx context.Context, evt *event.Event) {
 	defer func() {
 		if r := recover(); r != nil {
-			m.logger.Errorf("failed to process %s event, recovered from panic: %v", matrix.EventTypeC4TMessage.Type, r)
+			m.logger.Errorf("failed to process %s event, recovered from panic: %v", &matrix.EventTypeMessage.Type, r)
 		}
 	}()
-	m.logger.Debugf("Received %s event %s from %s in room %s", matrix.EventTypeC4TMessage.Type, evt.ID, evt.Sender, evt.RoomID)
+	m.logger.Debugf("Received %s event %s from %s in room %s", matrix.EventTypeMessage.Type, evt.ID, evt.Sender, evt.RoomID)
 
 	if evt.Sender == m.botUserID { // ignore own messages
 		m.logger.Debugf("Ignoring own message from %s in room %s", evt.Sender, evt.RoomID)
 		return
 	}
 
-	msgEventContent := evt.Content.Parsed.(*matrix.CaminoMatrixMessageEventContent)
+	eventContent := evt.Content.Parsed.(*matrix.MessageEventContent)
 
-	traceID, err := trace.TraceIDFromHex(msgEventContent.Metadata.RequestID)
+	traceID, err := trace.TraceIDFromHex(eventContent.Metadata.RequestID)
 	if err != nil {
-		m.logger.Warnf("failed to parse traceID from hex [requestID:%s]: %v", msgEventContent.Metadata.RequestID, err)
+		m.logger.Warnf("failed to parse traceID from hex [requestID: %s]: %v", eventContent.Metadata.RequestID, err)
 	}
 	ctx = trace.ContextWithRemoteSpanContext(ctx, trace.NewSpanContext(trace.SpanContextConfig{TraceID: traceID}))
 
-	_, span := m.tracer.Start(ctx, "messenger.OnC4TMessageReceive", trace.WithSpanKind(trace.SpanKindConsumer), trace.WithAttributes(attribute.String("type", evt.Type.Type)))
+	_, span := m.tracer.Start(ctx, "messenger.messageEventHandler", trace.WithSpanKind(trace.SpanKindConsumer), trace.WithAttributes(attribute.String("type", evt.Type.Type)))
 	defer span.End()
+
+	if err := eventContent.Verify(); err != nil {
+		m.logger.Warnf("Received invalid %s event (id %s): %v", &matrix.EventTypeMessage.Type, eventContent.Metadata.RequestID, err)
+		return
+	}
 
 	receivedAt := time.Now()
 
-	msg, completed, err := m.tryAssembleMessage(msgEventContent)
+	msg, completed, err := m.tryCompleteMessageWithFirstChunk(eventContent)
 	if err != nil {
-		m.logger.Errorf("failed to assemble message: %v", err)
+		m.logger.Warnf("Failed to assemble message from %s event (id %s): %v", &matrix.EventTypeMessage.Type, eventContent.Metadata.RequestID, err)
 		return
-	}
-	if !completed {
-		m.logger.Debugf("Received partial message with requestID %s, waiting for more chunks", msgEventContent.Metadata.RequestID)
-		return // partial messages are not passed down to the msgChannel
+	} else if !completed {
+		m.logger.Debugf("Received message (id %s) first chunk, waiting for more chunks", eventContent.Metadata.RequestID)
+		return
 	}
 
 	msg.SenderBotUserID = evt.Sender
 
-	msg.Metadata.StampOn(fmt.Sprintf("matrix-sent-%s", msgEventContent.MsgType), evt.Timestamp)
-	msg.Metadata.StampOn(fmt.Sprintf("%s-%s-%s", m.checkpoint(), "received", msgEventContent.MsgType), receivedAt.UnixMilli())
+	msg.Metadata.StampOn(fmt.Sprintf("matrix-sent-%s", msg.Type), evt.Timestamp)
+	msg.Metadata.StampOn(fmt.Sprintf("%s-%s-%s", m.checkpoint(), "received", msg.Type), receivedAt.UnixMilli())
 
 	m.msgChannel <- msg
 }
 
-func (m *messenger) tryAssembleMessage(msgEventContent *matrix.CaminoMatrixMessageEventContent) (types.Message, bool, error) {
-	// if the message is not chunked, we can assemble it immediately
-	if msgEventContent.Metadata.NumberOfChunks == 1 {
-		msg, err := m.assembleMessage(
-			msgEventContent.CompressedContent,
-			msgEventContent.Metadata,
-			types.MessageType(msgEventContent.MsgType),
-		)
+func (m *messenger) messageChunkEventHandler(ctx context.Context, evt *event.Event) {
+	defer func() {
+		if r := recover(); r != nil {
+			m.logger.Errorf("failed to process %s event, recovered from panic: %v", &matrix.EventTypeMessageChunk.Type, r)
+		}
+	}()
+	m.logger.Debugf("Received %s event %s from %s in room %s", matrix.EventTypeMessageChunk.Type, evt.ID, evt.Sender, evt.RoomID)
+
+	if evt.Sender == m.botUserID { // ignore own messages
+		m.logger.Debugf("Ignoring own message from %s in room %s", evt.Sender, evt.RoomID)
+		return
+	}
+
+	eventContent := evt.Content.Parsed.(*matrix.MessageChunkEventContent)
+
+	traceID, err := trace.TraceIDFromHex(eventContent.RequestID)
+	if err != nil {
+		m.logger.Warnf("failed to parse traceID from hex [requestID: %s]: %v", eventContent.RequestID, err)
+	}
+	ctx = trace.ContextWithRemoteSpanContext(ctx, trace.NewSpanContext(trace.SpanContextConfig{TraceID: traceID}))
+
+	_, span := m.tracer.Start(ctx, "messenger.messageChunkEventHandler", trace.WithSpanKind(trace.SpanKindConsumer), trace.WithAttributes(attribute.String("type", evt.Type.Type)))
+	defer span.End()
+
+	if err := eventContent.Verify(); err != nil {
+		m.logger.Warnf("Received invalid %s event: %v", &matrix.EventTypeMessageChunk.Type, err)
+		return
+	}
+
+	receivedAt := time.Now()
+
+	msg, completed, err := m.tryCompleteMessage(eventContent)
+	if err != nil {
+		m.logger.Warnf("Failed to assemble message from %s event (id %s): %v", &matrix.EventTypeMessage.Type, eventContent.RequestID, err)
+		return
+	} else if !completed {
+		m.logger.Debugf("Received message (id %s) chunk %d, waiting for more chunks", eventContent.RequestID, eventContent.ChunkIndex)
+		return
+	}
+
+	msg.SenderBotUserID = evt.Sender
+
+	msg.Metadata.StampOn(fmt.Sprintf("matrix-sent-%s", msg.Type), evt.Timestamp)
+	msg.Metadata.StampOn(fmt.Sprintf("%s-%s-%s", m.checkpoint(), "received", msg.Type), receivedAt.UnixMilli())
+
+	m.msgChannel <- msg
+}
+
+func (m *messenger) tryCompleteMessageWithFirstChunk(eventContent *matrix.MessageEventContent) (types.Message, bool, error) {
+	// if the message is not chunked, we can already complete it
+	if eventContent.Metadata.NumberOfChunks == 1 {
+		msg, err := m.assembleMessage(eventContent.Data, eventContent.Metadata, eventContent.MsgType)
 		return msg, err == nil, err
 	}
 
-	msgEventContents, complete := m.tryCompleteChunks(msgEventContent)
+	chunkedMessage, complete := m.addMessageFirstChunk(eventContent)
 	if !complete {
 		return types.Message{}, false, nil
 	}
-
-	// assemble payload from all chunks
-	sort.Sort(matrix.ByChunkIndex(msgEventContents))
-	compressedPayloads := make([][]byte, 0, len(msgEventContents))
-	for _, msg := range msgEventContents {
-		compressedPayloads = append(compressedPayloads, msg.CompressedContent)
-	}
-	payload := bytes.Join(compressedPayloads, nil)
-
-	msg, err := m.assembleMessage(
-		payload,
-		msgEventContents[0].Metadata,
-		types.MessageType(msgEventContents[0].MsgType),
-	)
+	msg, err := m.assembleMessageFromChunks(chunkedMessage)
 	return msg, err == nil, err
 }
 
-func (m *messenger) tryCompleteChunks(msgEventContent *matrix.CaminoMatrixMessageEventContent) ([]*matrix.CaminoMatrixMessageEventContent, bool) {
+func (m *messenger) tryCompleteMessage(eventContent *matrix.MessageChunkEventContent) (types.Message, bool, error) {
+	chunkedMessage, complete := m.addMessageNextChunk(eventContent)
+	if !complete {
+		return types.Message{}, false, nil
+	}
+	msg, err := m.assembleMessageFromChunks(chunkedMessage)
+	return msg, err == nil, err
+}
+
+func (m *messenger) addMessageFirstChunk(eventContent *matrix.MessageEventContent) (*chunkedMessage, bool) {
 	m.messagesMutex.Lock()
 	defer m.messagesMutex.Unlock()
 
-	id := msgEventContent.Metadata.RequestID
+	message, ok := m.chunkedMessages[eventContent.Metadata.RequestID]
+	if !ok {
+		message = &chunkedMessage{chunks: make([]messageChunk, 0, eventContent.Metadata.NumberOfChunks)}
+		m.chunkedMessages[eventContent.Metadata.RequestID] = message
+	}
 
-	msgEventContents := append(m.messages[id], msgEventContent) //nolint:gocritic
+	message.metadata = eventContent.Metadata
+	message.msgType = eventContent.MsgType
 
-	if uint64(len(msgEventContents)) != msgEventContent.Metadata.NumberOfChunks {
-		// don't have all chunks yet, store for later assembly and return
-		m.messages[id] = msgEventContents
+	return m.addMessageChunk(message, &matrix.MessageChunkEventContent{
+		RequestID: eventContent.Metadata.RequestID,
+		Data:      eventContent.Data,
+	})
+}
+
+func (m *messenger) addMessageNextChunk(eventContent *matrix.MessageChunkEventContent) (*chunkedMessage, bool) {
+	m.messagesMutex.Lock()
+	defer m.messagesMutex.Unlock()
+
+	message, ok := m.chunkedMessages[eventContent.RequestID]
+	if !ok {
+		message = &chunkedMessage{chunks: []messageChunk{}}
+		m.chunkedMessages[eventContent.RequestID] = message
+	}
+
+	return m.addMessageChunk(message, eventContent)
+}
+
+func (m *messenger) addMessageChunk(message *chunkedMessage, eventContent *matrix.MessageChunkEventContent) (*chunkedMessage, bool) {
+	message.chunks = append(message.chunks, messageChunk{
+		index: eventContent.ChunkIndex,
+		data:  eventContent.Data,
+	})
+
+	if message.metadata.NumberOfChunks == 0 || uint64(len(message.chunks)) < message.metadata.NumberOfChunks {
 		return nil, false
 	}
 
-	delete(m.messages, id)
+	delete(m.chunkedMessages, eventContent.RequestID)
 
-	return msgEventContents, true
+	return message, true
+}
+
+func (m *messenger) assembleMessageFromChunks(chunkedMessage *chunkedMessage) (types.Message, error) {
+	sort.Sort(byChunkIndex(chunkedMessage.chunks))
+	compressedPayloads := make([][]byte, 0, len(chunkedMessage.chunks))
+	for _, chunk := range chunkedMessage.chunks {
+		compressedPayloads = append(compressedPayloads, chunk.data)
+	}
+	return m.assembleMessage(bytes.Join(compressedPayloads, nil), chunkedMessage.metadata, chunkedMessage.msgType)
 }
 
 func (m *messenger) assembleMessage(payload []byte, metadata metadata.Metadata, msgType types.MessageType) (types.Message, error) {
@@ -148,8 +267,8 @@ func (m *messenger) assembleMessage(payload []byte, metadata metadata.Metadata, 
 	}
 
 	msg := types.Message{
-		Metadata: metadata,
 		Type:     msgType,
+		Metadata: metadata,
 	}
 
 	if err := generated.UnmarshalContent(contentBytes, msgType, &msg.Content); err != nil {
@@ -157,29 +276,4 @@ func (m *messenger) assembleMessage(payload []byte, metadata metadata.Metadata, 
 	}
 
 	return msg, nil
-}
-
-func createMessageEventContents(msg *types.Message) []matrix.CaminoMatrixMessageEventContent {
-	messages := make([]matrix.CaminoMatrixMessageEventContent, 0, len(msg.CompressedContent))
-
-	// add first chunk to messages slice
-	caminoMatrixMsg := matrix.CaminoMatrixMessageEventContent{
-		MessageEventContent: event.MessageEventContent{MsgType: event.MessageType(msg.Type)},
-		Metadata:            msg.Metadata,
-	}
-	caminoMatrixMsg.Metadata.NumberOfChunks = uint64(len(msg.CompressedContent))
-	caminoMatrixMsg.Metadata.ChunkIndex = 0
-	caminoMatrixMsg.CompressedContent = msg.CompressedContent[0]
-	messages = append(messages, caminoMatrixMsg)
-
-	// if multiple chunks were produced upon compression, add them to messages slice
-	for i, chunk := range msg.CompressedContent[1:] {
-		messages = append(messages, matrix.CaminoMatrixMessageEventContent{
-			MessageEventContent: event.MessageEventContent{MsgType: event.MessageType(msg.Type)},
-			Metadata:            metadata.Metadata{RequestID: msg.Metadata.RequestID, NumberOfChunks: uint64(len(msg.CompressedContent)), ChunkIndex: uint64(i + 1)},
-			CompressedContent:   chunk,
-		})
-	}
-
-	return messages
 }

--- a/internal/matrix/messenger/messenger.go
+++ b/internal/matrix/messenger/messenger.go
@@ -4,24 +4,18 @@
 package messenger
 
 import (
-	"bytes"
 	"context"
 	"crypto/ecdsa"
 	"errors"
 	"fmt"
-	"sort"
 	"sync"
-	"time"
 
 	"github.com/chain4travel/camino-messenger-bot/v11/internal/compression"
 	"github.com/chain4travel/camino-messenger-bot/v11/internal/messaging"
 	"github.com/chain4travel/camino-messenger-bot/v11/internal/messaging/types"
-	"github.com/chain4travel/camino-messenger-bot/v11/internal/rpc/generated"
 	"github.com/chain4travel/camino-messenger-bot/v11/pkg/matrix"
-	"github.com/chain4travel/camino-messenger-bot/v11/pkg/metadata"
 	lru "github.com/hashicorp/golang-lru/v2"
 	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 	"maunium.net/go/mautrix/event"
@@ -149,168 +143,4 @@ func (m *messenger) Stop() error {
 	}
 
 	return nil
-}
-
-func (m *messenger) SendMessage(ctx context.Context, msg *types.Message, sendTo id.UserID) error {
-	m.logger.Infof("Sending message (requestID %s) to %s", msg.Metadata.RequestID, sendTo)
-
-	ctx, span := m.tracer.Start(ctx, "messenger.SendMessage", trace.WithSpanKind(trace.SpanKindProducer), trace.WithAttributes(attribute.String("type", string(msg.Type))))
-	defer span.End()
-
-	ctx, roomSpan := m.tracer.Start(ctx, "messenger.getRoomForRecipient", trace.WithAttributes(attribute.String("type", string(msg.Type))))
-	roomID, err := m.getRoomForRecipient(ctx, sendTo)
-	if err != nil {
-		return err
-	}
-	roomSpan.End()
-
-	return m.sendMessageEvents(ctx, roomID, matrix.EventTypeC4TMessage, createMessageEventContents(msg))
-}
-
-func (m *messenger) sendMessageEvents(ctx context.Context, roomID id.RoomID, eventType event.Type, messageEvents []matrix.CaminoMatrixMessageEventContent) error {
-	// TODO @nikos add retry logic?
-	for _, msg := range messageEvents {
-		if err := m.client.SendMessageEvent(ctx, roomID, eventType, msg); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (m *messenger) c4tMessageEventHandler(ctx context.Context, evt *event.Event) {
-	defer func() {
-		if r := recover(); r != nil {
-			m.logger.Errorf("failed to process %s event, recovered from panic: %v", matrix.EventTypeC4TMessage.Type, r)
-		}
-	}()
-	m.logger.Debugf("Received %s event %s from %s in room %s", matrix.EventTypeC4TMessage.Type, evt.ID, evt.Sender, evt.RoomID)
-
-	if evt.Sender == m.botUserID { // ignore own messages
-		m.logger.Debugf("Ignoring own message from %s in room %s", evt.Sender, evt.RoomID)
-		return
-	}
-
-	msgEventContent := evt.Content.Parsed.(*matrix.CaminoMatrixMessageEventContent)
-
-	traceID, err := trace.TraceIDFromHex(msgEventContent.Metadata.RequestID)
-	if err != nil {
-		m.logger.Warnf("failed to parse traceID from hex [requestID:%s]: %v", msgEventContent.Metadata.RequestID, err)
-	}
-	ctx = trace.ContextWithRemoteSpanContext(ctx, trace.NewSpanContext(trace.SpanContextConfig{TraceID: traceID}))
-
-	_, span := m.tracer.Start(ctx, "messenger.OnC4TMessageReceive", trace.WithSpanKind(trace.SpanKindConsumer), trace.WithAttributes(attribute.String("type", evt.Type.Type)))
-	defer span.End()
-
-	receivedAt := time.Now()
-
-	msg, completed, err := m.tryAssembleMessage(msgEventContent)
-	if err != nil {
-		m.logger.Errorf("failed to assemble message: %v", err)
-		return
-	}
-	if !completed {
-		m.logger.Debugf("Received partial message with requestID %s, waiting for more chunks", msgEventContent.Metadata.RequestID)
-		return // partial messages are not passed down to the msgChannel
-	}
-
-	msg.SenderBotUserID = evt.Sender
-
-	msg.Metadata.StampOn(fmt.Sprintf("matrix-sent-%s", msgEventContent.MsgType), evt.Timestamp)
-	msg.Metadata.StampOn(fmt.Sprintf("%s-%s-%s", m.checkpoint(), "received", msgEventContent.MsgType), receivedAt.UnixMilli())
-
-	m.msgChannel <- msg
-}
-
-func (m *messenger) tryAssembleMessage(msgEventContent *matrix.CaminoMatrixMessageEventContent) (types.Message, bool, error) {
-	// if the message is not chunked, we can assemble it immediately
-	if msgEventContent.Metadata.NumberOfChunks == 1 {
-		msg, err := m.assembleMessage(
-			msgEventContent.CompressedContent,
-			msgEventContent.Metadata,
-			types.MessageType(msgEventContent.MsgType),
-		)
-		return msg, err == nil, err
-	}
-
-	msgEventContents, complete := m.tryCompleteChunks(msgEventContent)
-	if !complete {
-		return types.Message{}, false, nil
-	}
-
-	// assemble payload from all chunks
-	sort.Sort(matrix.ByChunkIndex(msgEventContents))
-	compressedPayloads := make([][]byte, 0, len(msgEventContents))
-	for _, msg := range msgEventContents {
-		compressedPayloads = append(compressedPayloads, msg.CompressedContent)
-	}
-	payload := bytes.Join(compressedPayloads, nil)
-
-	msg, err := m.assembleMessage(
-		payload,
-		msgEventContents[0].Metadata,
-		types.MessageType(msgEventContents[0].MsgType),
-	)
-	return msg, err == nil, err
-}
-
-func (m *messenger) tryCompleteChunks(msgEventContent *matrix.CaminoMatrixMessageEventContent) ([]*matrix.CaminoMatrixMessageEventContent, bool) {
-	m.messagesMutex.Lock()
-	defer m.messagesMutex.Unlock()
-
-	id := msgEventContent.Metadata.RequestID
-
-	msgEventContents := append(m.messages[id], msgEventContent) //nolint:gocritic
-
-	if uint64(len(msgEventContents)) != msgEventContent.Metadata.NumberOfChunks {
-		// don't have all chunks yet, store for later assembly and return
-		m.messages[id] = msgEventContents
-		return nil, false
-	}
-
-	delete(m.messages, id)
-
-	return msgEventContents, true
-}
-
-func (m *messenger) assembleMessage(payload []byte, metadata metadata.Metadata, msgType types.MessageType) (types.Message, error) {
-	contentBytes, err := m.decompressor.Decompress(payload)
-	if err != nil {
-		return types.Message{}, fmt.Errorf("%w: %w", errDecompressFailed, err)
-	}
-
-	msg := types.Message{
-		Metadata: metadata,
-		Type:     msgType,
-	}
-
-	if err := generated.UnmarshalContent(contentBytes, msgType, &msg.Content); err != nil {
-		return types.Message{}, fmt.Errorf("%w: %w %v", errUnmarshalContent, err, msgType)
-	}
-
-	return msg, nil
-}
-
-func createMessageEventContents(msg *types.Message) []matrix.CaminoMatrixMessageEventContent {
-	messages := make([]matrix.CaminoMatrixMessageEventContent, 0, len(msg.CompressedContent))
-
-	// add first chunk to messages slice
-	caminoMatrixMsg := matrix.CaminoMatrixMessageEventContent{
-		MessageEventContent: event.MessageEventContent{MsgType: event.MessageType(msg.Type)},
-		Metadata:            msg.Metadata,
-	}
-	caminoMatrixMsg.Metadata.NumberOfChunks = uint64(len(msg.CompressedContent))
-	caminoMatrixMsg.Metadata.ChunkIndex = 0
-	caminoMatrixMsg.CompressedContent = msg.CompressedContent[0]
-	messages = append(messages, caminoMatrixMsg)
-
-	// if multiple chunks were produced upon compression, add them to messages slice
-	for i, chunk := range msg.CompressedContent[1:] {
-		messages = append(messages, matrix.CaminoMatrixMessageEventContent{
-			MessageEventContent: event.MessageEventContent{MsgType: event.MessageType(msg.Type)},
-			Metadata:            metadata.Metadata{RequestID: msg.Metadata.RequestID, NumberOfChunks: uint64(len(msg.CompressedContent)), ChunkIndex: uint64(i + 1)},
-			CompressedContent:   chunk,
-		})
-	}
-
-	return messages
 }

--- a/internal/matrix/messenger/messenger.go
+++ b/internal/matrix/messenger/messenger.go
@@ -45,18 +45,19 @@ func NewMessenger(
 	}
 
 	m := &messenger{
-		msgChannel:   make(chan types.Message),
-		logger:       logger,
-		tracer:       otel.GetTracerProvider().Tracer(""),
-		client:       matrixClient,
-		rooms:        roomsCache,
-		decompressor: decompressor,
-		messages:     make(map[string][]*matrix.CaminoMatrixMessageEventContent),
-		botKey:       botKey,
-		botUserID:    botUserID,
+		msgChannel:      make(chan types.Message),
+		logger:          logger,
+		tracer:          otel.GetTracerProvider().Tracer(""),
+		client:          matrixClient,
+		rooms:           roomsCache,
+		decompressor:    decompressor,
+		chunkedMessages: make(map[string]*chunkedMessage),
+		botKey:          botKey,
+		botUserID:       botUserID,
 	}
 
-	m.client.SetEventHandler(matrix.EventTypeC4TMessage, m.c4tMessageEventHandler)
+	m.client.SetEventHandler(matrix.EventTypeMessage, m.messageEventHandler)
+	m.client.SetEventHandler(matrix.EventTypeMessageChunk, m.messageChunkEventHandler)
 	m.client.SetEventHandler(event.StateMember, m.stateMemberEventHandler)
 
 	return m, nil
@@ -66,12 +67,12 @@ type messenger struct {
 	botKey    *ecdsa.PrivateKey
 	botUserID id.UserID
 
-	msgChannel     chan types.Message
-	rooms          *lru.Cache[id.UserID, id.RoomID]
-	messages       map[string][]*matrix.CaminoMatrixMessageEventContent
-	messagesMutex  sync.RWMutex
-	cancelSync     func()
-	syncerDoneChan chan struct{}
+	msgChannel      chan types.Message
+	rooms           *lru.Cache[id.UserID, id.RoomID]
+	chunkedMessages map[string]*chunkedMessage
+	messagesMutex   sync.RWMutex
+	cancelSync      func()
+	syncerDoneChan  chan struct{}
 
 	logger       *zap.SugaredLogger
 	tracer       trace.Tracer

--- a/internal/matrix/messenger/messenger_test.go
+++ b/internal/matrix/messenger/messenger_test.go
@@ -6,7 +6,6 @@ package messenger
 import (
 	"crypto/ecdsa"
 	"crypto/rand"
-	"errors"
 	"fmt"
 	"testing"
 
@@ -16,6 +15,7 @@ import (
 	"github.com/chain4travel/camino-messenger-bot/v11/internal/rpc/generated"
 	"github.com/chain4travel/camino-messenger-bot/v11/pkg/matrix"
 	"github.com/chain4travel/camino-messenger-bot/v11/pkg/metadata"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/require"
 	gomock "go.uber.org/mock/gomock"
@@ -35,205 +35,148 @@ func init() {
 	}
 }
 
-func TestTryAssembleMessage(t *testing.T) {
+func TestTryCompleteMessageWithFirstChunk(t *testing.T) {
 	logger := zap.NewNop().Sugar()
 	botKey := testKey
-	testError := errors.New("test error")
 
-	msg := types.Message{
-		Metadata: metadata.Metadata{
-			RequestID:          "testRequestID",
-			RecipientCMAccount: "0xADDRESS",
-		},
-		Type:    generated.PingServiceV1Response,
-		Content: &pingv1.PingResponse{PingMessage: "pong"},
+	requestID := "message-id"
+
+	// we will always expect this message chunk to be present in the map unchanged in addition to case-specific expects
+	otherRequestID := "other-message-id"
+	otherChunkedMessage := func() *chunkedMessage { // to make copies, not references
+		return &chunkedMessage{
+			metadata: metadata.Metadata{
+				NumberOfChunks:  4,
+				SenderCMAccount: common.Address{2}.Hex(),
+			},
+			msgType: generated.AccommodationProductInfoServiceV1Request,
+			chunks: []messageChunk{
+				{index: 0, data: []byte("other-chunk0")},
+				{index: 1, data: []byte("other-chunk1")},
+			},
+		}
 	}
-	contentBytes, err := msg.MarshalContent()
+
+	content := pingv1.PingRequest{
+		PingMessage: "ping message",
+	}
+	contentBytes, err := proto.Marshal(&content)
 	require.NoError(t, err)
 
-	compressedContentBytes := []byte{'c', 'o', 'm', 'p', 'r', 'e', 's', 's', 'e', 'd'}
-
 	tests := map[string]struct {
-		decompressor                     func(c *gomock.Controller) *compression.MockDecompressor
-		existingMsgEventContents         map[string][]*matrix.CaminoMatrixMessageEventContent
-		msgEventContent                  *matrix.CaminoMatrixMessageEventContent
-		expectedExistingMsgEventContents map[string][]*matrix.CaminoMatrixMessageEventContent
-		expectedMessage                  types.Message
-		expectedComplete                 bool
-		expectedErr                      error
+		decompressor            func(*gomock.Controller) *compression.MockDecompressor
+		msgEventContent         *matrix.MessageEventContent
+		existingChunkedMessages map[string]*chunkedMessage
+		expectedChunkedMessages map[string]*chunkedMessage
+		expectedMessage         types.Message
+		expectedComplete        bool
+		expectedError           error
 	}{
-		"Decoder failed to decompress": {
-			decompressor: func(c *gomock.Controller) *compression.MockDecompressor {
-				d := compression.NewMockDecompressor(c)
-				d.EXPECT().Decompress(compressedContentBytes).Return(nil, testError)
-				return d
+		"Single-chunk message": {
+			decompressor: func(ctrl *gomock.Controller) *compression.MockDecompressor {
+				decompressor := compression.NewMockDecompressor(ctrl)
+				decompressor.EXPECT().Decompress([]byte("single chunk data")).Return(contentBytes, nil)
+				return decompressor
 			},
-			msgEventContent: &matrix.CaminoMatrixMessageEventContent{
+			msgEventContent: &matrix.MessageEventContent{
+				MsgType: generated.PingServiceV1Request,
 				Metadata: metadata.Metadata{
-					RequestID:      msg.Metadata.RequestID,
 					NumberOfChunks: 1,
+					RequestID:      requestID,
 				},
-				CompressedContent: compressedContentBytes,
-			},
-			expectedErr: errDecompressFailed,
-		},
-		"Unknown message type": {
-			decompressor: func(c *gomock.Controller) *compression.MockDecompressor {
-				d := compression.NewMockDecompressor(c)
-				d.EXPECT().Decompress(compressedContentBytes).Return([]byte{}, nil)
-				return d
-			},
-			msgEventContent: &matrix.CaminoMatrixMessageEventContent{
-				Metadata: metadata.Metadata{
-					RequestID:      msg.Metadata.RequestID,
-					NumberOfChunks: 1,
-				},
-				CompressedContent: compressedContentBytes,
-			},
-			expectedErr: errUnmarshalContent,
-		},
-		"OK: Empty input": {
-			msgEventContent: &matrix.CaminoMatrixMessageEventContent{},
-			expectedExistingMsgEventContents: map[string][]*matrix.CaminoMatrixMessageEventContent{
-				"": {{}},
-			},
-		},
-		"OK: Single chunk message": {
-			decompressor: func(c *gomock.Controller) *compression.MockDecompressor {
-				d := compression.NewMockDecompressor(c)
-				d.EXPECT().Decompress(compressedContentBytes).Return(contentBytes, nil)
-				return d
-			},
-			msgEventContent: &matrix.CaminoMatrixMessageEventContent{
-				MessageEventContent: event.MessageEventContent{
-					MsgType: event.MessageType(generated.PingServiceV1Response),
-				},
-				Metadata: metadata.Metadata{
-					RequestID:      msg.Metadata.RequestID,
-					NumberOfChunks: 1,
-				},
-				CompressedContent: compressedContentBytes,
+				Data: []byte("single chunk data"),
 			},
 			expectedMessage: types.Message{
-				Type:    generated.PingServiceV1Response,
-				Content: proto.Clone(msg.Content),
+				Type: generated.PingServiceV1Request,
 				Metadata: metadata.Metadata{
-					RequestID:      msg.Metadata.RequestID,
 					NumberOfChunks: 1,
+					RequestID:      requestID,
 				},
+				Content: proto.Clone(&content),
 			},
 			expectedComplete: true,
 		},
-		"OK: 3-chunk message, first chunk": {
-			msgEventContent: &matrix.CaminoMatrixMessageEventContent{
+		"First chunk is actually first": {
+			msgEventContent: &matrix.MessageEventContent{
+				MsgType: generated.PingServiceV1Request,
 				Metadata: metadata.Metadata{
-					RequestID:      msg.Metadata.RequestID,
+					RequestID:      requestID,
 					NumberOfChunks: 3,
-					ChunkIndex:     1,
 				},
-				CompressedContent: compressedContentBytes[3:5],
+				Data: []byte("chunk0"),
 			},
-			expectedExistingMsgEventContents: map[string][]*matrix.CaminoMatrixMessageEventContent{
-				msg.Metadata.RequestID: {
-					{
-						Metadata: metadata.Metadata{
-							RequestID:      msg.Metadata.RequestID,
-							NumberOfChunks: 3,
-							ChunkIndex:     1,
-						},
-						CompressedContent: compressedContentBytes[3:5],
-					},
-				},
-			},
-		},
-		"OK: 3-chunk message, not first, but not last chunk": {
-			existingMsgEventContents: map[string][]*matrix.CaminoMatrixMessageEventContent{
-				msg.Metadata.RequestID: {{
-					Metadata: metadata.Metadata{
-						RequestID:      msg.Metadata.RequestID,
+			expectedChunkedMessages: map[string]*chunkedMessage{
+				requestID: {
+					msgType: generated.PingServiceV1Request,
+					metadata: metadata.Metadata{
+						RequestID:      requestID,
 						NumberOfChunks: 3,
-						ChunkIndex:     1,
 					},
-					CompressedContent: compressedContentBytes[3:5],
-				}},
-			},
-			msgEventContent: &matrix.CaminoMatrixMessageEventContent{
-				Metadata: metadata.Metadata{
-					RequestID:          msg.Metadata.RequestID,
-					NumberOfChunks:     3,
-					ChunkIndex:         0,
-					RecipientCMAccount: msg.Metadata.RecipientCMAccount,
-				},
-				CompressedContent: compressedContentBytes[0:3],
-			},
-			expectedExistingMsgEventContents: map[string][]*matrix.CaminoMatrixMessageEventContent{
-				msg.Metadata.RequestID: {
-					{
-						Metadata: metadata.Metadata{
-							RequestID:      msg.Metadata.RequestID,
-							NumberOfChunks: 3,
-							ChunkIndex:     1,
-						},
-						CompressedContent: compressedContentBytes[3:5],
-					},
-					{
-						Metadata: metadata.Metadata{
-							RequestID:          msg.Metadata.RequestID,
-							NumberOfChunks:     3,
-							ChunkIndex:         0,
-							RecipientCMAccount: msg.Metadata.RecipientCMAccount,
-						},
-						CompressedContent: compressedContentBytes[0:3],
+					chunks: []messageChunk{
+						{index: 0, data: []byte("chunk0")},
 					},
 				},
 			},
 		},
-		"OK: 3-chunk message, last chunk": {
-			decompressor: func(c *gomock.Controller) *compression.MockDecompressor {
-				d := compression.NewMockDecompressor(c)
-				d.EXPECT().Decompress(compressedContentBytes).Return(contentBytes, nil)
-				return d
-			},
-			existingMsgEventContents: map[string][]*matrix.CaminoMatrixMessageEventContent{
-				msg.Metadata.RequestID: {
-					{
-						Metadata: metadata.Metadata{
-							RequestID:      msg.Metadata.RequestID,
-							NumberOfChunks: 3,
-							ChunkIndex:     1,
-						},
-						CompressedContent: compressedContentBytes[3:5],
-					},
-					{
-						MessageEventContent: event.MessageEventContent{
-							MsgType: event.MessageType(generated.PingServiceV1Response),
-						},
-						Metadata: metadata.Metadata{
-							RequestID:          msg.Metadata.RequestID,
-							NumberOfChunks:     3,
-							ChunkIndex:         0,
-							RecipientCMAccount: msg.Metadata.RecipientCMAccount,
-						},
-						CompressedContent: compressedContentBytes[0:3],
-					},
-				},
-			},
-			msgEventContent: &matrix.CaminoMatrixMessageEventContent{ // last message
+		"First chunk is second": {
+			msgEventContent: &matrix.MessageEventContent{
+				MsgType: generated.PingServiceV1Request,
 				Metadata: metadata.Metadata{
-					RequestID:      msg.Metadata.RequestID,
+					RequestID:      requestID,
 					NumberOfChunks: 3,
-					ChunkIndex:     2,
 				},
-				CompressedContent: compressedContentBytes[5:],
+				Data: []byte("chunk0"),
+			},
+			existingChunkedMessages: map[string]*chunkedMessage{
+				requestID: {
+					chunks: []messageChunk{
+						{index: 1, data: []byte("chunk1")},
+					},
+				},
+			},
+			expectedChunkedMessages: map[string]*chunkedMessage{
+				requestID: {
+					msgType: generated.PingServiceV1Request,
+					metadata: metadata.Metadata{
+						RequestID:      requestID,
+						NumberOfChunks: 3,
+					},
+					chunks: []messageChunk{
+						{index: 1, data: []byte("chunk1")},
+						{index: 0, data: []byte("chunk0")},
+					},
+				},
+			},
+		},
+		"First chunk is last": {
+			decompressor: func(ctrl *gomock.Controller) *compression.MockDecompressor {
+				decompressor := compression.NewMockDecompressor(ctrl)
+				decompressor.EXPECT().Decompress([]byte("chunk0chunk1chunk2")).Return(contentBytes, nil)
+				return decompressor
+			},
+			msgEventContent: &matrix.MessageEventContent{
+				MsgType: generated.PingServiceV1Request,
+				Metadata: metadata.Metadata{
+					RequestID:      requestID,
+					NumberOfChunks: 3,
+				},
+				Data: []byte("chunk0"),
+			},
+			existingChunkedMessages: map[string]*chunkedMessage{
+				requestID: {
+					chunks: []messageChunk{
+						{index: 1, data: []byte("chunk1")},
+						{index: 2, data: []byte("chunk2")},
+					},
+				},
 			},
 			expectedMessage: types.Message{
-				Type:    generated.PingServiceV1Response,
-				Content: proto.Clone(msg.Content),
+				Type: generated.PingServiceV1Request,
 				Metadata: metadata.Metadata{
-					RequestID:          msg.Metadata.RequestID,
-					NumberOfChunks:     3,
-					RecipientCMAccount: msg.Metadata.RecipientCMAccount,
+					NumberOfChunks: 3,
+					RequestID:      requestID,
 				},
+				Content: proto.Clone(&content),
 			},
 			expectedComplete: true,
 		},
@@ -243,7 +186,8 @@ func TestTryAssembleMessage(t *testing.T) {
 			ctrl := gomock.NewController(t)
 
 			matrixClient := NewMockClient(ctrl)
-			matrixClient.EXPECT().SetEventHandler(matrix.EventTypeC4TMessage, gomock.Any())
+			matrixClient.EXPECT().SetEventHandler(matrix.EventTypeMessage, gomock.Any())
+			matrixClient.EXPECT().SetEventHandler(matrix.EventTypeMessageChunk, gomock.Any())
 			matrixClient.EXPECT().SetEventHandler(event.StateMember, gomock.Any())
 
 			if tt.decompressor == nil {
@@ -260,27 +204,185 @@ func TestTryAssembleMessage(t *testing.T) {
 			require.NoError(t, err)
 			matrixMessengerImpl := matrixMessenger.(*messenger)
 
-			if tt.existingMsgEventContents != nil {
-				matrixMessengerImpl.messages = tt.existingMsgEventContents
+			for msgID, chunkedMessage := range tt.existingChunkedMessages {
+				matrixMessengerImpl.chunkedMessages[msgID] = chunkedMessage
 			}
 
-			message, completed, err := matrixMessengerImpl.tryAssembleMessage(tt.msgEventContent)
-			require.ErrorIs(t, err, tt.expectedErr)
-			require.Equal(t, tt.expectedComplete, completed)
+			if tt.expectedChunkedMessages == nil {
+				tt.expectedChunkedMessages = make(map[string]*chunkedMessage)
+			}
 
-			if tt.expectedComplete {
+			// we expect the other message to be present in the map unchanged
+			matrixMessengerImpl.chunkedMessages[otherRequestID] = otherChunkedMessage()
+			tt.expectedChunkedMessages[otherRequestID] = otherChunkedMessage()
+
+			message, completed, err := matrixMessengerImpl.tryCompleteMessageWithFirstChunk(tt.msgEventContent)
+			require.ErrorIs(t, err, tt.expectedError)
+			require.Equal(t, tt.expectedComplete, completed)
+			if completed {
 				require.True(t, proto.Equal(tt.expectedMessage.Content, message.Content))
 				proto.Reset(tt.expectedMessage.Content)
 				proto.Reset(message.Content)
-				require.Equal(t, tt.expectedMessage, message)
-			} else {
-				require.Empty(t, message)
+			}
+			require.Equal(t, tt.expectedMessage, message)
+			require.Equal(t, tt.expectedChunkedMessages, matrixMessengerImpl.chunkedMessages)
+		})
+	}
+}
+
+func TestTryCompleteMessage(t *testing.T) {
+	logger := zap.NewNop().Sugar()
+	botKey := testKey
+
+	requestID := "message-id"
+
+	// we will always expect this message chunk to be present in the map unchanged in addition to case-specific expects
+	otherRequestID := "other-message-id"
+	otherChunkedMessage := func() *chunkedMessage { // to make copies, not references
+		return &chunkedMessage{
+			metadata: metadata.Metadata{
+				RequestID:      otherRequestID,
+				NumberOfChunks: 4,
+			},
+			msgType: generated.AccommodationProductInfoServiceV1Request,
+			chunks: []messageChunk{
+				{index: 0, data: []byte("other-chunk0")},
+				{index: 1, data: []byte("other-chunk1")},
+			},
+		}
+	}
+
+	content := pingv1.PingRequest{
+		PingMessage: "ping message",
+	}
+	contentBytes, err := proto.Marshal(&content)
+	require.NoError(t, err)
+
+	tests := map[string]struct {
+		decompressor            func(*gomock.Controller) *compression.MockDecompressor
+		msgEventContent         *matrix.MessageChunkEventContent
+		existingChunkedMessages map[string]*chunkedMessage
+		expectedChunkedMessages map[string]*chunkedMessage
+		expectedMessage         types.Message
+		expectedComplete        bool
+		expectedError           error
+	}{
+		"Chunk is first": {
+			msgEventContent: &matrix.MessageChunkEventContent{
+				RequestID:  requestID,
+				Data:       []byte("chunk1"),
+				ChunkIndex: 1,
+			},
+			expectedChunkedMessages: map[string]*chunkedMessage{
+				requestID: {
+					chunks: []messageChunk{
+						{index: 1, data: []byte("chunk1")},
+					},
+				},
+			},
+		},
+		"Chunk is second": {
+			msgEventContent: &matrix.MessageChunkEventContent{
+				RequestID:  requestID,
+				Data:       []byte("chunk2"),
+				ChunkIndex: 2,
+			},
+			existingChunkedMessages: map[string]*chunkedMessage{
+				requestID: {
+					chunks: []messageChunk{
+						{index: 1, data: []byte("chunk1")},
+					},
+				},
+			},
+			expectedChunkedMessages: map[string]*chunkedMessage{
+				requestID: {
+					chunks: []messageChunk{
+						{index: 1, data: []byte("chunk1")},
+						{index: 2, data: []byte("chunk2")},
+					},
+				},
+			},
+		},
+		"Chunk is last": {
+			decompressor: func(ctrl *gomock.Controller) *compression.MockDecompressor {
+				decompressor := compression.NewMockDecompressor(ctrl)
+				decompressor.EXPECT().Decompress([]byte("chunk0chunk1chunk2")).Return(contentBytes, nil)
+				return decompressor
+			},
+			msgEventContent: &matrix.MessageChunkEventContent{
+				RequestID:  requestID,
+				Data:       []byte("chunk1"),
+				ChunkIndex: 1,
+			},
+			existingChunkedMessages: map[string]*chunkedMessage{
+				requestID: {
+					metadata: metadata.Metadata{
+						RequestID:      requestID,
+						NumberOfChunks: 3,
+					},
+					msgType: generated.PingServiceV1Request,
+					chunks: []messageChunk{
+						{index: 2, data: []byte("chunk2")},
+						{index: 0, data: []byte("chunk0")},
+					},
+				},
+			},
+			expectedMessage: types.Message{
+				Metadata: metadata.Metadata{
+					RequestID:      requestID,
+					NumberOfChunks: 3,
+				},
+				Type:    generated.PingServiceV1Request,
+				Content: proto.Clone(&content),
+			},
+			expectedComplete: true,
+		},
+	}
+	for tc, tt := range tests {
+		t.Run(tc, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+
+			matrixClient := NewMockClient(ctrl)
+			matrixClient.EXPECT().SetEventHandler(matrix.EventTypeMessage, gomock.Any())
+			matrixClient.EXPECT().SetEventHandler(matrix.EventTypeMessageChunk, gomock.Any())
+			matrixClient.EXPECT().SetEventHandler(event.StateMember, gomock.Any())
+
+			if tt.decompressor == nil {
+				tt.decompressor = compression.NewMockDecompressor
 			}
 
-			if tt.expectedExistingMsgEventContents == nil {
-				tt.expectedExistingMsgEventContents = make(map[string][]*matrix.CaminoMatrixMessageEventContent)
+			matrixMessenger, err := NewMessenger(
+				logger,
+				matrixClient,
+				tt.decompressor(ctrl),
+				botKey,
+				id.UserID("botUserID"),
+			)
+			require.NoError(t, err)
+			matrixMessengerImpl := matrixMessenger.(*messenger)
+
+			for msgID, chunkedMessage := range tt.existingChunkedMessages {
+				matrixMessengerImpl.chunkedMessages[msgID] = chunkedMessage
 			}
-			require.Equal(t, tt.expectedExistingMsgEventContents, matrixMessengerImpl.messages)
+
+			if tt.expectedChunkedMessages == nil {
+				tt.expectedChunkedMessages = make(map[string]*chunkedMessage)
+			}
+
+			// we expect the other message to be present in the map unchanged
+			matrixMessengerImpl.chunkedMessages[otherRequestID] = otherChunkedMessage()
+			tt.expectedChunkedMessages[otherRequestID] = otherChunkedMessage()
+
+			message, completed, err := matrixMessengerImpl.tryCompleteMessage(tt.msgEventContent)
+			require.ErrorIs(t, err, tt.expectedError)
+			require.Equal(t, tt.expectedComplete, completed)
+			if completed {
+				require.True(t, proto.Equal(tt.expectedMessage.Content, message.Content))
+				proto.Reset(tt.expectedMessage.Content)
+				proto.Reset(message.Content)
+			}
+			require.Equal(t, tt.expectedMessage, message)
+			require.Equal(t, tt.expectedChunkedMessages, matrixMessengerImpl.chunkedMessages)
 		})
 	}
 }

--- a/internal/matrix/messenger/mock_client.go
+++ b/internal/matrix/messenger/mock_client.go
@@ -158,18 +158,32 @@ func (mr *MockClientMockRecorder) LeaveRoom(arg0, arg1 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LeaveRoom", reflect.TypeOf((*MockClient)(nil).LeaveRoom), arg0, arg1)
 }
 
-// SendMessageEvent mocks base method.
-func (m *MockClient) SendMessageEvent(arg0 context.Context, arg1 id.RoomID, arg2 event.Type, arg3 matrix.CaminoMatrixMessageEventContent) error {
+// SendMessageChunkEvent mocks base method.
+func (m *MockClient) SendMessageChunkEvent(arg0 context.Context, arg1 id.RoomID, arg2 matrix.MessageChunkEventContent) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SendMessageEvent", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "SendMessageChunkEvent", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SendMessageChunkEvent indicates an expected call of SendMessageChunkEvent.
+func (mr *MockClientMockRecorder) SendMessageChunkEvent(arg0, arg1, arg2 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendMessageChunkEvent", reflect.TypeOf((*MockClient)(nil).SendMessageChunkEvent), arg0, arg1, arg2)
+}
+
+// SendMessageEvent mocks base method.
+func (m *MockClient) SendMessageEvent(arg0 context.Context, arg1 id.RoomID, arg2 matrix.MessageEventContent) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SendMessageEvent", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SendMessageEvent indicates an expected call of SendMessageEvent.
-func (mr *MockClientMockRecorder) SendMessageEvent(arg0, arg1, arg2, arg3 any) *gomock.Call {
+func (mr *MockClientMockRecorder) SendMessageEvent(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendMessageEvent", reflect.TypeOf((*MockClient)(nil).SendMessageEvent), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendMessageEvent", reflect.TypeOf((*MockClient)(nil).SendMessageEvent), arg0, arg1, arg2)
 }
 
 // SetEventHandler mocks base method.

--- a/internal/matrix/messenger/rooms_test.go
+++ b/internal/matrix/messenger/rooms_test.go
@@ -86,7 +86,8 @@ func TestGetRoomForRecipient(t *testing.T) {
 				tt.client = NewMockClient
 			}
 			matrixClient := tt.client(ctrl)
-			matrixClient.EXPECT().SetEventHandler(matrix.EventTypeC4TMessage, gomock.Any())
+			matrixClient.EXPECT().SetEventHandler(matrix.EventTypeMessage, gomock.Any())
+			matrixClient.EXPECT().SetEventHandler(matrix.EventTypeMessageChunk, gomock.Any())
 			matrixClient.EXPECT().SetEventHandler(event.StateMember, gomock.Any())
 
 			matrixMessenger, err := NewMessenger(

--- a/pkg/conversion/conversion.go
+++ b/pkg/conversion/conversion.go
@@ -15,3 +15,11 @@ func IntToInt32(value int) (int32, error) {
 	}
 	return int32(value), nil // nolint:gosec
 }
+
+// Safely converts an int to uint32, panicking with error if out of range.
+func MustIntToUInt32(value int) uint32 {
+	if value < 0 || value > math.MaxUint32 {
+		panic(fmt.Errorf("value out of range for uint32: %d", value))
+	}
+	return uint32(value) // nolint:gosec
+}

--- a/pkg/matrix/types.go
+++ b/pkg/matrix/types.go
@@ -4,48 +4,59 @@
 package matrix
 
 import (
+	"errors"
 	"reflect"
 
 	"github.com/chain4travel/camino-messenger-bot/v11/internal/messaging/types"
-	"github.com/chain4travel/camino-messenger-bot/v11/internal/rpc/generated"
-	"github.com/chain4travel/camino-messenger-bot/v11/pkg/cheques"
 	"github.com/chain4travel/camino-messenger-bot/v11/pkg/metadata"
-	"github.com/ethereum/go-ethereum/common"
-	"google.golang.org/protobuf/reflect/protoreflect"
 	"maunium.net/go/mautrix/event"
 )
 
-var EventTypeC4TMessage = event.Type{Type: "m.room.c4t-msg", Class: event.MessageEventType}
+var (
+	EventTypeMessage      = event.Type{Type: "m.room.c4t-msg", Class: event.MessageEventType}
+	EventTypeMessageChunk = event.Type{Type: "m.room.c4t-msg-chunk", Class: event.MessageEventType}
+
+	ErrNoChunks    = errors.New("zero chunks count")
+	ErrNoData      = errors.New("no data in message chunk")
+	ErrNoRequestID = errors.New("missing request ID")
+)
 
 func init() {
-	event.TypeMap[EventTypeC4TMessage] = reflect.TypeOf(CaminoMatrixMessageEventContent{})
+	event.TypeMap[EventTypeMessage] = reflect.TypeOf(MessageEventContent{})
+	event.TypeMap[EventTypeMessageChunk] = reflect.TypeOf(MessageChunkEventContent{})
 }
 
-// CaminoMatrixMessageEventContent is a matrix-specific message format used for communication between the messenger and the service
-type CaminoMatrixMessageEventContent struct {
-	event.MessageEventContent
-	Content           protoreflect.ProtoMessage `json:"content"`
-	CompressedContent []byte                    `json:"compressed_content"`
-	Metadata          metadata.Metadata         `json:"metadata"`
+type MessageChunkEventContent struct {
+	RequestID  string `json:"request_id"`
+	ChunkIndex uint32 `json:"chunk_index,omitempty"`
+	Data       []byte `json:"data"`
 }
 
-type ByChunkIndex []*CaminoMatrixMessageEventContent
-
-func (b ByChunkIndex) Len() int { return len(b) }
-func (b ByChunkIndex) Less(i, j int) bool {
-	return b[i].Metadata.ChunkIndex < b[j].Metadata.ChunkIndex
-}
-func (b ByChunkIndex) Swap(i, j int) { b[i], b[j] = b[j], b[i] }
-
-func (m *CaminoMatrixMessageEventContent) UnmarshalContent(src []byte) error {
-	return generated.UnmarshalContent(src, types.MessageType(m.MsgType), &m.Content)
+func (e *MessageChunkEventContent) Verify() error {
+	if len(e.Data) == 0 {
+		return ErrNoData
+	}
+	if e.RequestID == "" {
+		return ErrNoRequestID
+	}
+	return nil
 }
 
-func (m *CaminoMatrixMessageEventContent) GetChequeFor(addr common.Address) *cheques.SignedCheque {
-	for _, cheque := range m.Metadata.Cheques {
-		if cheque.Cheque.ToCMAccount == addr {
-			return &cheque
-		}
+type MessageEventContent struct {
+	MsgType  types.MessageType `json:"msgtype"`
+	Metadata metadata.Metadata `json:"metadata"`
+	Data     []byte            `json:"data"`
+}
+
+func (e *MessageEventContent) Verify() error {
+	if e.Metadata.NumberOfChunks == 0 {
+		return ErrNoChunks
+	}
+	if e.Metadata.RequestID == "" {
+		return ErrNoRequestID
+	}
+	if len(e.Data) == 0 {
+		return ErrNoData
 	}
 	return nil
 }

--- a/pkg/metadata/metadata.go
+++ b/pkg/metadata/metadata.go
@@ -21,7 +21,6 @@ type Metadata struct {
 	Cheques            []cheques.SignedCheque `json:"cheques"`
 	Timestamps         map[string]int64       `json:"timestamps"` // map of checkpoints to timestamps in unix milliseconds
 	NumberOfChunks     uint64                 `json:"number_of_chunks"`
-	ChunkIndex         uint64                 `json:"chunk_index"`
 
 	// Deprecated: this metadata serves only as a temp solution and should be removed and addressed on the protocol level
 	ProviderOperator string `json:"provider_operator"`


### PR DESCRIPTION
Messenger splits message into chunks and sends them as matrix events.
Currently all events are of the same type and contain metadata, but we only need it in first chunk.
This PR splits matrix events into two: one with metadata and message type and other with just data and chunk index.
