### PR TITLE
Cleanup metadata usage and transport

### DIFF
--- a/internal/matrix/messenger/messages.go
+++ b/internal/matrix/messenger/messages.go
@@ -60,8 +60,11 @@ func (m *messenger) SendMessage(ctx context.Context, msg *types.Message, sendTo 
 			RequestID: msg.RequestID,
 			Data:      msg.CompressedContent[0],
 		},
-		MsgType:     msg.Type,
-		ChunksCount: conversion.MustIntToUInt32(len(msg.CompressedContent)),
+		MsgType:          msg.Type,
+		Timestamps:       msg.Timestamps,
+		ServiceFeeCheque: msg.ServiceFeeCheque,
+		NetworkFeeCheque: *msg.NetworkFeeCheque,
+		ChunksCount:      conversion.MustIntToUInt32(len(msg.CompressedContent)),
 	}
 
 	var chunkEvents []matrix.MessageChunkEventContent

--- a/internal/matrix/messenger/messages.go
+++ b/internal/matrix/messenger/messages.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/chain4travel/camino-messenger-bot/v11/internal/messaging/types"
 	"github.com/chain4travel/camino-messenger-bot/v11/internal/rpc/generated"
+	"github.com/chain4travel/camino-messenger-bot/v11/pkg/cheques"
 	"github.com/chain4travel/camino-messenger-bot/v11/pkg/conversion"
 	"github.com/chain4travel/camino-messenger-bot/v11/pkg/matrix"
 	"github.com/chain4travel/camino-messenger-bot/v11/pkg/metadata"
@@ -22,10 +23,12 @@ import (
 )
 
 type chunkedMessage struct {
-	msgType     types.MessageType
-	timestamps  metadata.Timestamps
-	chunksCount uint32
-	chunks      []messageChunk
+	msgType          types.MessageType
+	timestamps       metadata.Timestamps
+	serviceFeeCheque *cheques.SignedCheque
+	networkFeeCheque *cheques.SignedCheque
+	chunksCount      uint32
+	chunks           []messageChunk
 }
 
 type messageChunk struct {
@@ -185,7 +188,14 @@ func (m *messenger) messageChunkEventHandler(ctx context.Context, evt *event.Eve
 func (m *messenger) tryCompleteMessageWithFirstChunk(eventContent *matrix.MessageEventContent) (types.Message, bool, error) {
 	// if the message is not chunked, we can already complete it
 	if eventContent.ChunksCount == 1 {
-		msg, err := m.assembleMessage(eventContent.Data, eventContent.RequestID, eventContent.Timestamps, eventContent.MsgType)
+		msg, err := m.assembleMessage(
+			eventContent.Data,
+			eventContent.RequestID,
+			eventContent.Timestamps,
+			eventContent.MsgType,
+			eventContent.ServiceFeeCheque,
+			&eventContent.NetworkFeeCheque,
+		)
 		return msg, err == nil, err
 	}
 
@@ -219,6 +229,8 @@ func (m *messenger) addMessageFirstChunk(eventContent *matrix.MessageEventConten
 	message.chunksCount = eventContent.ChunksCount
 	message.timestamps = eventContent.Timestamps
 	message.msgType = eventContent.MsgType
+	message.serviceFeeCheque = eventContent.ServiceFeeCheque
+	message.networkFeeCheque = &eventContent.NetworkFeeCheque
 
 	return m.addMessageChunk(message, &matrix.MessageChunkEventContent{
 		RequestID: eventContent.RequestID,
@@ -260,19 +272,35 @@ func (m *messenger) assembleMessageFromChunks(requestID string, chunkedMessage *
 	for _, chunk := range chunkedMessage.chunks {
 		compressedPayloads = append(compressedPayloads, chunk.data)
 	}
-	return m.assembleMessage(bytes.Join(compressedPayloads, nil), requestID, chunkedMessage.timestamps, chunkedMessage.msgType)
+	return m.assembleMessage(
+		bytes.Join(compressedPayloads, nil),
+		requestID,
+		chunkedMessage.timestamps,
+		chunkedMessage.msgType,
+		chunkedMessage.serviceFeeCheque,
+		chunkedMessage.networkFeeCheque,
+	)
 }
 
-func (m *messenger) assembleMessage(payload []byte, requestID string, timestamps metadata.Timestamps, msgType types.MessageType) (types.Message, error) {
+func (m *messenger) assembleMessage(
+	payload []byte,
+	requestID string,
+	timestamps metadata.Timestamps,
+	msgType types.MessageType,
+	serviceFeeCheque *cheques.SignedCheque,
+	networkFeeCheque *cheques.SignedCheque,
+) (types.Message, error) {
 	contentBytes, err := m.decompressor.Decompress(payload)
 	if err != nil {
 		return types.Message{}, fmt.Errorf("%w: %w", errDecompressFailed, err)
 	}
 
 	msg := types.Message{
-		Type:       msgType,
-		RequestID:  requestID,
-		Timestamps: timestamps,
+		Type:             msgType,
+		RequestID:        requestID,
+		Timestamps:       timestamps,
+		ServiceFeeCheque: serviceFeeCheque,
+		NetworkFeeCheque: networkFeeCheque,
 	}
 
 	if err := generated.UnmarshalContent(contentBytes, msgType, &msg.Content); err != nil {

--- a/internal/matrix/messenger/messages.go
+++ b/internal/matrix/messenger/messages.go
@@ -22,9 +22,10 @@ import (
 )
 
 type chunkedMessage struct {
-	msgType  types.MessageType
-	metadata metadata.Metadata
-	chunks   []messageChunk
+	msgType     types.MessageType
+	timestamps  metadata.Timestamps
+	chunksCount uint32
+	chunks      []messageChunk
 }
 
 type messageChunk struct {
@@ -39,7 +40,7 @@ func (b byChunkIndex) Less(i, j int) bool { return b[i].index < b[j].index }
 func (b byChunkIndex) Swap(i, j int)      { b[i], b[j] = b[j], b[i] }
 
 func (m *messenger) SendMessage(ctx context.Context, msg *types.Message, sendTo id.UserID) error {
-	m.logger.Debugf("Sending message (id %s) to %s", msg.Metadata.RequestID, sendTo)
+	m.logger.Debugf("Sending message (id %s) to %s", msg.RequestID, sendTo)
 
 	ctx, span := m.tracer.Start(ctx, "messenger.SendMessage", trace.WithSpanKind(trace.SpanKindProducer), trace.WithAttributes(attribute.String("type", string(msg.Type))))
 	defer span.End()
@@ -52,19 +53,20 @@ func (m *messenger) SendMessage(ctx context.Context, msg *types.Message, sendTo 
 	roomSpan.End()
 
 	messageEvent := matrix.MessageEventContent{
-		MsgType:  msg.Type,
-		Metadata: msg.Metadata,
-		Data:     msg.CompressedContent[0],
+		MessageChunkEventContent: matrix.MessageChunkEventContent{
+			RequestID: msg.RequestID,
+			Data:      msg.CompressedContent[0],
+		},
+		MsgType:     msg.Type,
+		ChunksCount: conversion.MustIntToUInt32(len(msg.CompressedContent)),
 	}
 
-	messageEvent.Metadata.NumberOfChunks = uint64(len(msg.CompressedContent))
-
 	var chunkEvents []matrix.MessageChunkEventContent
-	if msg.Metadata.NumberOfChunks > 1 {
-		chunkEvents = make([]matrix.MessageChunkEventContent, 0, msg.Metadata.NumberOfChunks-1)
+	if messageEvent.ChunksCount > 1 {
+		chunkEvents = make([]matrix.MessageChunkEventContent, 0, messageEvent.ChunksCount-1)
 		for i, chunk := range msg.CompressedContent[1:] {
 			chunkEvents = append(chunkEvents, matrix.MessageChunkEventContent{
-				RequestID:  msg.Metadata.RequestID,
+				RequestID:  msg.RequestID,
 				ChunkIndex: conversion.MustIntToUInt32(i + 1),
 				Data:       chunk,
 			})
@@ -99,9 +101,9 @@ func (m *messenger) messageEventHandler(ctx context.Context, evt *event.Event) {
 
 	eventContent := evt.Content.Parsed.(*matrix.MessageEventContent)
 
-	traceID, err := trace.TraceIDFromHex(eventContent.Metadata.RequestID)
+	traceID, err := trace.TraceIDFromHex(eventContent.RequestID)
 	if err != nil {
-		m.logger.Warnf("failed to parse traceID from hex [requestID: %s]: %v", eventContent.Metadata.RequestID, err)
+		m.logger.Warnf("failed to parse traceID from hex [requestID: %s]: %v", eventContent.RequestID, err)
 	}
 	ctx = trace.ContextWithRemoteSpanContext(ctx, trace.NewSpanContext(trace.SpanContextConfig{TraceID: traceID}))
 
@@ -109,7 +111,7 @@ func (m *messenger) messageEventHandler(ctx context.Context, evt *event.Event) {
 	defer span.End()
 
 	if err := eventContent.Verify(); err != nil {
-		m.logger.Warnf("Received invalid %s event (id %s): %v", &matrix.EventTypeMessage.Type, eventContent.Metadata.RequestID, err)
+		m.logger.Warnf("Received invalid %s event (id %s): %v", &matrix.EventTypeMessage.Type, eventContent.RequestID, err)
 		return
 	}
 
@@ -117,17 +119,17 @@ func (m *messenger) messageEventHandler(ctx context.Context, evt *event.Event) {
 
 	msg, completed, err := m.tryCompleteMessageWithFirstChunk(eventContent)
 	if err != nil {
-		m.logger.Warnf("Failed to assemble message from %s event (id %s): %v", &matrix.EventTypeMessage.Type, eventContent.Metadata.RequestID, err)
+		m.logger.Warnf("Failed to assemble message from %s event (id %s): %v", &matrix.EventTypeMessage.Type, eventContent.RequestID, err)
 		return
 	} else if !completed {
-		m.logger.Debugf("Received message (id %s) first chunk, waiting for more chunks", eventContent.Metadata.RequestID)
+		m.logger.Debugf("Received message (id %s) first chunk, waiting for more chunks", eventContent.RequestID)
 		return
 	}
 
 	msg.SenderBotUserID = evt.Sender
 
-	msg.Metadata.StampOn(fmt.Sprintf("matrix-sent-%s", msg.Type), evt.Timestamp)
-	msg.Metadata.StampOn(fmt.Sprintf("%s-%s-%s", m.checkpoint(), "received", msg.Type), receivedAt.UnixMilli())
+	msg.Timestamps.StampOn(fmt.Sprintf("matrix-sent-%s", msg.Type), evt.Timestamp)
+	msg.Timestamps.StampOn(fmt.Sprintf("%s-%s-%s", m.checkpoint(), "received", msg.Type), receivedAt.UnixMilli())
 
 	m.msgChannel <- msg
 }
@@ -174,16 +176,16 @@ func (m *messenger) messageChunkEventHandler(ctx context.Context, evt *event.Eve
 
 	msg.SenderBotUserID = evt.Sender
 
-	msg.Metadata.StampOn(fmt.Sprintf("matrix-sent-%s", msg.Type), evt.Timestamp)
-	msg.Metadata.StampOn(fmt.Sprintf("%s-%s-%s", m.checkpoint(), "received", msg.Type), receivedAt.UnixMilli())
+	msg.Timestamps.StampOn(fmt.Sprintf("matrix-sent-%s", msg.Type), evt.Timestamp)
+	msg.Timestamps.StampOn(fmt.Sprintf("%s-%s-%s", m.checkpoint(), "received", msg.Type), receivedAt.UnixMilli())
 
 	m.msgChannel <- msg
 }
 
 func (m *messenger) tryCompleteMessageWithFirstChunk(eventContent *matrix.MessageEventContent) (types.Message, bool, error) {
 	// if the message is not chunked, we can already complete it
-	if eventContent.Metadata.NumberOfChunks == 1 {
-		msg, err := m.assembleMessage(eventContent.Data, eventContent.Metadata, eventContent.MsgType)
+	if eventContent.ChunksCount == 1 {
+		msg, err := m.assembleMessage(eventContent.Data, eventContent.RequestID, eventContent.Timestamps, eventContent.MsgType)
 		return msg, err == nil, err
 	}
 
@@ -191,7 +193,7 @@ func (m *messenger) tryCompleteMessageWithFirstChunk(eventContent *matrix.Messag
 	if !complete {
 		return types.Message{}, false, nil
 	}
-	msg, err := m.assembleMessageFromChunks(chunkedMessage)
+	msg, err := m.assembleMessageFromChunks(eventContent.RequestID, chunkedMessage)
 	return msg, err == nil, err
 }
 
@@ -200,7 +202,7 @@ func (m *messenger) tryCompleteMessage(eventContent *matrix.MessageChunkEventCon
 	if !complete {
 		return types.Message{}, false, nil
 	}
-	msg, err := m.assembleMessageFromChunks(chunkedMessage)
+	msg, err := m.assembleMessageFromChunks(eventContent.RequestID, chunkedMessage)
 	return msg, err == nil, err
 }
 
@@ -208,17 +210,18 @@ func (m *messenger) addMessageFirstChunk(eventContent *matrix.MessageEventConten
 	m.messagesMutex.Lock()
 	defer m.messagesMutex.Unlock()
 
-	message, ok := m.chunkedMessages[eventContent.Metadata.RequestID]
+	message, ok := m.chunkedMessages[eventContent.RequestID]
 	if !ok {
-		message = &chunkedMessage{chunks: make([]messageChunk, 0, eventContent.Metadata.NumberOfChunks)}
-		m.chunkedMessages[eventContent.Metadata.RequestID] = message
+		message = &chunkedMessage{chunks: make([]messageChunk, 0, eventContent.ChunksCount)}
+		m.chunkedMessages[eventContent.RequestID] = message
 	}
 
-	message.metadata = eventContent.Metadata
+	message.chunksCount = eventContent.ChunksCount
+	message.timestamps = eventContent.Timestamps
 	message.msgType = eventContent.MsgType
 
 	return m.addMessageChunk(message, &matrix.MessageChunkEventContent{
-		RequestID: eventContent.Metadata.RequestID,
+		RequestID: eventContent.RequestID,
 		Data:      eventContent.Data,
 	})
 }
@@ -242,7 +245,7 @@ func (m *messenger) addMessageChunk(message *chunkedMessage, eventContent *matri
 		data:  eventContent.Data,
 	})
 
-	if message.metadata.NumberOfChunks == 0 || uint64(len(message.chunks)) < message.metadata.NumberOfChunks {
+	if message.chunksCount == 0 || conversion.MustIntToUInt32(len(message.chunks)) < message.chunksCount {
 		return nil, false
 	}
 
@@ -251,24 +254,25 @@ func (m *messenger) addMessageChunk(message *chunkedMessage, eventContent *matri
 	return message, true
 }
 
-func (m *messenger) assembleMessageFromChunks(chunkedMessage *chunkedMessage) (types.Message, error) {
+func (m *messenger) assembleMessageFromChunks(requestID string, chunkedMessage *chunkedMessage) (types.Message, error) {
 	sort.Sort(byChunkIndex(chunkedMessage.chunks))
 	compressedPayloads := make([][]byte, 0, len(chunkedMessage.chunks))
 	for _, chunk := range chunkedMessage.chunks {
 		compressedPayloads = append(compressedPayloads, chunk.data)
 	}
-	return m.assembleMessage(bytes.Join(compressedPayloads, nil), chunkedMessage.metadata, chunkedMessage.msgType)
+	return m.assembleMessage(bytes.Join(compressedPayloads, nil), requestID, chunkedMessage.timestamps, chunkedMessage.msgType)
 }
 
-func (m *messenger) assembleMessage(payload []byte, metadata metadata.Metadata, msgType types.MessageType) (types.Message, error) {
+func (m *messenger) assembleMessage(payload []byte, requestID string, timestamps metadata.Timestamps, msgType types.MessageType) (types.Message, error) {
 	contentBytes, err := m.decompressor.Decompress(payload)
 	if err != nil {
 		return types.Message{}, fmt.Errorf("%w: %w", errDecompressFailed, err)
 	}
 
 	msg := types.Message{
-		Type:     msgType,
-		Metadata: metadata,
+		Type:       msgType,
+		RequestID:  requestID,
+		Timestamps: timestamps,
 	}
 
 	if err := generated.UnmarshalContent(contentBytes, msgType, &msg.Content); err != nil {

--- a/internal/matrix/messenger/messages_test.go
+++ b/internal/matrix/messenger/messages_test.go
@@ -13,9 +13,9 @@ import (
 	"github.com/chain4travel/camino-messenger-bot/v11/internal/compression"
 	"github.com/chain4travel/camino-messenger-bot/v11/internal/messaging/types"
 	"github.com/chain4travel/camino-messenger-bot/v11/internal/rpc/generated"
+	"github.com/chain4travel/camino-messenger-bot/v11/pkg/cheques"
 	"github.com/chain4travel/camino-messenger-bot/v11/pkg/matrix"
 	"github.com/chain4travel/camino-messenger-bot/v11/pkg/metadata"
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/require"
 	gomock "go.uber.org/mock/gomock"
@@ -40,16 +40,19 @@ func TestTryCompleteMessageWithFirstChunk(t *testing.T) {
 	botKey := testKey
 
 	requestID := "message-id"
+	serviceFeeCheque := &cheques.SignedCheque{Signature: []byte("service-fee-signature")}
+	networkFeeCheque := &cheques.SignedCheque{Signature: []byte("network-fee-signature")}
+	timestamps := metadata.Timestamps{"1": 9876543210}
 
 	// we will always expect this message chunk to be present in the map unchanged in addition to case-specific expects
 	otherRequestID := "other-message-id"
 	otherChunkedMessage := func() *chunkedMessage { // to make copies, not references
 		return &chunkedMessage{
-			metadata: metadata.Metadata{
-				NumberOfChunks:  4,
-				SenderCMAccount: common.Address{2}.Hex(),
-			},
-			msgType: generated.AccommodationProductInfoServiceV1Request,
+			timestamps:       metadata.Timestamps{"1-other": 1234567890},
+			serviceFeeCheque: &cheques.SignedCheque{Signature: []byte("other-service-fee-signature")},
+			networkFeeCheque: &cheques.SignedCheque{Signature: []byte("other-network-fee-signature")},
+			chunksCount:      4,
+			msgType:          generated.AccommodationProductInfoServiceV1Request,
 			chunks: []messageChunk{
 				{index: 0, data: []byte("other-chunk0")},
 				{index: 1, data: []byte("other-chunk1")},
@@ -79,39 +82,45 @@ func TestTryCompleteMessageWithFirstChunk(t *testing.T) {
 				return decompressor
 			},
 			msgEventContent: &matrix.MessageEventContent{
-				MsgType: generated.PingServiceV1Request,
-				Metadata: metadata.Metadata{
-					NumberOfChunks: 1,
-					RequestID:      requestID,
+				MessageChunkEventContent: matrix.MessageChunkEventContent{
+					RequestID: requestID,
+					Data:      []byte("single chunk data"),
 				},
-				Data: []byte("single chunk data"),
+				MsgType:          generated.PingServiceV1Request,
+				Timestamps:       timestamps,
+				ServiceFeeCheque: serviceFeeCheque,
+				NetworkFeeCheque: *networkFeeCheque,
+				ChunksCount:      1,
 			},
 			expectedMessage: types.Message{
-				Type: generated.PingServiceV1Request,
-				Metadata: metadata.Metadata{
-					NumberOfChunks: 1,
-					RequestID:      requestID,
-				},
-				Content: proto.Clone(&content),
+				RequestID:        requestID,
+				Type:             generated.PingServiceV1Request,
+				Timestamps:       timestamps,
+				ServiceFeeCheque: serviceFeeCheque,
+				NetworkFeeCheque: networkFeeCheque,
+				Content:          proto.Clone(&content),
 			},
 			expectedComplete: true,
 		},
 		"First chunk is actually first": {
 			msgEventContent: &matrix.MessageEventContent{
-				MsgType: generated.PingServiceV1Request,
-				Metadata: metadata.Metadata{
-					RequestID:      requestID,
-					NumberOfChunks: 3,
+				MessageChunkEventContent: matrix.MessageChunkEventContent{
+					RequestID: requestID,
+					Data:      []byte("chunk0"),
 				},
-				Data: []byte("chunk0"),
+				MsgType:          generated.PingServiceV1Request,
+				Timestamps:       timestamps,
+				ServiceFeeCheque: serviceFeeCheque,
+				NetworkFeeCheque: *networkFeeCheque,
+				ChunksCount:      3,
 			},
 			expectedChunkedMessages: map[string]*chunkedMessage{
 				requestID: {
-					msgType: generated.PingServiceV1Request,
-					metadata: metadata.Metadata{
-						RequestID:      requestID,
-						NumberOfChunks: 3,
-					},
+					msgType:          generated.PingServiceV1Request,
+					chunksCount:      3,
+					timestamps:       timestamps,
+					serviceFeeCheque: serviceFeeCheque,
+					networkFeeCheque: networkFeeCheque,
 					chunks: []messageChunk{
 						{index: 0, data: []byte("chunk0")},
 					},
@@ -120,12 +129,15 @@ func TestTryCompleteMessageWithFirstChunk(t *testing.T) {
 		},
 		"First chunk is second": {
 			msgEventContent: &matrix.MessageEventContent{
-				MsgType: generated.PingServiceV1Request,
-				Metadata: metadata.Metadata{
-					RequestID:      requestID,
-					NumberOfChunks: 3,
+				MessageChunkEventContent: matrix.MessageChunkEventContent{
+					RequestID: requestID,
+					Data:      []byte("chunk0"),
 				},
-				Data: []byte("chunk0"),
+				MsgType:          generated.PingServiceV1Request,
+				Timestamps:       timestamps,
+				ServiceFeeCheque: serviceFeeCheque,
+				NetworkFeeCheque: *networkFeeCheque,
+				ChunksCount:      3,
 			},
 			existingChunkedMessages: map[string]*chunkedMessage{
 				requestID: {
@@ -136,11 +148,11 @@ func TestTryCompleteMessageWithFirstChunk(t *testing.T) {
 			},
 			expectedChunkedMessages: map[string]*chunkedMessage{
 				requestID: {
-					msgType: generated.PingServiceV1Request,
-					metadata: metadata.Metadata{
-						RequestID:      requestID,
-						NumberOfChunks: 3,
-					},
+					msgType:          generated.PingServiceV1Request,
+					chunksCount:      3,
+					timestamps:       timestamps,
+					serviceFeeCheque: serviceFeeCheque,
+					networkFeeCheque: networkFeeCheque,
 					chunks: []messageChunk{
 						{index: 1, data: []byte("chunk1")},
 						{index: 0, data: []byte("chunk0")},
@@ -155,12 +167,15 @@ func TestTryCompleteMessageWithFirstChunk(t *testing.T) {
 				return decompressor
 			},
 			msgEventContent: &matrix.MessageEventContent{
-				MsgType: generated.PingServiceV1Request,
-				Metadata: metadata.Metadata{
-					RequestID:      requestID,
-					NumberOfChunks: 3,
+				MessageChunkEventContent: matrix.MessageChunkEventContent{
+					RequestID: requestID,
+					Data:      []byte("chunk0"),
 				},
-				Data: []byte("chunk0"),
+				MsgType:          generated.PingServiceV1Request,
+				Timestamps:       timestamps,
+				ServiceFeeCheque: serviceFeeCheque,
+				NetworkFeeCheque: *networkFeeCheque,
+				ChunksCount:      3,
 			},
 			existingChunkedMessages: map[string]*chunkedMessage{
 				requestID: {
@@ -171,12 +186,12 @@ func TestTryCompleteMessageWithFirstChunk(t *testing.T) {
 				},
 			},
 			expectedMessage: types.Message{
-				Type: generated.PingServiceV1Request,
-				Metadata: metadata.Metadata{
-					NumberOfChunks: 3,
-					RequestID:      requestID,
-				},
-				Content: proto.Clone(&content),
+				RequestID:        requestID,
+				Type:             generated.PingServiceV1Request,
+				Timestamps:       timestamps,
+				ServiceFeeCheque: serviceFeeCheque,
+				NetworkFeeCheque: networkFeeCheque,
+				Content:          proto.Clone(&content),
 			},
 			expectedComplete: true,
 		},
@@ -235,16 +250,19 @@ func TestTryCompleteMessage(t *testing.T) {
 	botKey := testKey
 
 	requestID := "message-id"
+	serviceFeeCheque := &cheques.SignedCheque{Signature: []byte("service-fee-signature")}
+	networkFeeCheque := &cheques.SignedCheque{Signature: []byte("network-fee-signature")}
+	timestamps := metadata.Timestamps{"1": 9876543210}
 
 	// we will always expect this message chunk to be present in the map unchanged in addition to case-specific expects
 	otherRequestID := "other-message-id"
 	otherChunkedMessage := func() *chunkedMessage { // to make copies, not references
 		return &chunkedMessage{
-			metadata: metadata.Metadata{
-				RequestID:      otherRequestID,
-				NumberOfChunks: 4,
-			},
-			msgType: generated.AccommodationProductInfoServiceV1Request,
+			timestamps:       metadata.Timestamps{"1-other": 1234567890},
+			serviceFeeCheque: &cheques.SignedCheque{Signature: []byte("other-service-fee-signature")},
+			networkFeeCheque: &cheques.SignedCheque{Signature: []byte("other-network-fee-signature")},
+			chunksCount:      4,
+			msgType:          generated.AccommodationProductInfoServiceV1Request,
 			chunks: []messageChunk{
 				{index: 0, data: []byte("other-chunk0")},
 				{index: 1, data: []byte("other-chunk1")},
@@ -316,11 +334,11 @@ func TestTryCompleteMessage(t *testing.T) {
 			},
 			existingChunkedMessages: map[string]*chunkedMessage{
 				requestID: {
-					metadata: metadata.Metadata{
-						RequestID:      requestID,
-						NumberOfChunks: 3,
-					},
-					msgType: generated.PingServiceV1Request,
+					chunksCount:      3,
+					msgType:          generated.PingServiceV1Request,
+					timestamps:       timestamps,
+					serviceFeeCheque: serviceFeeCheque,
+					networkFeeCheque: networkFeeCheque,
 					chunks: []messageChunk{
 						{index: 2, data: []byte("chunk2")},
 						{index: 0, data: []byte("chunk0")},
@@ -328,12 +346,12 @@ func TestTryCompleteMessage(t *testing.T) {
 				},
 			},
 			expectedMessage: types.Message{
-				Metadata: metadata.Metadata{
-					RequestID:      requestID,
-					NumberOfChunks: 3,
-				},
-				Type:    generated.PingServiceV1Request,
-				Content: proto.Clone(&content),
+				RequestID:        requestID,
+				Timestamps:       timestamps,
+				ServiceFeeCheque: serviceFeeCheque,
+				NetworkFeeCheque: networkFeeCheque,
+				Type:             generated.PingServiceV1Request,
+				Content:          proto.Clone(&content),
 			},
 			expectedComplete: true,
 		},

--- a/internal/messaging/compressor.go
+++ b/internal/messaging/compressor.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/chain4travel/camino-messenger-bot/v11/internal/compression"
 	"github.com/chain4travel/camino-messenger-bot/v11/internal/messaging/types"
+	"google.golang.org/protobuf/proto"
 )
 
 var (
@@ -47,7 +48,7 @@ func (c *chunkingCompressor) split(bytes []byte) ([][]byte, error) {
 }
 
 func compress(msg *types.Message) ([]byte, error) {
-	content, err := msg.MarshalContent()
+	content, err := proto.Marshal(msg.Content)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", ErrEncodingMsg, err)
 	}

--- a/internal/messaging/processor.go
+++ b/internal/messaging/processor.go
@@ -18,7 +18,6 @@ import (
 	"github.com/chain4travel/camino-messenger-bot/v11/internal/partnerplugin"
 	"github.com/chain4travel/camino-messenger-bot/v11/internal/rpc"
 	"github.com/chain4travel/camino-messenger-bot/v11/pkg/chequehandler"
-	"github.com/chain4travel/camino-messenger-bot/v11/pkg/cheques"
 	cmaccounts "github.com/chain4travel/camino-messenger-bot/v11/pkg/cm_accounts"
 	"github.com/chain4travel/camino-messenger-bot/v11/pkg/matrix"
 	ethCommon "github.com/ethereum/go-ethereum/common"
@@ -35,7 +34,6 @@ var (
 	ErrUnknownMessageCategory       = errors.New("unknown message category")
 	ErrOnlyRequestMessagesAllowed   = errors.New("only request messages allowed")
 	ErrUnsupportedService           = errors.New("unsupported service")
-	ErrInvalidRecipient             = errors.New("invalid recipient address")
 	ErrForeignCMAccount             = errors.New("foreign or Invalid CM Account")
 	ErrExceededResponseTimeout      = errors.New("response exceeded configured timeout")
 	ErrMissingCheques               = errors.New("missing cheques in metadata")
@@ -47,7 +45,11 @@ var (
 type MessageProcessor interface {
 	Start(ctx context.Context)
 	ProcessIncomingMessage(message *types.Message) error
-	SendRequestMessage(ctx context.Context, message *types.Message) (*types.Message, error)
+	SendRequestMessage(
+		ctx context.Context,
+		message *types.Message,
+		recipientCMAccountAddress ethCommon.Address,
+	) (*types.Message, error)
 }
 
 func NewMessageProcessor(
@@ -156,7 +158,11 @@ func (p *messageProcessor) ProcessIncomingMessage(msg *types.Message) error {
 	}
 }
 
-func (p *messageProcessor) SendRequestMessage(ctx context.Context, requestMsg *types.Message) (*types.Message, error) {
+func (p *messageProcessor) SendRequestMessage(
+	ctx context.Context,
+	requestMsg *types.Message,
+	recipientCMAccountAddress ethCommon.Address,
+) (*types.Message, error) {
 	if requestMsg.Type.Category() != types.Request {
 		return nil, ErrOnlyRequestMessagesAllowed
 	}
@@ -171,19 +177,12 @@ func (p *messageProcessor) SendRequestMessage(ctx context.Context, requestMsg *t
 	ctx, cancel := context.WithTimeout(ctx, p.responseTimeout)
 	defer cancel()
 
-	if !ethCommon.IsHexAddress(requestMsg.Metadata.RecipientCMAccount) {
-		return nil, ErrInvalidRecipient
-	}
-
-	p.logger.Infof("Distributor: received a request to propagate to CMAccount %s", requestMsg.Metadata.RecipientCMAccount)
+	p.logger.Infof("Distributor: received a request to propagate to CMAccount %s", recipientCMAccountAddress)
 	// lookup for CM Account -> bot
-	recipientCMAccAddr := ethCommon.HexToAddress(requestMsg.Metadata.RecipientCMAccount)
-	recipientBotAddr, err := p.cmAccounts.GetFirstChequeOperator(ctx, recipientCMAccAddr)
+	recipientBotAddr, err := p.cmAccounts.GetFirstChequeOperator(ctx, recipientCMAccountAddress)
 	if err != nil {
 		return nil, err
 	}
-
-	requestMsg.Metadata.Cheques = []cheques.SignedCheque{}
 
 	isBotAllowed, err := p.cmAccounts.IsBotAllowed(ctx, p.cmAccountAddress, p.myBotAddress)
 	if err != nil {
@@ -193,7 +192,7 @@ func (p *messageProcessor) SendRequestMessage(ctx context.Context, requestMsg *t
 		return nil, ErrBotMissingChequeOperatorRole
 	}
 
-	serviceFee, err := p.cmAccounts.GetServiceFee(ctx, recipientCMAccAddr, requestMsg.Type.ToServiceName())
+	serviceFee, err := p.cmAccounts.GetServiceFee(ctx, recipientCMAccountAddress, requestMsg.Type.ToServiceName())
 	if err != nil {
 		// TODO @evlekht explicitly say if service is not supported and its not just some network error
 		return nil, err
@@ -218,14 +217,14 @@ func (p *messageProcessor) SendRequestMessage(ctx context.Context, requestMsg *t
 		return nil, err
 	}
 
-	if err := p.issueServiceCheque(ctx, requestMsg, serviceFee, recipientCMAccAddr, recipientBotAddr); err != nil {
+	if err := p.issueServiceCheque(ctx, requestMsg, serviceFee, recipientCMAccountAddress, recipientBotAddr); err != nil {
 		return nil, err
 	}
 
 	ctx, span := p.tracer.Start(ctx, "processor.Request", trace.WithAttributes(attribute.String("type", string(requestMsg.Type))))
 	defer span.End()
 
-	p.logger.Infof("Distributor: Bot %s is contacting bot %s of the CMaccount %s", requestMsg.SenderBotUserID, recipientBotAddr, requestMsg.Metadata.RecipientCMAccount)
+	p.logger.Infof("Distributor: Bot %s is contacting bot %s of the CMaccount %s", requestMsg.SenderBotUserID, recipientBotAddr, recipientCMAccountAddress)
 
 	if err := p.messenger.SendMessage(
 		ctx,
@@ -268,24 +267,18 @@ func (p *messageProcessor) respond(requestMsg *types.Message) error {
 		return fmt.Errorf("%w: %s", ErrUnsupportedService, requestMsg.Type)
 	}
 
-	cheque, err := p.getChequeForThisBot(requestMsg.Metadata.Cheques)
+	serviceFee, err := p.cmAccounts.GetServiceFee(ctx, p.cmAccountAddress, service.Name())
 	if err != nil {
 		return err
 	}
 
-	serviceFee, err := p.cmAccounts.GetServiceFee(ctx, ethCommon.HexToAddress(requestMsg.Metadata.RecipientCMAccount), service.Name())
-	if err != nil {
+	if err := p.chequeHandler.VerifyCheque(ctx, requestMsg.ServiceFeeCheque, matrix.AddressFromUserID(requestMsg.SenderBotUserID), serviceFee); err != nil {
 		return err
 	}
 
-	if err := p.chequeHandler.VerifyCheque(ctx, cheque, matrix.AddressFromUserID(requestMsg.SenderBotUserID), serviceFee); err != nil {
-		return err
-	}
-	requestMsg.Metadata.SenderCMAccount = cheque.FromCMAccount.Hex()
+	p.logger.Infof("CMAccount %s is calling partner-plugin of the CMAccount %s", requestMsg.ServiceFeeCheque.FromCMAccount, requestMsg.ServiceFeeCheque.ToCMAccount)
 
-	p.logger.Infof("CMAccount %s is calling partner-plugin of the CMAccount %s", requestMsg.Metadata.SenderCMAccount, requestMsg.Metadata.RecipientCMAccount)
-
-	ctx, responseMsg := p.callPartnerPluginAndGetResponse(ctx, requestMsg, service)
+	ctx, responseMsg := p.callPartnerPluginAndGetResponse(ctx, requestMsg, service, requestMsg.ServiceFeeCheque.FromCMAccount, requestMsg.ServiceFeeCheque.ToCMAccount)
 
 	ctx, err = p.compressMessage(ctx, responseMsg)
 	if err != nil {
@@ -305,10 +298,12 @@ func (p *messageProcessor) callPartnerPluginAndGetResponse(
 	ctx context.Context,
 	requestMsg *types.Message,
 	service rpc.Client,
+	fromCMAccount ethCommon.Address,
+	toCMAccount ethCommon.Address,
 ) (context.Context, *types.Message) {
-	requestMsg.Metadata.Stamp(fmt.Sprintf("%s-%s", p.checkpoint(), "request"))
+	requestMsg.Timestamps.Stamp(fmt.Sprintf("%s-%s", p.checkpoint(), "request"))
 
-	ctx, responseMsg, err := p.partnerPlugin.DoServiceRequest(ctx, requestMsg, service)
+	ctx, responseMsg, err := p.partnerPlugin.DoServiceRequest(ctx, requestMsg, service, fromCMAccount, toCMAccount)
 	if err != nil {
 		errMessage := fmt.Sprintf("error calling partner plugin service: %v", err)
 		p.logger.Errorf(errMessage)
@@ -334,15 +329,6 @@ func (p *messageProcessor) forwardToHandler(msg *types.Message) error {
 	err := fmt.Errorf("no response channel for request ID: %s", msg.RequestID)
 	p.logger.Errorf("Failed to forward message: %v", err)
 	return err
-}
-
-func (p *messageProcessor) getChequeForThisBot(cheques []cheques.SignedCheque) (*cheques.SignedCheque, error) {
-	for _, cheque := range cheques {
-		if cheque.ToBot == p.myBotAddress && cheque.ToCMAccount == p.cmAccountAddress {
-			return &cheque, nil
-		}
-	}
-	return nil, ErrMissingCheques
 }
 
 func (p *messageProcessor) compressMessage(ctx context.Context, msg *types.Message) (context.Context, error) {
@@ -372,7 +358,7 @@ func (p *messageProcessor) issueNetworkCheque(ctx context.Context, msg *types.Me
 		return err
 	}
 
-	msg.Metadata.Cheques = append(msg.Metadata.Cheques, *networkFeeCheque)
+	msg.NetworkFeeCheque = networkFeeCheque
 	return nil
 }
 
@@ -395,7 +381,7 @@ func (p *messageProcessor) issueServiceCheque(
 		return err
 	}
 
-	msg.Metadata.Cheques = append(msg.Metadata.Cheques, *serviceFeeCheque)
+	msg.ServiceFeeCheque = serviceFeeCheque
 	return nil
 }
 

--- a/internal/messaging/processor.go
+++ b/internal/messaging/processor.go
@@ -129,7 +129,7 @@ func (p *messageProcessor) Start(ctx context.Context) {
 							p.logger.Errorf("Recovered from panic while processing message: %v", r)
 						}
 					}()
-					p.logger.Debugf("Processing incoming message (%s): %s", msg.Type, msg.Metadata.RequestID)
+					p.logger.Debugf("Processing incoming message (%s): %s", msg.Type, msg.RequestID)
 
 					if err := p.ProcessIncomingMessage(&msg); err != nil {
 						p.logger.Warnf("could not process message: %v", err)
@@ -165,8 +165,8 @@ func (p *messageProcessor) SendRequestMessage(ctx context.Context, requestMsg *t
 
 	p.logger.Debug("Sending outbound request message")
 	responseChan := make(chan *types.Message)
-	p.setResponseChannel(requestMsg.Metadata.RequestID, responseChan)
-	defer p.deleteResponseChannel(requestMsg.Metadata.RequestID)
+	p.setResponseChannel(requestMsg.RequestID, responseChan)
+	defer p.deleteResponseChannel(requestMsg.RequestID)
 
 	ctx, cancel := context.WithTimeout(ctx, p.responseTimeout)
 	defer cancel()
@@ -240,23 +240,23 @@ func (p *messageProcessor) SendRequestMessage(ctx context.Context, requestMsg *t
 
 	select {
 	case responseMsg := <-responseChan:
-		if responseMsg.Metadata.RequestID == requestMsg.Metadata.RequestID {
+		if responseMsg.RequestID == requestMsg.RequestID {
 			p.responseHandler.ProcessResponseMessage(ctx, responseMsg)
 			return responseMsg, nil
 		} else {
-			err := fmt.Errorf("unexpected response (%s) for request (%s)", responseMsg.Metadata.RequestID, requestMsg.Metadata.RequestID)
+			err := fmt.Errorf("unexpected response (%s) for request (%s)", responseMsg.RequestID, requestMsg.RequestID)
 			p.logger.Error(err)
 			return nil, err
 		}
 	case <-ctx.Done():
-		return nil, fmt.Errorf("%w of %v seconds for request: %s", ErrExceededResponseTimeout, p.responseTimeout, requestMsg.Metadata.RequestID)
+		return nil, fmt.Errorf("%w of %v seconds for request: %s", ErrExceededResponseTimeout, p.responseTimeout, requestMsg.RequestID)
 	}
 }
 
 func (p *messageProcessor) respond(requestMsg *types.Message) error {
-	traceID, err := trace.TraceIDFromHex(requestMsg.Metadata.RequestID)
+	traceID, err := trace.TraceIDFromHex(requestMsg.RequestID)
 	if err != nil {
-		p.logger.Warnf("failed to parse traceID from hex [requestID:%s]: %v", requestMsg.Metadata.RequestID, err)
+		p.logger.Warnf("failed to parse traceID from hex [requestID:%s]: %v", requestMsg.RequestID, err)
 	}
 
 	ctx := trace.ContextWithRemoteSpanContext(context.Background(), trace.NewSpanContext(trace.SpanContextConfig{TraceID: traceID}))
@@ -324,14 +324,14 @@ func (p *messageProcessor) callPartnerPluginAndGetResponse(
 }
 
 func (p *messageProcessor) forwardToHandler(msg *types.Message) error {
-	p.logger.Debugf("Forwarding outbound response message: %s", msg.Metadata.RequestID)
-	responseChan, ok := p.getResponseChannel(msg.Metadata.RequestID)
+	p.logger.Debugf("Forwarding outbound response message: %s", msg.RequestID)
+	responseChan, ok := p.getResponseChannel(msg.RequestID)
 	if ok {
 		responseChan <- msg
 		close(responseChan)
 		return nil
 	}
-	err := fmt.Errorf("no response channel for request ID: %s", msg.Metadata.RequestID)
+	err := fmt.Errorf("no response channel for request ID: %s", msg.RequestID)
 	p.logger.Errorf("Failed to forward message: %v", err)
 	return err
 }

--- a/internal/messaging/processor_test.go
+++ b/internal/messaging/processor_test.go
@@ -32,32 +32,21 @@ import (
 )
 
 var (
-	userID        = id.UserID("0x4626cb544230e4d13fb72950501ff91740116a0a:localhost")
-	cmAccountAddr = "0x25a113a7bba8f898c546f1ebf2331b086645f40f"
-	requestID     = "requestID"
-	errSomeError  = errors.New("some error")
-
-	dummyCheque = cheques.SignedCheque{
-		Cheque: cheques.Cheque{
-			FromCMAccount: ethCommon.Address{},
-			ToCMAccount:   ethCommon.Address{},
-			ToBot:         ethCommon.Address{},
-			Counter:       big.NewInt(0),
-			Amount:        big.NewInt(0),
-			CreatedAt:     big.NewInt(0),
-			ExpiresAt:     big.NewInt(0),
-		},
-		Signature: []byte("signature"),
-	}
+	userID       = id.UserID("0x4626cb544230e4d13fb72950501ff91740116a0a:localhost")
+	requestID    = "requestID"
+	errSomeError = errors.New("some error")
 )
 
 func TestProcessIncomingMessage(t *testing.T) {
 	responseMessage := types.Message{
-		Type: generated.PingServiceV1Response,
-		Metadata: metadata.Metadata{
-			RequestID:       requestID,
-			SenderCMAccount: cmAccountAddr,
-			Cheques:         []cheques.SignedCheque{},
+		Type:      generated.PingServiceV1Response,
+		RequestID: requestID,
+	}
+
+	serviceFeeCheque := &cheques.SignedCheque{
+		Cheque: cheques.Cheque{
+			FromCMAccount: ethCommon.Address{1},
+			ToCMAccount:   ethCommon.Address{2},
 		},
 	}
 
@@ -93,7 +82,7 @@ func TestProcessIncomingMessage(t *testing.T) {
 		"err: invalid message type": {
 			fields: fields{},
 			args: args{
-				msg: &types.Message{Type: "invalid", Metadata: metadata.Metadata{SenderCMAccount: cmAccountAddr, Cheques: []cheques.SignedCheque{}}},
+				msg: &types.Message{Type: "invalid"},
 			},
 			err: ErrUnknownMessageCategory,
 		},
@@ -107,10 +96,6 @@ func TestProcessIncomingMessage(t *testing.T) {
 			args: args{
 				msg: &types.Message{
 					Type: generated.PingServiceV1Request,
-					Metadata: metadata.Metadata{
-						SenderCMAccount: cmAccountAddr,
-						Cheques:         []cheques.SignedCheque{},
-					},
 				},
 			},
 			err: ErrUnsupportedService,
@@ -131,17 +116,15 @@ func TestProcessIncomingMessage(t *testing.T) {
 				mockServiceRegistry.EXPECT().GetService(gomock.Any()).Return(mockService, true)
 				mockChequeHandler.EXPECT().VerifyCheque(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 				mockCMAccounts.EXPECT().GetServiceFee(gomock.Any(), gomock.Any(), gomock.Any()).Return(big.NewInt(1), nil)
-				mockPartnerPlugin.EXPECT().DoServiceRequest(gomock.Any(), gomock.Any(), gomock.Any()).Return(context.Background(), &responseMessage, nil)
+				mockPartnerPlugin.EXPECT().DoServiceRequest(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(context.Background(), &responseMessage, nil)
 				mockChequeHandler.EXPECT().IssueCheque(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&cheques.SignedCheque{}, nil)
 				mockMessenger.EXPECT().SendMessage(gomock.Any(), gomock.Any(), gomock.Any()).Return(errSomeError)
 			},
 			args: args{
 				msg: &types.Message{
-					Type: generated.PingServiceV1Request,
-					Metadata: metadata.Metadata{
-						SenderCMAccount: cmAccountAddr,
-						Cheques:         []cheques.SignedCheque{dummyCheque},
-					},
+					Type:             generated.PingServiceV1Request,
+					ServiceFeeCheque: serviceFeeCheque,
+					Timestamps:       metadata.Timestamps{},
 				},
 			},
 			err: errSomeError,
@@ -162,17 +145,15 @@ func TestProcessIncomingMessage(t *testing.T) {
 				mockServiceRegistry.EXPECT().GetService(gomock.Any()).Return(mockService, true)
 				mockChequeHandler.EXPECT().VerifyCheque(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 				mockCMAccounts.EXPECT().GetServiceFee(gomock.Any(), gomock.Any(), gomock.Any()).Return(big.NewInt(1), nil)
-				mockPartnerPlugin.EXPECT().DoServiceRequest(gomock.Any(), gomock.Any(), gomock.Any()).Return(context.Background(), &responseMessage, nil)
+				mockPartnerPlugin.EXPECT().DoServiceRequest(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(context.Background(), &responseMessage, nil)
 				mockChequeHandler.EXPECT().IssueCheque(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&cheques.SignedCheque{}, nil)
 				mockMessenger.EXPECT().SendMessage(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			},
 			args: args{
 				msg: &types.Message{
-					Type: generated.PingServiceV1Request,
-					Metadata: metadata.Metadata{
-						SenderCMAccount: cmAccountAddr,
-						Cheques:         []cheques.SignedCheque{dummyCheque},
-					},
+					Type:             generated.PingServiceV1Request,
+					ServiceFeeCheque: serviceFeeCheque,
+					Timestamps:       metadata.Timestamps{},
 				},
 			},
 		},
@@ -235,9 +216,11 @@ func TestProcessIncomingMessage(t *testing.T) {
 
 func TestSendRequestMessage(t *testing.T) {
 	productListResponse := &types.Message{
-		Type:     generated.PingServiceV1Response,
-		Metadata: metadata.Metadata{RequestID: requestID},
+		Type:      generated.PingServiceV1Response,
+		RequestID: requestID,
 	}
+
+	recipientCMAccount := ethCommon.Address{1}
 
 	mockCtrl := gomock.NewController(t)
 	mockServiceRegistry := NewMockServiceRegistry(mockCtrl)
@@ -259,7 +242,8 @@ func TestSendRequestMessage(t *testing.T) {
 		maxAllowedServiceFee  *big.Int
 	}
 	type args struct {
-		msg *types.Message
+		msg                *types.Message
+		recipientCMAccount ethCommon.Address
 	}
 	tests := map[string]struct {
 		fields                 fields
@@ -280,24 +264,14 @@ func TestSendRequestMessage(t *testing.T) {
 				responseHeaderHandler: mockResponseHeaderHandler,
 			},
 			args: args{
-				msg: &types.Message{Type: generated.PingServiceV1Response},
+				msg: &types.Message{
+					RequestID:  requestID,
+					Type:       generated.PingServiceV1Response,
+					Timestamps: metadata.Timestamps{},
+				},
+				recipientCMAccount: recipientCMAccount,
 			},
 			err: ErrOnlyRequestMessagesAllowed,
-		},
-		"err: invalid recipient": {
-			fields: fields{
-				serviceRegistry:       mockServiceRegistry,
-				responseHandler:       NoopResponseHandler{},
-				chequeHandler:         mockChequeHandler,
-				messenger:             mockMessenger,
-				compressor:            &noopCompressor{},
-				cmAccounts:            mockCMAccounts,
-				responseHeaderHandler: mockResponseHeaderHandler,
-			},
-			args: args{
-				msg: &types.Message{Type: generated.PingServiceV1Request},
-			},
-			err: ErrInvalidRecipient,
 		},
 		"err: awaiting-response-timeout exceeded": {
 			fields: fields{
@@ -313,9 +287,11 @@ func TestSendRequestMessage(t *testing.T) {
 			},
 			args: args{
 				msg: &types.Message{
-					Type:     generated.PingServiceV1Request,
-					Metadata: metadata.Metadata{RecipientCMAccount: cmAccountAddr},
+					RequestID:  requestID,
+					Type:       generated.PingServiceV1Request,
+					Timestamps: metadata.Timestamps{},
 				},
+				recipientCMAccount: recipientCMAccount,
 			},
 			prepare: func() {
 				mockCMAccounts.EXPECT().GetFirstChequeOperator(gomock.Any(), gomock.Any()).Return(ethCommon.Address{}, nil)
@@ -340,9 +316,11 @@ func TestSendRequestMessage(t *testing.T) {
 			},
 			args: args{
 				msg: &types.Message{
-					Type:     generated.PingServiceV1Request,
-					Metadata: metadata.Metadata{RecipientCMAccount: cmAccountAddr},
+					RequestID:  requestID,
+					Type:       generated.PingServiceV1Request,
+					Timestamps: metadata.Timestamps{},
 				},
+				recipientCMAccount: recipientCMAccount,
 			},
 			prepare: func() {
 				mockCMAccounts.EXPECT().GetFirstChequeOperator(gomock.Any(), gomock.Any()).Return(ethCommon.Address{}, nil)
@@ -369,9 +347,11 @@ func TestSendRequestMessage(t *testing.T) {
 			},
 			args: args{
 				msg: &types.Message{
-					Type:     generated.PingServiceV1Request,
-					Metadata: metadata.Metadata{RecipientCMAccount: cmAccountAddr, RequestID: requestID},
+					RequestID:  requestID,
+					Type:       generated.PingServiceV1Request,
+					Timestamps: metadata.Timestamps{},
 				},
+				recipientCMAccount: recipientCMAccount,
 			},
 			prepare: func() {
 				mockCMAccounts.EXPECT().GetFirstChequeOperator(gomock.Any(), gomock.Any()).Return(ethCommon.Address{}, nil)
@@ -425,7 +405,7 @@ func TestSendRequestMessage(t *testing.T) {
 			if tt.writeResponseToChannel != nil {
 				go tt.writeResponseToChannel(p.(*messageProcessor))
 			}
-			got, err := p.SendRequestMessage(context.Background(), tt.args.msg)
+			got, err := p.SendRequestMessage(context.Background(), tt.args.msg, tt.args.recipientCMAccount)
 
 			require.ErrorIs(t, err, tt.err)
 			require.Equal(t, tt.want, got)
@@ -435,6 +415,13 @@ func TestSendRequestMessage(t *testing.T) {
 
 func TestStart(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
+
+	serviceFeeCheque := &cheques.SignedCheque{
+		Cheque: cheques.Cheque{
+			FromCMAccount: ethCommon.Address{1},
+			ToCMAccount:   ethCommon.Address{2},
+		},
+	}
 
 	mockService := rpc.NewMockService(mockCtrl)
 	mockService.EXPECT().Name().Return("dummy").Times(2)
@@ -450,8 +437,7 @@ func TestStart(t *testing.T) {
 	mockChequeHandler.EXPECT().IssueCheque(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&cheques.SignedCheque{}, nil).Times(2)
 
 	mockPartnerPlugin := partnerplugin.NewMockPartnerPlugin(mockCtrl)
-	mockPartnerPlugin.EXPECT().DoServiceRequest(gomock.Any(), gomock.Any(), gomock.Any()).Return(context.Background(), &types.Message{}, nil)
-	mockPartnerPlugin.EXPECT().DoServiceRequest(gomock.Any(), gomock.Any(), gomock.Any()).Return(context.Background(), &types.Message{}, nil)
+	mockPartnerPlugin.EXPECT().DoServiceRequest(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(2).Return(context.Background(), &types.Message{}, nil)
 	mockMessenger := NewMockMessenger(mockCtrl)
 	mockMessenger.EXPECT().SendMessage(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(2)
 
@@ -460,20 +446,22 @@ func TestStart(t *testing.T) {
 	ch := make(chan types.Message, 5) // incoming messages
 
 	// msg without sender
-	ch <- types.Message{Metadata: metadata.Metadata{}}
-	// msg with sender == userID
-	ch <- types.Message{Metadata: metadata.Metadata{}, SenderBotUserID: userID}
-	// msg with sender == userID but without valid msgType
-	ch <- types.Message{Metadata: metadata.Metadata{SenderCMAccount: cmAccountAddr, Cheques: []cheques.SignedCheque{dummyCheque}}}
-	// msg with sender == userID and valid msgType
+	ch <- types.Message{Timestamps: metadata.Timestamps{}} // should fail
+	// msg with sender, but without valid msgType
+	ch <- types.Message{Timestamps: metadata.Timestamps{}, ServiceFeeCheque: serviceFeeCheque} // should fail
+	// msg with sender and valid msgType
 	ch <- types.Message{
-		Type:     generated.PingServiceV1Request,
-		Metadata: metadata.Metadata{SenderCMAccount: cmAccountAddr, Cheques: []cheques.SignedCheque{dummyCheque}},
+		Timestamps:       metadata.Timestamps{},
+		Type:             generated.PingServiceV1Request,
+		ServiceFeeCheque: serviceFeeCheque,
+		SenderBotUserID:  userID,
 	}
 	// 2nd msg with sender == userID and valid msgType
 	ch <- types.Message{
-		Type:     generated.AccommodationProductInfoServiceV2Request,
-		Metadata: metadata.Metadata{SenderCMAccount: cmAccountAddr, Cheques: []cheques.SignedCheque{dummyCheque}},
+		Timestamps:       metadata.Timestamps{},
+		Type:             generated.AccommodationProductInfoServiceV2Request,
+		ServiceFeeCheque: serviceFeeCheque,
+		SenderBotUserID:  userID,
 	}
 
 	// mocks

--- a/internal/messaging/types/types.go
+++ b/internal/messaging/types/types.go
@@ -47,8 +47,9 @@ func ServiceNameToRequestMessageType(serviceName string) MessageType {
 }
 
 type Message struct {
-	Type       MessageType
-	Content    protoreflect.ProtoMessage
-	RequestID  string
-	Timestamps metadata.Timestamps
+	Type              MessageType
+	Content           protoreflect.ProtoMessage
+	CompressedContent [][]byte
+	RequestID         string
+	Timestamps        metadata.Timestamps
 }

--- a/internal/messaging/types/types.go
+++ b/internal/messaging/types/types.go
@@ -8,9 +8,7 @@ import (
 	"strings"
 
 	"github.com/chain4travel/camino-messenger-bot/v11/pkg/metadata"
-	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
-	"maunium.net/go/mautrix/id"
 )
 
 var ErrUnknownMessageType = errors.New("unknown message type")
@@ -48,16 +46,9 @@ func ServiceNameToRequestMessageType(serviceName string) MessageType {
 	return MessageType(serviceName + ".Request")
 }
 
-// Message is the message format used for communication between the messenger and the service
-// TODO @evlekht why json tags? where is this shown? Its not passed into matrix message
 type Message struct {
-	Type              MessageType               `json:"msgtype"` // TODO @evlekht it might be possible to get rid of this field
-	Content           protoreflect.ProtoMessage `json:"content"`
-	Metadata          metadata.Metadata         `json:"metadata"`
-	SenderBotUserID   id.UserID
-	CompressedContent [][]byte
-}
-
-func (m *Message) MarshalContent() ([]byte, error) {
-	return proto.Marshal(m.Content)
+	Type       MessageType
+	Content    protoreflect.ProtoMessage
+	RequestID  string
+	Timestamps metadata.Timestamps
 }

--- a/internal/messaging/types/types.go
+++ b/internal/messaging/types/types.go
@@ -7,8 +7,10 @@ import (
 	"errors"
 	"strings"
 
+	"github.com/chain4travel/camino-messenger-bot/v11/pkg/cheques"
 	"github.com/chain4travel/camino-messenger-bot/v11/pkg/metadata"
 	"google.golang.org/protobuf/reflect/protoreflect"
+	"maunium.net/go/mautrix/id"
 )
 
 var ErrUnknownMessageType = errors.New("unknown message type")
@@ -52,4 +54,7 @@ type Message struct {
 	CompressedContent [][]byte
 	RequestID         string
 	Timestamps        metadata.Timestamps
+	ServiceFeeCheque  *cheques.SignedCheque
+	NetworkFeeCheque  *cheques.SignedCheque
+	SenderBotUserID   id.UserID
 }

--- a/internal/partnerplugin/mock_partner_plugin.go
+++ b/internal/partnerplugin/mock_partner_plugin.go
@@ -101,9 +101,9 @@ func (mr *MockPartnerPluginMockRecorder) CancellationWithdrawnNotification(arg0,
 }
 
 // DoServiceRequest mocks base method.
-func (m *MockPartnerPlugin) DoServiceRequest(arg0 context.Context, arg1 *types.Message, arg2 rpc.Client) (context.Context, *types.Message, error) {
+func (m *MockPartnerPlugin) DoServiceRequest(arg0 context.Context, arg1 *types.Message, arg2 rpc.Client, arg3, arg4 common.Address) (context.Context, *types.Message, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DoServiceRequest", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "DoServiceRequest", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(context.Context)
 	ret1, _ := ret[1].(*types.Message)
 	ret2, _ := ret[2].(error)
@@ -111,9 +111,9 @@ func (m *MockPartnerPlugin) DoServiceRequest(arg0 context.Context, arg1 *types.M
 }
 
 // DoServiceRequest indicates an expected call of DoServiceRequest.
-func (mr *MockPartnerPluginMockRecorder) DoServiceRequest(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockPartnerPluginMockRecorder) DoServiceRequest(arg0, arg1, arg2, arg3, arg4 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DoServiceRequest", reflect.TypeOf((*MockPartnerPlugin)(nil).DoServiceRequest), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DoServiceRequest", reflect.TypeOf((*MockPartnerPlugin)(nil).DoServiceRequest), arg0, arg1, arg2, arg3, arg4)
 }
 
 // TokenBoughtNotificationWithBuyTx mocks base method.

--- a/internal/partnerplugin/partner_plugin.go
+++ b/internal/partnerplugin/partner_plugin.go
@@ -17,19 +17,25 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
-	"google.golang.org/grpc"
 	grpc_metadata "google.golang.org/grpc/metadata"
 
 	types "github.com/chain4travel/camino-messenger-bot/v11/internal/messaging/types"
 	rpc "github.com/chain4travel/camino-messenger-bot/v11/internal/rpc"
 	"github.com/chain4travel/camino-messenger-bot/v11/internal/rpc/client"
+	"github.com/chain4travel/camino-messenger-bot/v11/pkg/metadata"
 )
 
 var _ PartnerPlugin = (*partnerPlugin)(nil)
 
 // Handles all communication with the partner plugin
 type PartnerPlugin interface {
-	DoServiceRequest(ctx context.Context, requestMsg *types.Message, service rpc.Client) (context.Context, *types.Message, error)
+	DoServiceRequest(
+		ctx context.Context,
+		requestMsg *types.Message,
+		serviceClient rpc.Client,
+		fromCMAccount common.Address,
+		toCMAccount common.Address,
+	) (context.Context, *types.Message, error)
 
 	TokenBoughtNotificationWithoutBuyTx(ctx context.Context, tokenID *big.Int, mintID string) error
 	TokenBoughtNotificationWithBuyTx(ctx context.Context, tokenID *big.Int, mintID string, buyTxID common.Hash) error
@@ -62,23 +68,29 @@ type partnerPlugin struct {
 	responseTimeout    time.Duration
 }
 
-func (p *partnerPlugin) DoServiceRequest(ctx context.Context, requestMsg *types.Message, service rpc.Client) (context.Context, *types.Message, error) {
+func (p *partnerPlugin) DoServiceRequest(
+	ctx context.Context,
+	requestMsg *types.Message,
+	serviceClient rpc.Client,
+	fromCMAccount common.Address,
+	toCMAccount common.Address,
+) (context.Context, *types.Message, error) {
 	responseMsg := &types.Message{
-		Metadata: requestMsg.Metadata,
+		RequestID:  requestMsg.RequestID,
+		Timestamps: requestMsg.Timestamps,
 	}
+
+	ctx, partnerPluginSpan := p.tracer.Start(ctx, "service.Call", trace.WithSpanKind(trace.SpanKindClient), trace.WithAttributes(attribute.String("type", string(requestMsg.Type))))
+	defer partnerPluginSpan.End()
 
 	var err error
-	header := &grpc_metadata.MD{}
-	ctx = grpc_metadata.NewOutgoingContext(ctx, requestMsg.Metadata.ToGrpcMD())
-	ctx, partnerPluginSpan := p.tracer.Start(ctx, "service.Call", trace.WithSpanKind(trace.SpanKindClient), trace.WithAttributes(attribute.String("type", string(requestMsg.Type))))
-	responseMsg.Content, responseMsg.Type, err = service.Call(ctx, requestMsg.Content, grpc.Header(header))
-	partnerPluginSpan.End()
+	responseMsg.Content, responseMsg.Type, err = serviceClient.Call(grpc_metadata.NewOutgoingContext(ctx, grpc_metadata.Pairs(
+		metadata.KeyRequestID, requestMsg.RequestID,
+		metadata.KeyRecipientCMAccount, toCMAccount.Hex(),
+		metadata.KeySenderCMAccount, fromCMAccount.Hex(),
+	)), requestMsg.Content)
 	if err != nil {
 		return ctx, responseMsg, fmt.Errorf("error calling partner plugin service: %w", err)
-	}
-
-	if err := responseMsg.Metadata.FromGrpcMD(*header); err != nil {
-		return ctx, responseMsg, fmt.Errorf("error extracting metadata from response: %w", err)
 	}
 
 	return ctx, responseMsg, nil

--- a/internal/rpc/server/server.go
+++ b/internal/rpc/server/server.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"net"
 
-	"buf.build/gen/go/chain4travel/camino-messenger-protocol/grpc/go/cmp/services/cancellation/v1/cancellationv1grpc"
 	"github.com/chain4travel/camino-messenger-bot/v11/config"
 	"github.com/chain4travel/camino-messenger-bot/v11/internal/common"
 	"github.com/chain4travel/camino-messenger-bot/v11/internal/messaging"
@@ -20,12 +19,16 @@ import (
 	"github.com/chain4travel/camino-messenger-bot/v11/internal/utils/tls"
 	"github.com/chain4travel/camino-messenger-bot/v11/pkg/metadata"
 	"github.com/chain4travel/camino-messenger-bot/v11/proto/pb/readiness"
+
+	"buf.build/gen/go/chain4travel/camino-messenger-protocol/grpc/go/cmp/services/cancellation/v1/cancellationv1grpc"
+
+	ethCommon "github.com/ethereum/go-ethereum/common"
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors"
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/selector"
-
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
+	grpcMetadata "google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/reflection"
 	"google.golang.org/protobuf/reflect/protoreflect"
 )
@@ -149,32 +152,38 @@ func (s *server) Stop() {
 func (s *server) HandleMessageRequest(ctx context.Context, requestType types.MessageType, request protoreflect.ProtoMessage) (protoreflect.ProtoMessage, error) {
 	ctx, span := s.tracer.Start(ctx, "server.HandleMessageRequest", trace.WithSpanKind(trace.SpanKindServer))
 	defer span.End()
-	md, err := s.processMetadata(ctx, s.tracer.TraceIDForSpan(span))
+
+	recipientCMAccountAddress, err := s.getRecipientAddress(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("error processing metadata: %w", err)
+		return nil, fmt.Errorf("failed to get recipient cm account address from request context: %w", err)
 	}
 
-	response, err := s.processor.SendRequestMessage(ctx, &types.Message{
-		Type:     requestType,
-		Content:  request,
-		Metadata: md,
-	})
+	requestMsg := &types.Message{
+		Type:       requestType,
+		Content:    request,
+		RequestID:  s.tracer.TraceIDForSpan(span).String(),
+		Timestamps: metadata.Timestamps{},
+	}
+
+	requestMsg.Timestamps.Stamp(fmt.Sprintf("%s-%s", s.checkpoint(), "received"))
+
+	responseMsg, err := s.processor.SendRequestMessage(ctx, requestMsg, recipientCMAccountAddress)
 	if err != nil {
 		return nil, fmt.Errorf("error processing outbound request: %w", err)
 	}
-	response.Metadata.Stamp(fmt.Sprintf("%s-%s", s.checkpoint(), "processed"))
+
+	responseMsg.Timestamps.Stamp(fmt.Sprintf("%s-%s", s.checkpoint(), "processed"))
+
+	timestampsStr, err := responseMsg.Timestamps.MarshalToString()
+	if err != nil {
+		return nil, fmt.Errorf("error marshalling timestamps: %w", err)
+	}
 
 	// TODO @nikos set specific errors according to https://grpc.github.io/grpc/core/md_doc_statuscodes.html ?
-	return response.Content, grpc.SendHeader(ctx, response.Metadata.ToGrpcMD())
-}
-
-func (s *server) processMetadata(ctx context.Context, id trace.TraceID) (metadata.Metadata, error) {
-	md := metadata.Metadata{
-		RequestID: id.String(),
-	}
-	md.Stamp(fmt.Sprintf("%s-%s", s.checkpoint(), "received"))
-	err := md.ExtractMetadata(ctx)
-	return md, err
+	return responseMsg.Content, grpc.SendHeader(ctx, grpcMetadata.Pairs(
+		metadata.KeyRequestID, responseMsg.RequestID,
+		metadata.KeyTimestamps, timestampsStr,
+	))
 }
 
 func (s *server) errorHandlingInterceptor(
@@ -194,14 +203,28 @@ func (s *server) errorHandlingInterceptor(
 	return response, nil
 }
 
+func (s *server) getRecipientAddress(ctx context.Context) (ethCommon.Address, error) {
+	mdPairs, ok := grpcMetadata.FromIncomingContext(ctx)
+	if !ok {
+		return ethCommon.Address{}, fmt.Errorf("metadata not found in incoming context")
+	}
+
+	recipient := mdPairs[metadata.KeyRecipientCMAccount]
+	if len(recipient) != 1 || !ethCommon.IsHexAddress(recipient[0]) {
+		return ethCommon.Address{}, fmt.Errorf("invalid recipient address: %s", recipient)
+	}
+
+	return ethCommon.HexToAddress(recipient[0]), nil
+}
+
 func (s *server) unaryRecoverInterceptor(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (response any, err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			md := &metadata.Metadata{}
-			if err := md.ExtractMetadata(ctx); err != nil {
-				s.logger.Error("error extracting metadata from context", zap.Error(err))
+			recipientCMAccountAddress, err := s.getRecipientAddress(ctx)
+			if err != nil {
+				s.logger.Errorf("failed to get recipient cm account address from request context: %v", err)
 			}
-			err = fmt.Errorf("gRPC %s (request %s) handler panicked: %v", info.FullMethod, md.RequestID, r) // we return this error to the client
+			err = fmt.Errorf("gRPC %s (recipient %s) handler panicked: %v", info.FullMethod, recipientCMAccountAddress.Hex(), r) // we return this error to the client
 			s.logger.Errorf("recovered from panic: %v", err)
 		}
 	}()

--- a/pkg/chequehandler/cheque_handler.go
+++ b/pkg/chequehandler/cheque_handler.go
@@ -196,8 +196,7 @@ func (ch *evmChequeHandler) IssueCheque(
 			ch.logger.Errorf("failed to verify cheque with smart contract after getting last cash-in: %v", err)
 			return nil, fmt.Errorf("failed to verify cheque with smart contract: %w", err)
 		} else if !isChequeValid {
-			b, _ := signedCheque.MarshalJSON()
-			ch.logger.Errorf("failed to issue valid cheque: %s", string(b))
+			ch.logger.Errorf("failed to issue valid cheque")
 			return nil, fmt.Errorf("failed to issue valid cheque")
 		}
 	}

--- a/pkg/cheques/cheques.go
+++ b/pkg/cheques/cheques.go
@@ -4,14 +4,11 @@
 package cheques
 
 import (
-	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/hexutil"
 )
 
 var (
@@ -22,81 +19,18 @@ var (
 )
 
 type SignedCheque struct {
-	Cheque    `json:"cheque"`
-	Signature []byte `json:"signature"`
+	Cheque
+	Signature []byte
 }
 
 type Cheque struct {
-	FromCMAccount common.Address `json:"fromCMAccount"`
-	ToCMAccount   common.Address `json:"toCMAccount"`
-	ToBot         common.Address `json:"toBot"`
-	Counter       *big.Int       `json:"counter"`
-	Amount        *big.Int       `json:"amount"`
-	CreatedAt     *big.Int       `json:"createdAt"`
-	ExpiresAt     *big.Int       `json:"expiresAt"`
-}
-
-type signedChequeJSON struct {
-	Cheque    chequeJSON `json:"cheque"`
-	Signature string     `json:"signature"`
-}
-
-type chequeJSON struct {
-	FromCMAccount string `json:"fromCMAccount"`
-	ToCMAccount   string `json:"toCMAccount"`
-	ToBot         string `json:"toBot"`
-	Counter       string `json:"counter"`
-	Amount        string `json:"amount"`
-	CreatedAt     uint64 `json:"createdAt"`
-	ExpiresAt     uint64 `json:"expiresAt"`
-}
-
-func (sc *SignedCheque) MarshalJSON() ([]byte, error) {
-	return json.Marshal(&signedChequeJSON{
-		Cheque: chequeJSON{
-			FromCMAccount: sc.Cheque.FromCMAccount.Hex(),
-			ToCMAccount:   sc.Cheque.ToCMAccount.Hex(),
-			ToBot:         sc.Cheque.ToBot.Hex(),
-			Counter:       hexutil.EncodeBig(sc.Cheque.Counter),
-			Amount:        hexutil.EncodeBig(sc.Cheque.Amount),
-			CreatedAt:     sc.Cheque.CreatedAt.Uint64(),
-			ExpiresAt:     sc.Cheque.ExpiresAt.Uint64(),
-		},
-		Signature: hex.EncodeToString(sc.Signature),
-	})
-}
-
-func (sc *SignedCheque) UnmarshalJSON(data []byte) error {
-	var raw signedChequeJSON
-	if err := json.Unmarshal(data, &raw); err != nil {
-		return err
-	}
-
-	counter, err := hexutil.DecodeBig(raw.Cheque.Counter)
-	if err != nil {
-		return err
-	}
-	sc.Cheque.Counter = counter
-
-	amount, err := hexutil.DecodeBig(raw.Cheque.Amount)
-	if err != nil {
-		return err
-	}
-	sc.Cheque.Amount = amount
-
-	signatureBytes, err := hex.DecodeString(raw.Signature)
-	if err != nil {
-		return fmt.Errorf("invalid signature hex string: %w", err)
-	}
-	sc.Signature = signatureBytes
-
-	sc.Cheque.FromCMAccount = common.HexToAddress(raw.Cheque.FromCMAccount)
-	sc.Cheque.ToCMAccount = common.HexToAddress(raw.Cheque.ToCMAccount)
-	sc.Cheque.ToBot = common.HexToAddress(raw.Cheque.ToBot)
-	sc.Cheque.CreatedAt = big.NewInt(0).SetUint64(raw.Cheque.CreatedAt)
-	sc.Cheque.ExpiresAt = big.NewInt(0).SetUint64(raw.Cheque.ExpiresAt)
-
-	return nil
+	FromCMAccount common.Address
+	ToCMAccount   common.Address
+	ToBot         common.Address
+	Counter       *big.Int
+	Amount        *big.Int
+	CreatedAt     *big.Int
+	ExpiresAt     *big.Int
 }
 
 func VerifyCheque(previousCheque, newCheque *SignedCheque, timestamp, minDurationUntilExpiration *big.Int) error {

--- a/pkg/matrix/types.go
+++ b/pkg/matrix/types.go
@@ -43,20 +43,16 @@ func (e *MessageChunkEventContent) Verify() error {
 }
 
 type MessageEventContent struct {
-	MsgType  types.MessageType `json:"msgtype"`
-	Metadata metadata.Metadata `json:"metadata"`
-	Data     []byte            `json:"data"`
+	MessageChunkEventContent
+
+	MsgType     types.MessageType   `json:"msgtype"`
+	ChunksCount uint32              `json:"chunks_count"`
+	Timestamps  metadata.Timestamps `json:"timestamps"`
 }
 
 func (e *MessageEventContent) Verify() error {
-	if e.Metadata.NumberOfChunks == 0 {
+	if e.ChunksCount == 0 {
 		return ErrNoChunks
 	}
-	if e.Metadata.RequestID == "" {
-		return ErrNoRequestID
-	}
-	if len(e.Data) == 0 {
-		return ErrNoData
-	}
-	return nil
+	return e.MessageChunkEventContent.Verify()
 }

--- a/pkg/matrix/types.go
+++ b/pkg/matrix/types.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/chain4travel/camino-messenger-bot/v11/internal/messaging/types"
+	"github.com/chain4travel/camino-messenger-bot/v11/pkg/cheques"
 	"github.com/chain4travel/camino-messenger-bot/v11/pkg/metadata"
 	"maunium.net/go/mautrix/event"
 )
@@ -45,9 +46,11 @@ func (e *MessageChunkEventContent) Verify() error {
 type MessageEventContent struct {
 	MessageChunkEventContent
 
-	MsgType     types.MessageType   `json:"msgtype"`
-	ChunksCount uint32              `json:"chunks_count"`
-	Timestamps  metadata.Timestamps `json:"timestamps"`
+	MsgType          types.MessageType     `json:"msgtype"`
+	ChunksCount      uint32                `json:"chunks_count"`
+	Timestamps       metadata.Timestamps   `json:"timestamps"`
+	ServiceFeeCheque *cheques.SignedCheque `json:"service_fee_cheque,omitempty"`
+	NetworkFeeCheque cheques.SignedCheque  `json:"network_fee_cheque"`
 }
 
 func (e *MessageEventContent) Verify() error {

--- a/pkg/metadata/metadata.go
+++ b/pkg/metadata/metadata.go
@@ -5,101 +5,48 @@ package metadata
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
-	"strings"
-	"time"
 
-	"github.com/chain4travel/camino-messenger-bot/v11/pkg/cheques"
+	"github.com/ethereum/go-ethereum/common"
 	"google.golang.org/grpc/metadata"
 )
 
+const (
+	KeyRequestID          = "request_id"
+	KeyRecipientCMAccount = "recipient_cm_account"
+	KeySenderCMAccount    = "sender_cm_account"
+	KeyTimestamps         = "timestamps"
+)
+
 type Metadata struct {
-	RequestID          string                 `json:"request_id"`
-	SenderCMAccount    string                 `json:"sender"`
-	RecipientCMAccount string                 `json:"recipient"`
-	Cheques            []cheques.SignedCheque `json:"cheques"`
-	Timestamps         map[string]int64       `json:"timestamps"` // map of checkpoints to timestamps in unix milliseconds
-	NumberOfChunks     uint64                 `json:"number_of_chunks"`
-
-	// Deprecated: this metadata serves only as a temp solution and should be removed and addressed on the protocol level
-	ProviderOperator string `json:"provider_operator"`
+	RequestID          string
+	RecipientCMAccount common.Address
+	SenderCMAccount    common.Address
+	Timestamps         Timestamps // can be nil
 }
 
-func (m *Metadata) ExtractMetadata(ctx context.Context) error {
+func FromGRPCContext(ctx context.Context) *Metadata {
+	md := &Metadata{}
+
 	mdPairs, ok := metadata.FromIncomingContext(ctx)
-
 	if !ok {
-		mdPairs, ok = metadata.FromOutgoingContext(ctx)
-		if !ok {
-			return fmt.Errorf("metadata not found in context")
-		}
-	}
-	return m.FromGrpcMD(mdPairs)
-}
-
-func (m *Metadata) FromGrpcMD(mdPairs metadata.MD) error {
-	if requestID, found := mdPairs["request_id"]; found && len(requestID[0]) > 0 {
-		m.RequestID = requestID[0]
+		return md
 	}
 
-	if sender, found := mdPairs["sender"]; found && len(sender[0]) > 0 {
-		m.SenderCMAccount = sender[0]
+	if requestID := mdPairs["request_id"]; len(requestID) == 1 {
+		md.RequestID = requestID[0]
 	}
 
-	if recipient, found := mdPairs["recipient"]; found && len(recipient[0]) > 0 {
-		m.RecipientCMAccount = recipient[0]
+	if recipientCMAccount := mdPairs["recipient_cm_account"]; len(recipientCMAccount) == 1 {
+		md.RecipientCMAccount = common.HexToAddress(recipientCMAccount[0])
 	}
 
-	if cheques, found := mdPairs["cheques"]; found && len(cheques[0]) > 0 {
-		chequesJSON := strings.Join(cheques, "")
-		if err := json.Unmarshal([]byte(chequesJSON), &m.Cheques); err != nil {
-			return fmt.Errorf("error unmarshalling cheques: %w", err)
-		}
+	if senderCMAccount := mdPairs["sender_cm_account"]; len(senderCMAccount) == 1 {
+		md.SenderCMAccount = common.HexToAddress(senderCMAccount[0])
 	}
 
-	if timestamps, found := mdPairs["timestamps"]; found && len(timestamps[0]) > 0 {
-		timestampsJSON := strings.Join(timestamps, "")
-		if err := json.Unmarshal([]byte(timestampsJSON), &m.Timestamps); err != nil {
-			return fmt.Errorf("error unmarshalling timestamps: %w", err)
-		}
+	if timestampsStr := mdPairs["timestamps"]; len(timestampsStr) == 1 {
+		md.Timestamps, _ = TimestampsFromString(timestampsStr[0])
 	}
-	if providerOperator, found := mdPairs["provider_operator"]; found && len(providerOperator[0]) > 0 {
-		m.ProviderOperator = providerOperator[0]
-	}
-	return nil
-}
 
-func (m *Metadata) ToGrpcMD() metadata.MD {
-	md := metadata.New(map[string]string{
-		"request_id": m.RequestID,
-		"sender":     m.SenderCMAccount,
-		"recipient":  m.RecipientCMAccount,
-		"timestamps": func() string {
-			timestampsJSON, _ := json.Marshal(m.Timestamps)
-			return string(timestampsJSON)
-		}(),
-		"cheques": func() string {
-			chequesJSON, _ := json.Marshal(m.Cheques)
-			return string(chequesJSON)
-		}(),
-		"provider_operator": m.ProviderOperator,
-	})
 	return md
-}
-
-func (m *Metadata) Stamp(checkpoint string) {
-	if m.Timestamps == nil {
-		m.Timestamps = make(map[string]int64)
-	}
-	idx := len(m.Timestamps) // for analysis' sake, we want to know the order of the checkpoints
-	m.Timestamps[fmt.Sprintf("%d-%s", idx, checkpoint)] = time.Now().UnixMilli()
-}
-
-func (m *Metadata) StampOn(checkpoint string, t int64) {
-	if m.Timestamps == nil {
-		m.Timestamps = make(map[string]int64)
-	}
-	idx := len(m.Timestamps) // for analysis' sake, we want to know the order of the checkpoints
-	m.Timestamps[fmt.Sprintf("%d-%s", idx, checkpoint)] = t
 }

--- a/pkg/metadata/timestamps.go
+++ b/pkg/metadata/timestamps.go
@@ -1,0 +1,37 @@
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package metadata
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+type Timestamps map[string]int64
+
+func TimestampsFromString(s string) (Timestamps, error) {
+	var timestamps Timestamps
+	if err := json.Unmarshal([]byte(s), &timestamps); err != nil {
+		return nil, fmt.Errorf("error unmarshalling timestamps: %w", err)
+	}
+	return timestamps, nil
+}
+
+func (t Timestamps) Stamp(checkpoint string) {
+	t.StampOn(checkpoint, time.Now().UnixMilli())
+}
+
+func (t Timestamps) StampOn(checkpoint string, timestamp int64) {
+	idx := len(t) // for analysis' sake, we want to know the order of the checkpoints
+	t[fmt.Sprintf("%d-%s", idx, checkpoint)] = timestamp
+}
+
+func (t Timestamps) MarshalToString() (string, error) {
+	timestampsJSON, err := json.Marshal(t)
+	if err != nil {
+		return "", fmt.Errorf("error marshalling timestamps: %w", err)
+	}
+	return string(timestampsJSON), nil
+}

--- a/pkg/metadata/timestamps_test.go
+++ b/pkg/metadata/timestamps_test.go
@@ -1,0 +1,38 @@
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package metadata
+
+import (
+	"maps"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTimestamps(t *testing.T) {
+	timestamps := Timestamps{
+		"0-started":   1633072800000,
+		"1-processed": 1633072801000,
+		"2-ended":     1633072802000,
+	}
+	timestampsStr, err := timestamps.MarshalToString()
+	require.NoError(t, err)
+	timestampsFromStr, err := TimestampsFromString(timestampsStr)
+	require.NoError(t, err)
+	require.Equal(t, timestamps, timestampsFromStr)
+
+	now := time.Now().Unix()
+	nowPlus100 := now + 100
+
+	expectedTimestamps := Timestamps{}
+	maps.Copy(expectedTimestamps, timestamps)
+	expectedTimestamps["3-now"] = now
+	expectedTimestamps["4-now+100"] = nowPlus100
+
+	timestamps.StampOn("now", now)
+	timestamps.StampOn("now+100", nowPlus100)
+
+	require.Equal(t, expectedTimestamps, timestamps)
+}

--- a/pp-mock/handlers/accommodation/v1/accommodation_product_info.go
+++ b/pp-mock/handlers/accommodation/v1/accommodation_product_info.go
@@ -5,7 +5,6 @@ package v1
 
 import (
 	"context"
-	"fmt"
 	"log"
 
 	"buf.build/gen/go/chain4travel/camino-messenger-protocol/grpc/go/cmp/services/accommodation/v1/accommodationv1grpc"
@@ -14,7 +13,6 @@ import (
 	"github.com/chain4travel/camino-messenger-bot/v11/pkg/metadata"
 	"github.com/chain4travel/camino-messenger-bot/v11/pp-mock/events"
 	mockdata "github.com/chain4travel/camino-messenger-bot/v11/pp-mock/services/data"
-	"google.golang.org/grpc"
 )
 
 var _ accommodationv1grpc.AccommodationProductInfoServiceServer = (*accommodationProductInfoV1Server)(nil)
@@ -32,13 +30,7 @@ func (s *accommodationProductInfoV1Server) AccommodationProductInfo(ctx context.
 		log.Printf("error sending event: %v", err)
 	}
 
-	md := metadata.Metadata{}
-
-	if err := md.ExtractMetadata(ctx); err != nil {
-		log.Print("error extracting metadata")
-	}
-
-	md.Stamp(fmt.Sprintf("%s-%s", "ext-system", "response"))
+	md := metadata.FromGRPCContext(ctx)
 
 	log.Printf("Responding to request (Accommodation Product Info): %s", md.RequestID)
 
@@ -60,10 +52,6 @@ func (s *accommodationProductInfoV1Server) AccommodationProductInfo(ctx context.
 	}
 
 	log.Printf("CMAccount %s received request from CMAccount %s", md.RecipientCMAccount, md.SenderCMAccount)
-
-	if err := grpc.SetHeader(ctx, md.ToGrpcMD()); err != nil {
-		log.Printf("Failed to set header: %v", err)
-	}
 
 	return response, nil
 }

--- a/pp-mock/handlers/accommodation/v1/accommodation_product_list.go
+++ b/pp-mock/handlers/accommodation/v1/accommodation_product_list.go
@@ -5,7 +5,6 @@ package v1
 
 import (
 	"context"
-	"fmt"
 	"log"
 
 	"buf.build/gen/go/chain4travel/camino-messenger-protocol/grpc/go/cmp/services/accommodation/v1/accommodationv1grpc"
@@ -14,7 +13,6 @@ import (
 	"github.com/chain4travel/camino-messenger-bot/v11/pkg/metadata"
 	"github.com/chain4travel/camino-messenger-bot/v11/pp-mock/events"
 	mockdata "github.com/chain4travel/camino-messenger-bot/v11/pp-mock/services/data"
-	"google.golang.org/grpc"
 )
 
 var _ accommodationv1grpc.AccommodationProductListServiceServer = (*accommodationProductListV1Server)(nil)
@@ -32,13 +30,7 @@ func (s *accommodationProductListV1Server) AccommodationProductList(ctx context.
 		log.Printf("error sending event: %v", err)
 	}
 
-	md := metadata.Metadata{}
-
-	if err := md.ExtractMetadata(ctx); err != nil {
-		log.Print("error extracting metadata")
-	}
-
-	md.Stamp(fmt.Sprintf("%s-%s", "ext-system", "response"))
+	md := metadata.FromGRPCContext(ctx)
 
 	log.Printf("Responding to request (Accommodation Product List): %s", md.RequestID)
 
@@ -59,10 +51,6 @@ func (s *accommodationProductListV1Server) AccommodationProductList(ctx context.
 	}
 
 	log.Printf("CMAccount %s received request from CMAccount %s", md.RecipientCMAccount, md.SenderCMAccount)
-
-	if err := grpc.SetHeader(ctx, md.ToGrpcMD()); err != nil {
-		log.Printf("Failed to set header: %v", err)
-	}
 
 	return response, nil
 }

--- a/pp-mock/handlers/accommodation/v1/accommodation_search.go
+++ b/pp-mock/handlers/accommodation/v1/accommodation_search.go
@@ -18,7 +18,6 @@ import (
 	"github.com/chain4travel/camino-messenger-bot/v11/pp-mock/handlers/state"
 	mockdata "github.com/chain4travel/camino-messenger-bot/v11/pp-mock/services/data"
 	"github.com/google/uuid"
-	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -37,15 +36,10 @@ func (s *accommodationSearchV1Server) AccommodationSearch(ctx context.Context, r
 		log.Printf("error sending event: %v", err)
 	}
 
-	md := metadata.Metadata{}
-
 	fmt.Printf("Search generic params: %+v\n", req.SearchParametersGeneric)
 
-	if err := md.ExtractMetadata(ctx); err != nil {
-		log.Print("error extracting metadata")
-	}
+	md := metadata.FromGRPCContext(ctx)
 
-	md.Stamp(fmt.Sprintf("%s-%s", "ext-system", "response"))
 	log.Printf("Responding to request (Accommodation Search): %s", md.RequestID)
 
 	// if there is no query, return no results
@@ -232,10 +226,6 @@ func (s *accommodationSearchV1Server) AccommodationSearch(ctx context.Context, r
 	}
 
 	log.Printf("CMAccount %s received request from CMAccount %s", md.RecipientCMAccount, md.SenderCMAccount)
-
-	if err := grpc.SetHeader(ctx, md.ToGrpcMD()); err != nil {
-		log.Printf("Failed to set header: %v", err)
-	}
 
 	state.GetStore().AddSearchResult(response.Metadata.SearchId.Value, state.SearchData{
 		NumResults:   len(searchResults),

--- a/pp-mock/handlers/accommodation/v2/accommodation_product_info.go
+++ b/pp-mock/handlers/accommodation/v2/accommodation_product_info.go
@@ -5,7 +5,6 @@ package v2
 
 import (
 	"context"
-	"fmt"
 	"log"
 
 	"buf.build/gen/go/chain4travel/camino-messenger-protocol/grpc/go/cmp/services/accommodation/v2/accommodationv2grpc"
@@ -14,7 +13,6 @@ import (
 	"github.com/chain4travel/camino-messenger-bot/v11/pkg/metadata"
 	"github.com/chain4travel/camino-messenger-bot/v11/pp-mock/events"
 	mockdata "github.com/chain4travel/camino-messenger-bot/v11/pp-mock/services/data"
-	"google.golang.org/grpc"
 )
 
 var _ accommodationv2grpc.AccommodationProductInfoServiceServer = (*accommodationProductInfoV2Server)(nil)
@@ -32,13 +30,8 @@ func (s *accommodationProductInfoV2Server) AccommodationProductInfo(ctx context.
 		log.Printf("error sending event: %v", err)
 	}
 
-	md := metadata.Metadata{}
+	md := metadata.FromGRPCContext(ctx)
 
-	if err := md.ExtractMetadata(ctx); err != nil {
-		log.Print("error extracting metadata")
-	}
-
-	md.Stamp(fmt.Sprintf("%s-%s", "ext-system", "response"))
 	log.Printf("Responding to request (Accommodation Product Info): %s", md.RequestID)
 
 	filteredProperties := filterExtendedPropertiesBySupplierCodes(mockdata.PropertiesV2, req.SupplierCodes)
@@ -59,10 +52,6 @@ func (s *accommodationProductInfoV2Server) AccommodationProductInfo(ctx context.
 	}
 
 	log.Printf("CMAccount %s received request from CMAccount %s", md.RecipientCMAccount, md.SenderCMAccount)
-
-	if err := grpc.SetHeader(ctx, md.ToGrpcMD()); err != nil {
-		log.Printf("Failed to set header: %v", err)
-	}
 
 	return response, nil
 }

--- a/pp-mock/handlers/accommodation/v2/accommodation_product_list.go
+++ b/pp-mock/handlers/accommodation/v2/accommodation_product_list.go
@@ -5,7 +5,6 @@ package v2
 
 import (
 	"context"
-	"fmt"
 	"log"
 
 	"buf.build/gen/go/chain4travel/camino-messenger-protocol/grpc/go/cmp/services/accommodation/v2/accommodationv2grpc"
@@ -14,7 +13,6 @@ import (
 	"github.com/chain4travel/camino-messenger-bot/v11/pkg/metadata"
 	"github.com/chain4travel/camino-messenger-bot/v11/pp-mock/events"
 	mockdata "github.com/chain4travel/camino-messenger-bot/v11/pp-mock/services/data"
-	"google.golang.org/grpc"
 )
 
 var _ accommodationv2grpc.AccommodationProductListServiceServer = (*accommodationProductListV2Server)(nil)
@@ -32,13 +30,8 @@ func (s *accommodationProductListV2Server) AccommodationProductList(ctx context.
 		log.Printf("error sending event: %v", err)
 	}
 
-	md := metadata.Metadata{}
+	md := metadata.FromGRPCContext(ctx)
 
-	if err := md.ExtractMetadata(ctx); err != nil {
-		log.Print("error extracting metadata")
-	}
-
-	md.Stamp(fmt.Sprintf("%s-%s", "ext-system", "response"))
 	log.Printf("Responding to request (Accommodation Product List): %s", md.RequestID)
 
 	filteredProperties := filterPropertiesByLastModified(mockdata.PropertiesV2, req.GetModifiedAfter().AsTime())
@@ -58,10 +51,6 @@ func (s *accommodationProductListV2Server) AccommodationProductList(ctx context.
 	}
 
 	log.Printf("CMAccount %s received request from CMAccount %s", md.RecipientCMAccount, md.SenderCMAccount)
-
-	if err := grpc.SetHeader(ctx, md.ToGrpcMD()); err != nil {
-		log.Printf("Failed to set header: %v", err)
-	}
 
 	return response, nil
 }

--- a/pp-mock/handlers/accommodation/v2/accommodation_search.go
+++ b/pp-mock/handlers/accommodation/v2/accommodation_search.go
@@ -19,7 +19,6 @@ import (
 	"github.com/chain4travel/camino-messenger-bot/v11/pp-mock/handlers/state"
 	mockdata "github.com/chain4travel/camino-messenger-bot/v11/pp-mock/services/data"
 	"github.com/google/uuid"
-	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -38,16 +37,10 @@ func (s *accommodationSearchV2Server) AccommodationSearch(ctx context.Context, r
 		log.Printf("error sending event: %v", err)
 	}
 
-	md := metadata.Metadata{}
-
 	fmt.Printf("Search generic params: %+v\n", req.SearchParametersGeneric)
 
-	if err := md.ExtractMetadata(ctx); err != nil {
-		// TODO @evlekht Improve error handling for metadata extraction - handle consistently across all files. Must either return error or error response.
-		log.Print("error extracting metadata")
-	}
+	md := metadata.FromGRPCContext(ctx)
 
-	md.Stamp(fmt.Sprintf("%s-%s", "ext-system", "response"))
 	log.Printf("Responding to request (Accommodation Search): %s", md.RequestID)
 
 	// if there is no query, return no results
@@ -235,10 +228,6 @@ func (s *accommodationSearchV2Server) AccommodationSearch(ctx context.Context, r
 	}
 
 	log.Printf("CMAccount %s received request from CMAccount %s", md.RecipientCMAccount, md.SenderCMAccount)
-
-	if err := grpc.SetHeader(ctx, md.ToGrpcMD()); err != nil {
-		log.Printf("Failed to set header: %v", err)
-	}
 
 	state.GetStore().AddSearchResult(response.Metadata.SearchId.Value, state.SearchData{
 		NumResults:   len(searchResults),

--- a/pp-mock/handlers/accommodation/v3/accommodation_product_info.go
+++ b/pp-mock/handlers/accommodation/v3/accommodation_product_info.go
@@ -5,7 +5,6 @@ package v3
 
 import (
 	"context"
-	"fmt"
 	"log"
 
 	"buf.build/gen/go/chain4travel/camino-messenger-protocol/grpc/go/cmp/services/accommodation/v3/accommodationv3grpc"
@@ -14,7 +13,6 @@ import (
 	"github.com/chain4travel/camino-messenger-bot/v11/pkg/metadata"
 	"github.com/chain4travel/camino-messenger-bot/v11/pp-mock/events"
 	mockdata "github.com/chain4travel/camino-messenger-bot/v11/pp-mock/services/data"
-	"google.golang.org/grpc"
 )
 
 var _ accommodationv3grpc.AccommodationProductInfoServiceServer = (*accommodationProductInfoV3Server)(nil)
@@ -32,13 +30,8 @@ func (s *accommodationProductInfoV3Server) AccommodationProductInfo(ctx context.
 		log.Printf("error sending event: %v", err)
 	}
 
-	md := metadata.Metadata{}
+	md := metadata.FromGRPCContext(ctx)
 
-	if err := md.ExtractMetadata(ctx); err != nil {
-		log.Print("error extracting metadata")
-	}
-
-	md.Stamp(fmt.Sprintf("%s-%s", "ext-system", "response"))
 	log.Printf("Responding to request (Accommodation Product Info): %s", md.RequestID)
 
 	filteredProperties := filterExtendedPropertiesBySupplierCodes(mockdata.PropertiesV3, req.SupplierCodes)
@@ -59,10 +52,6 @@ func (s *accommodationProductInfoV3Server) AccommodationProductInfo(ctx context.
 	}
 
 	log.Printf("CMAccount %s received request from CMAccount %s", md.RecipientCMAccount, md.SenderCMAccount)
-
-	if err := grpc.SetHeader(ctx, md.ToGrpcMD()); err != nil {
-		log.Printf("Failed to set header: %v", err)
-	}
 
 	return response, nil
 }

--- a/pp-mock/handlers/accommodation/v3/accommodation_product_list.go
+++ b/pp-mock/handlers/accommodation/v3/accommodation_product_list.go
@@ -5,7 +5,6 @@ package v3
 
 import (
 	"context"
-	"fmt"
 	"log"
 
 	"buf.build/gen/go/chain4travel/camino-messenger-protocol/grpc/go/cmp/services/accommodation/v3/accommodationv3grpc"
@@ -14,7 +13,6 @@ import (
 	"github.com/chain4travel/camino-messenger-bot/v11/pkg/metadata"
 	"github.com/chain4travel/camino-messenger-bot/v11/pp-mock/events"
 	mockdata "github.com/chain4travel/camino-messenger-bot/v11/pp-mock/services/data"
-	"google.golang.org/grpc"
 )
 
 var _ accommodationv3grpc.AccommodationProductListServiceServer = (*accommodationProductListV3Server)(nil)
@@ -32,13 +30,8 @@ func (s *accommodationProductListV3Server) AccommodationProductList(ctx context.
 		log.Printf("error sending event: %v", err)
 	}
 
-	md := metadata.Metadata{}
+	md := metadata.FromGRPCContext(ctx)
 
-	if err := md.ExtractMetadata(ctx); err != nil {
-		log.Print("error extracting metadata")
-	}
-
-	md.Stamp(fmt.Sprintf("%s-%s", "ext-system", "response"))
 	log.Printf("Responding to request (Accommodation Product List): %s", md.RequestID)
 
 	filteredProperties := filterPropertiesByLastModified(mockdata.PropertiesV3, req.GetModifiedAfter().AsTime())
@@ -58,10 +51,6 @@ func (s *accommodationProductListV3Server) AccommodationProductList(ctx context.
 	}
 
 	log.Printf("CMAccount %s received request from CMAccount %s", md.RecipientCMAccount, md.SenderCMAccount)
-
-	if err := grpc.SetHeader(ctx, md.ToGrpcMD()); err != nil {
-		log.Printf("Failed to set header: %v", err)
-	}
 
 	return response, nil
 }

--- a/pp-mock/handlers/accommodation/v3/accommodation_search.go
+++ b/pp-mock/handlers/accommodation/v3/accommodation_search.go
@@ -20,7 +20,6 @@ import (
 	"github.com/chain4travel/camino-messenger-bot/v11/pp-mock/handlers/state"
 	mockdata "github.com/chain4travel/camino-messenger-bot/v11/pp-mock/services/data"
 	"github.com/google/uuid"
-	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -39,16 +38,10 @@ func (s *accommodationSearchV3Server) AccommodationSearch(ctx context.Context, r
 		log.Printf("error sending event: %v", err)
 	}
 
-	md := metadata.Metadata{}
-
 	fmt.Printf("Search generic params: %+v\n", req.SearchParametersGeneric)
 
-	if err := md.ExtractMetadata(ctx); err != nil {
-		// TODO @evlekht Improve error handling for metadata extraction - handle consistently across all files. Must either return error or error response.
-		log.Print("error extracting metadata")
-	}
+	md := metadata.FromGRPCContext(ctx)
 
-	md.Stamp(fmt.Sprintf("%s-%s", "ext-system", "response"))
 	log.Printf("Responding to request (Accommodation Search): %s", md.RequestID)
 
 	// if there is no query, return no results
@@ -234,10 +227,6 @@ func (s *accommodationSearchV3Server) AccommodationSearch(ctx context.Context, r
 	}
 
 	log.Printf("CMAccount %s received request from CMAccount %s", md.RecipientCMAccount, md.SenderCMAccount)
-
-	if err := grpc.SetHeader(ctx, md.ToGrpcMD()); err != nil {
-		log.Printf("Failed to set header: %v", err)
-	}
 
 	state.GetStore().AddSearchResult(response.Metadata.SearchId.Value, state.SearchData{
 		NumResults:   len(searchResults),

--- a/pp-mock/handlers/book/v1/mint.go
+++ b/pp-mock/handlers/book/v1/mint.go
@@ -5,7 +5,6 @@ package v1
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"time"
 
@@ -17,7 +16,6 @@ import (
 	"github.com/chain4travel/camino-messenger-bot/v11/pp-mock/config"
 	"github.com/chain4travel/camino-messenger-bot/v11/pp-mock/events"
 	"github.com/google/uuid"
-	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -36,12 +34,8 @@ func (s *mintServiceV1Server) Mint(ctx context.Context, req *bookv1.MintRequest)
 		log.Printf("error sending event: %v", err)
 	}
 
-	md := metadata.Metadata{}
+	md := metadata.FromGRPCContext(ctx)
 
-	if err := md.ExtractMetadata(ctx); err != nil {
-		log.Print("error extracting metadata")
-	}
-	md.Stamp(fmt.Sprintf("%s-%s", "ext-system", "response"))
 	log.Printf("Responding to request (MintV1): %s", md.RequestID)
 
 	response := bookv1.MintResponse{
@@ -62,10 +56,6 @@ func (s *mintServiceV1Server) Mint(ctx context.Context, req *bookv1.MintRequest)
 	}
 
 	log.Printf("CMAccount %s received request from CMAccount %s", md.RecipientCMAccount, md.SenderCMAccount)
-
-	if err := grpc.SetHeader(ctx, md.ToGrpcMD()); err != nil {
-		log.Printf("Failed to set header: %v", err)
-	}
 
 	return &response, nil
 }

--- a/pp-mock/handlers/book/v1/validation.go
+++ b/pp-mock/handlers/book/v1/validation.go
@@ -11,7 +11,6 @@ import (
 	"buf.build/gen/go/chain4travel/camino-messenger-protocol/grpc/go/cmp/services/book/v1/bookv1grpc"
 	bookv1 "buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go/cmp/services/book/v1"
 	typesv1 "buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go/cmp/types/v1"
-	"google.golang.org/grpc"
 
 	"github.com/chain4travel/camino-messenger-bot/v11/pkg/metadata"
 	"github.com/chain4travel/camino-messenger-bot/v11/pp-mock/common"
@@ -38,12 +37,8 @@ func (s *validationServiceV1Server) Validation(ctx context.Context, req *bookv1.
 		log.Printf("error sending event: %v", err)
 	}
 
-	md := metadata.Metadata{}
-	err := md.ExtractMetadata(ctx)
-	if err != nil {
-		log.Print("error extracting metadata")
-	}
-	md.Stamp(fmt.Sprintf("%s-%s", "ext-system", "response"))
+	md := metadata.FromGRPCContext(ctx)
+
 	log.Printf("Responding to request: %s (Validation)", md.RequestID)
 	if req.ValidationObject == nil ||
 		req.ValidationObject.SearchIdentifier == nil ||
@@ -81,8 +76,5 @@ func (s *validationServiceV1Server) Validation(ctx context.Context, req *bookv1.
 	}
 	log.Printf("CMAccount %s received request from CMAccount %s", md.RecipientCMAccount, md.SenderCMAccount)
 
-	if err := grpc.SetHeader(ctx, md.ToGrpcMD()); err != nil {
-		log.Printf("Failed to set header: %v", err)
-	}
 	return &response, nil
 }

--- a/pp-mock/handlers/book/v2/mint.go
+++ b/pp-mock/handlers/book/v2/mint.go
@@ -5,7 +5,6 @@ package v2
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"time"
 
@@ -19,7 +18,6 @@ import (
 	"github.com/chain4travel/camino-messenger-bot/v11/pp-mock/events"
 	"github.com/chain4travel/camino-messenger-bot/v11/pp-mock/handlers/state"
 	"github.com/google/uuid"
-	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -38,12 +36,8 @@ func (s *mintServiceV2Server) Mint(ctx context.Context, req *bookv2.MintRequest)
 		log.Printf("error sending event: %v", err)
 	}
 
-	md := metadata.Metadata{}
+	md := metadata.FromGRPCContext(ctx)
 
-	if err := md.ExtractMetadata(ctx); err != nil {
-		log.Print("error extracting metadata")
-	}
-	md.Stamp(fmt.Sprintf("%s-%s", "ext-system", "response"))
 	log.Printf("Responding to request (MintV2): %s", md.RequestID)
 
 	storedValidateData, ok := state.GetStore().GetValidationResult(req.ValidationId.Value)
@@ -83,10 +77,6 @@ func (s *mintServiceV2Server) Mint(ctx context.Context, req *bookv2.MintRequest)
 	}
 
 	log.Printf("CMAccount %s received request from CMAccount %s", md.RecipientCMAccount, md.SenderCMAccount)
-
-	if err := grpc.SetHeader(ctx, md.ToGrpcMD()); err != nil {
-		log.Printf("Failed to set header: %v", err)
-	}
 
 	return &response, nil
 }

--- a/pp-mock/handlers/book/v2/validation.go
+++ b/pp-mock/handlers/book/v2/validation.go
@@ -5,14 +5,12 @@ package v2
 
 import (
 	"context"
-	"fmt"
 	"log"
 
 	"buf.build/gen/go/chain4travel/camino-messenger-protocol/grpc/go/cmp/services/book/v2/bookv2grpc"
 	bookv2 "buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go/cmp/services/book/v2"
 	typesv1 "buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go/cmp/types/v1"
 	typesv2 "buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go/cmp/types/v2"
-	"google.golang.org/grpc"
 
 	"github.com/chain4travel/camino-messenger-bot/v11/pkg/metadata"
 	"github.com/chain4travel/camino-messenger-bot/v11/pp-mock/events"
@@ -39,12 +37,8 @@ func (s *validationServiceV2Server) Validation(ctx context.Context, req *bookv2.
 		log.Printf("error sending event: %v", err)
 	}
 
-	md := metadata.Metadata{}
-	err := md.ExtractMetadata(ctx)
-	if err != nil {
-		log.Print("error extracting metadata")
-	}
-	md.Stamp(fmt.Sprintf("%s-%s", "ext-system", "response"))
+	md := metadata.FromGRPCContext(ctx)
+
 	log.Printf("Responding to request: %s (Validation)", md.RequestID)
 	if req.ValidationObject == nil ||
 		req.ValidationObject.SearchIdentifier == nil ||
@@ -104,10 +98,6 @@ func (s *validationServiceV2Server) Validation(ctx context.Context, req *bookv2.
 		},
 	}
 	log.Printf("CMAccount %s received request from CMAccount %s", md.RecipientCMAccount, md.SenderCMAccount)
-
-	if err := grpc.SetHeader(ctx, md.ToGrpcMD()); err != nil {
-		log.Printf("Failed to set header: %v", err)
-	}
 
 	state.GetStore().AddValidationResult(response.ValidationId.Value, state.ValidationData{
 		InitialSearchData: storedSearchData.Data,

--- a/pp-mock/handlers/book/v3/mint.go
+++ b/pp-mock/handlers/book/v3/mint.go
@@ -5,7 +5,6 @@ package v3
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"time"
 
@@ -19,7 +18,6 @@ import (
 	"github.com/chain4travel/camino-messenger-bot/v11/pp-mock/events"
 	"github.com/chain4travel/camino-messenger-bot/v11/pp-mock/handlers/state"
 	"github.com/google/uuid"
-	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -38,12 +36,8 @@ func (s *mintServiceV3Server) Mint(ctx context.Context, req *bookv3.MintRequest)
 		log.Printf("error sending event: %v", err)
 	}
 
-	md := metadata.Metadata{}
+	md := metadata.FromGRPCContext(ctx)
 
-	if err := md.ExtractMetadata(ctx); err != nil {
-		log.Print("error extracting metadata")
-	}
-	md.Stamp(fmt.Sprintf("%s-%s", "ext-system", "response"))
 	log.Printf("Responding to request (MintV3): %s", md.RequestID)
 
 	storedValidateData, ok := state.GetStore().GetValidationResult(req.ValidationId.Value)
@@ -84,10 +78,6 @@ func (s *mintServiceV3Server) Mint(ctx context.Context, req *bookv3.MintRequest)
 	}
 
 	log.Printf("CMAccount %s received request from CMAccount %s", md.RecipientCMAccount, md.SenderCMAccount)
-
-	if err := grpc.SetHeader(ctx, md.ToGrpcMD()); err != nil {
-		log.Printf("Failed to set header: %v", err)
-	}
 
 	return &response, nil
 }

--- a/pp-mock/handlers/book/v3/validation.go
+++ b/pp-mock/handlers/book/v3/validation.go
@@ -5,14 +5,12 @@ package v3
 
 import (
 	"context"
-	"fmt"
 	"log"
 
 	"buf.build/gen/go/chain4travel/camino-messenger-protocol/grpc/go/cmp/services/book/v3/bookv3grpc"
 	bookv3 "buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go/cmp/services/book/v3"
 	typesv1 "buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go/cmp/types/v1"
 	typesv3 "buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go/cmp/types/v3"
-	"google.golang.org/grpc"
 
 	"github.com/chain4travel/camino-messenger-bot/v11/pkg/metadata"
 	"github.com/chain4travel/camino-messenger-bot/v11/pp-mock/events"
@@ -39,12 +37,8 @@ func (s *validationServiceV3Server) Validation(ctx context.Context, req *bookv3.
 		log.Printf("error sending event: %v", err)
 	}
 
-	md := metadata.Metadata{}
-	err := md.ExtractMetadata(ctx)
-	if err != nil {
-		log.Print("error extracting metadata")
-	}
-	md.Stamp(fmt.Sprintf("%s-%s", "ext-system", "response"))
+	md := metadata.FromGRPCContext(ctx)
+
 	log.Printf("Responding to request: %s (Validation)", md.RequestID)
 	if req.ValidationObject == nil ||
 		req.ValidationObject.SearchIdentifier == nil ||
@@ -104,10 +98,6 @@ func (s *validationServiceV3Server) Validation(ctx context.Context, req *bookv3.
 		},
 	}
 	log.Printf("CMAccount %s received request from CMAccount %s", md.RecipientCMAccount, md.SenderCMAccount)
-
-	if err := grpc.SetHeader(ctx, md.ToGrpcMD()); err != nil {
-		log.Printf("Failed to set header: %v", err)
-	}
 
 	state.GetStore().AddValidationResult(response.ValidationId.Value, state.ValidationData{
 		InitialSearchData: storedSearchData.Data,

--- a/pp-mock/handlers/cancellation/v1/check_cancellation.go
+++ b/pp-mock/handlers/cancellation/v1/check_cancellation.go
@@ -5,7 +5,6 @@ package v1
 
 import (
 	"context"
-	"fmt"
 	"log"
 
 	"buf.build/gen/go/chain4travel/camino-messenger-protocol/grpc/go/cmp/services/cancellation/v1/cancellationv1grpc"
@@ -16,7 +15,6 @@ import (
 	"github.com/chain4travel/camino-messenger-bot/v11/pkg/price"
 	"github.com/chain4travel/camino-messenger-bot/v11/pp-mock/common"
 	"github.com/chain4travel/camino-messenger-bot/v11/pp-mock/events"
-	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -37,13 +35,7 @@ func (s *checkCancellationV1Server) CheckCancellation(ctx context.Context, req *
 		log.Printf("error sending event: %v", err)
 	}
 
-	md := metadata.Metadata{}
-
-	if err := md.ExtractMetadata(ctx); err != nil {
-		log.Print("error extracting metadata")
-	}
-
-	md.Stamp(fmt.Sprintf("%s-%s", "ext-system", "response"))
+	md := metadata.FromGRPCContext(ctx)
 
 	log.Printf("Responding to request (CheckCancellation): %s", md.RequestID)
 
@@ -65,10 +57,6 @@ func (s *checkCancellationV1Server) CheckCancellation(ctx context.Context, req *
 	}
 
 	log.Printf("CMAccount %s received request from CMAccount %s", md.RecipientCMAccount, md.SenderCMAccount)
-
-	if err := grpc.SetHeader(ctx, md.ToGrpcMD()); err != nil {
-		log.Printf("Failed to set header: %v", err)
-	}
 
 	return response, nil
 }

--- a/pp-mock/handlers/notification/v1/notification.go
+++ b/pp-mock/handlers/notification/v1/notification.go
@@ -5,7 +5,6 @@ package v1
 
 import (
 	"context"
-	"fmt"
 	"log"
 
 	"buf.build/gen/go/chain4travel/camino-messenger-protocol/grpc/go/cmp/services/notification/v1/notificationv1grpc"
@@ -34,12 +33,8 @@ func (s *notificationServiceV1Server) TokenBoughtNotification(ctx context.Contex
 		log.Printf("error sending event: %v", err)
 	}
 
-	md := metadata.Metadata{}
-	err := md.ExtractMetadata(ctx)
-	if err != nil {
-		log.Print("error extracting metadata")
-	}
-	md.Stamp(fmt.Sprintf("%s-%s", "ext-system", "response"))
+	md := metadata.FromGRPCContext(ctx)
+
 	log.Printf("Responding to request: %s (TokenBoughtNotification)", md.RequestID)
 
 	return &emptypb.Empty{}, nil
@@ -51,12 +46,8 @@ func (s *notificationServiceV1Server) TokenExpiredNotification(ctx context.Conte
 		log.Printf("error sending event: %v", err)
 	}
 
-	md := metadata.Metadata{}
-	err := md.ExtractMetadata(ctx)
-	if err != nil {
-		log.Print("error extracting metadata")
-	}
-	md.Stamp(fmt.Sprintf("%s-%s", "ext-system", "response"))
+	md := metadata.FromGRPCContext(ctx)
+
 	log.Printf("Responding to request: %s (TokenExpiredNotification)", md.RequestID)
 
 	return &emptypb.Empty{}, nil

--- a/pp-mock/handlers/notification/v2/notification.go
+++ b/pp-mock/handlers/notification/v2/notification.go
@@ -5,7 +5,6 @@ package v2
 
 import (
 	"context"
-	"fmt"
 	"log"
 
 	"buf.build/gen/go/chain4travel/camino-messenger-protocol/grpc/go/cmp/services/notification/v2/notificationv2grpc"
@@ -34,12 +33,8 @@ func (s *notificationServiceV2Server) TokenBoughtNotification(ctx context.Contex
 		log.Printf("error sending event: %v", err)
 	}
 
-	md := metadata.Metadata{}
-	err := md.ExtractMetadata(ctx)
-	if err != nil {
-		log.Print("error extracting metadata")
-	}
-	md.Stamp(fmt.Sprintf("%s-%s", "ext-system", "response"))
+	md := metadata.FromGRPCContext(ctx)
+
 	log.Printf("Responding to request: %s (TokenBoughtNotification)", md.RequestID)
 
 	return &emptypb.Empty{}, nil
@@ -51,12 +46,8 @@ func (s *notificationServiceV2Server) TokenExpiredNotification(ctx context.Conte
 		log.Printf("error sending event: %v", err)
 	}
 
-	md := metadata.Metadata{}
-	err := md.ExtractMetadata(ctx)
-	if err != nil {
-		log.Print("error extracting metadata")
-	}
-	md.Stamp(fmt.Sprintf("%s-%s", "ext-system", "response"))
+	md := metadata.FromGRPCContext(ctx)
+
 	log.Printf("Responding to request: %s (TokenExpiredNotification)", md.RequestID)
 
 	return &emptypb.Empty{}, nil
@@ -67,12 +58,8 @@ func (s *notificationServiceV2Server) CancellationPendingNotification(ctx contex
 		log.Printf("error sending event: %v", err)
 	}
 
-	md := metadata.Metadata{}
-	err := md.ExtractMetadata(ctx)
-	if err != nil {
-		log.Print("error extracting metadata")
-	}
-	md.Stamp(fmt.Sprintf("%s-%s", "ext-system", "response"))
+	md := metadata.FromGRPCContext(ctx)
+
 	log.Printf("Responding to request: %s (CancellationPendingNotification)", md.RequestID)
 
 	return &emptypb.Empty{}, nil
@@ -83,12 +70,8 @@ func (s *notificationServiceV2Server) CancellationWithdrawnNotification(ctx cont
 		log.Printf("error sending event: %v", err)
 	}
 
-	md := metadata.Metadata{}
-	err := md.ExtractMetadata(ctx)
-	if err != nil {
-		log.Print("error extracting metadata")
-	}
-	md.Stamp(fmt.Sprintf("%s-%s", "ext-system", "response"))
+	md := metadata.FromGRPCContext(ctx)
+
 	log.Printf("Responding to request: %s (CancellationWithdrawnNotification)", md.RequestID)
 
 	return &emptypb.Empty{}, nil
@@ -99,12 +82,8 @@ func (s *notificationServiceV2Server) CancellationRejectedNotification(ctx conte
 		log.Printf("error sending event: %v", err)
 	}
 
-	md := metadata.Metadata{}
-	err := md.ExtractMetadata(ctx)
-	if err != nil {
-		log.Print("error extracting metadata")
-	}
-	md.Stamp(fmt.Sprintf("%s-%s", "ext-system", "response"))
+	md := metadata.FromGRPCContext(ctx)
+
 	log.Printf("Responding to request: %s (CancellationRejectedNotification)", md.RequestID)
 
 	return &emptypb.Empty{}, nil
@@ -115,12 +94,8 @@ func (s *notificationServiceV2Server) CancellationFinalizedNotification(ctx cont
 		log.Printf("error sending event: %v", err)
 	}
 
-	md := metadata.Metadata{}
-	err := md.ExtractMetadata(ctx)
-	if err != nil {
-		log.Print("error extracting metadata")
-	}
-	md.Stamp(fmt.Sprintf("%s-%s", "ext-system", "response"))
+	md := metadata.FromGRPCContext(ctx)
+
 	log.Printf("Responding to request: %s (CancellationFinalizedNotification)", md.RequestID)
 
 	return &emptypb.Empty{}, nil

--- a/pp-mock/handlers/ping/v1/ping_handler.go
+++ b/pp-mock/handlers/ping/v1/ping_handler.go
@@ -30,12 +30,8 @@ func (s *pingServiceV1Server) Ping(ctx context.Context, req *pingv1.PingRequest)
 		log.Printf("error sending event: %v", err)
 	}
 
-	md := metadata.Metadata{}
-	err := md.ExtractMetadata(ctx)
-	if err != nil {
-		log.Print("error extracting metadata")
-	}
-	md.Stamp(fmt.Sprintf("%s-%s", "ext-system", "response"))
+	md := metadata.FromGRPCContext(ctx)
+
 	log.Printf("Responding to request: %s (Ping)", md.RequestID)
 
 	return &pingv1.PingResponse{

--- a/pp-mock/handlers/transport/v1/transport_search.go
+++ b/pp-mock/handlers/transport/v1/transport_search.go
@@ -18,7 +18,6 @@ import (
 	"github.com/chain4travel/camino-messenger-bot/v11/pp-mock/events"
 	mockdata "github.com/chain4travel/camino-messenger-bot/v11/pp-mock/services/data"
 	"github.com/google/uuid"
-	"google.golang.org/grpc"
 )
 
 var _ transportv1grpc.TransportSearchServiceServer = (*transportSearchV1Server)(nil)
@@ -36,14 +35,8 @@ func (s *transportSearchV1Server) TransportSearch(ctx context.Context, req *tran
 		log.Printf("error sending event: %v", err)
 	}
 
-	md := metadata.Metadata{}
+	md := metadata.FromGRPCContext(ctx)
 
-	err := md.ExtractMetadata(ctx)
-	if err != nil {
-		log.Print("error extracting metadata")
-	}
-
-	md.Stamp(fmt.Sprintf("%s-%s", "ext-system", "response"))
 	log.Printf("Responding to request: %s (TransportSearch) v1", md.RequestID)
 
 	// if there is no query, return no results
@@ -211,10 +204,6 @@ func (s *transportSearchV1Server) TransportSearch(ctx context.Context, req *tran
 	}
 
 	log.Printf("CMAccount %s received request from CMAccount %s", md.RecipientCMAccount, md.SenderCMAccount)
-
-	if err := grpc.SetHeader(ctx, md.ToGrpcMD()); err != nil {
-		log.Printf("Failed to set header: %v", err)
-	}
 
 	return response, nil
 }

--- a/pp-mock/handlers/transport/v2/transport_search.go
+++ b/pp-mock/handlers/transport/v2/transport_search.go
@@ -19,7 +19,6 @@ import (
 	"github.com/chain4travel/camino-messenger-bot/v11/pp-mock/events"
 	mockdata "github.com/chain4travel/camino-messenger-bot/v11/pp-mock/services/data"
 	"github.com/google/uuid"
-	"google.golang.org/grpc"
 )
 
 var _ transportv2grpc.TransportSearchServiceServer = (*transportSearchV2Server)(nil)
@@ -37,14 +36,8 @@ func (s *transportSearchV2Server) TransportSearch(ctx context.Context, req *tran
 		log.Printf("error sending event: %v", err)
 	}
 
-	md := metadata.Metadata{}
+	md := metadata.FromGRPCContext(ctx)
 
-	err := md.ExtractMetadata(ctx)
-	if err != nil {
-		log.Print("error extracting metadata")
-	}
-
-	md.Stamp(fmt.Sprintf("%s-%s", "ext-system", "response"))
 	log.Printf("Responding to request: %s (TransportSearch) v2", md.RequestID)
 
 	// if there is no query, return no results
@@ -212,10 +205,6 @@ func (s *transportSearchV2Server) TransportSearch(ctx context.Context, req *tran
 	}
 
 	log.Printf("CMAccount %s received request from CMAccount %s", md.RecipientCMAccount, md.SenderCMAccount)
-
-	if err := grpc.SetHeader(ctx, md.ToGrpcMD()); err != nil {
-		log.Printf("Failed to set header: %v", err)
-	}
 
 	return response, nil
 }

--- a/pp-mock/handlers/transport/v3/transport_product_list.go
+++ b/pp-mock/handlers/transport/v3/transport_product_list.go
@@ -5,7 +5,6 @@ package v3
 
 import (
 	"context"
-	"fmt"
 	"log"
 
 	"buf.build/gen/go/chain4travel/camino-messenger-protocol/grpc/go/cmp/services/transport/v3/transportv3grpc"
@@ -14,7 +13,6 @@ import (
 	"github.com/chain4travel/camino-messenger-bot/v11/pkg/metadata"
 	"github.com/chain4travel/camino-messenger-bot/v11/pp-mock/events"
 	mockdata "github.com/chain4travel/camino-messenger-bot/v11/pp-mock/services/data"
-	"google.golang.org/grpc"
 )
 
 var _ transportv3grpc.TransportProductListServiceServer = (*transportProductListV3Server)(nil)
@@ -32,13 +30,8 @@ func (s *transportProductListV3Server) TransportProductList(ctx context.Context,
 		log.Printf("error sending event: %v", err)
 	}
 
-	md := metadata.Metadata{}
+	md := metadata.FromGRPCContext(ctx)
 
-	if err := md.ExtractMetadata(ctx); err != nil {
-		log.Print("error extracting metadata")
-	}
-
-	md.Stamp(fmt.Sprintf("%s-%s", "ext-system", "response"))
 	log.Printf("Responding to request: %s (TransportProductList)", md.RequestID)
 
 	filteredTrips := filterPropertiesByLastModified(mockdata.TripsBasicV3, req.GetModifiedAfter().AsTime())
@@ -58,10 +51,6 @@ func (s *transportProductListV3Server) TransportProductList(ctx context.Context,
 	}
 
 	log.Printf("CMAccount %s received request from CMAccount %s", md.RecipientCMAccount, md.SenderCMAccount)
-
-	if err := grpc.SetHeader(ctx, md.ToGrpcMD()); err != nil {
-		log.Printf("Failed to set header: %v", err)
-	}
 
 	return response, nil
 }

--- a/pp-mock/handlers/transport/v3/transport_search.go
+++ b/pp-mock/handlers/transport/v3/transport_search.go
@@ -21,7 +21,6 @@ import (
 	"github.com/chain4travel/camino-messenger-bot/v11/pp-mock/handlers/state"
 	mockdata "github.com/chain4travel/camino-messenger-bot/v11/pp-mock/services/data"
 	"github.com/google/uuid"
-	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -40,14 +39,8 @@ func (s *transportSearchV3Server) TransportSearch(ctx context.Context, req *tran
 		log.Printf("error sending event: %v", err)
 	}
 
-	md := metadata.Metadata{}
+	md := metadata.FromGRPCContext(ctx)
 
-	err := md.ExtractMetadata(ctx)
-	if err != nil {
-		log.Print("error extracting metadata")
-	}
-
-	md.Stamp(fmt.Sprintf("%s-%s", "ext-system", "response"))
 	log.Printf("Responding to request: %s (TransportSearch) v3", md.RequestID)
 
 	// if there is no query, return no results
@@ -269,10 +262,6 @@ func (s *transportSearchV3Server) TransportSearch(ctx context.Context, req *tran
 	}
 
 	log.Printf("CMAccount %s received request from CMAccount %s", md.RecipientCMAccount, md.SenderCMAccount)
-
-	if err := grpc.SetHeader(ctx, md.ToGrpcMD()); err != nil {
-		log.Printf("Failed to set header: %v", err)
-	}
 
 	if len(searchResults) > 0 {
 		state.GetStore().AddSearchResult(response.Metadata.SearchId.Value, state.SearchData{

--- a/tests/e2e/tests/test_accommodation_v2.go
+++ b/tests/e2e/tests/test_accommodation_v2.go
@@ -16,7 +16,6 @@ import (
 	typesv2 "buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go/cmp/types/v2"
 	botGenerated "github.com/chain4travel/camino-messenger-bot/v11/internal/rpc/generated"
 	"github.com/chain4travel/camino-messenger-bot/v11/pkg/booking"
-	"github.com/chain4travel/camino-messenger-bot/v11/pkg/metadata"
 	"github.com/chain4travel/camino-messenger-bot/v11/pkg/price"
 	"github.com/chain4travel/camino-messenger-bot/v11/pp-mock/common"
 	"github.com/chain4travel/camino-messenger-bot/v11/tests/e2e/bot"
@@ -83,9 +82,7 @@ func testAccommodationV2ProductListService(
 		Header: &typesv1.RequestHeader{BaseHeader: &typesv1.Header{}},
 	}
 	resp, err := distributorBot.AccommodationProductListServiceV2.AccommodationProductList(
-		requestContext(ctx, &metadata.Metadata{
-			RecipientCMAccount: supplierBot.CMAccountAddress().Hex(),
-		}),
+		requestContext(ctx, supplierBot.CMAccountAddress()),
 		req,
 	)
 	require.NoError(t, err)
@@ -124,9 +121,7 @@ func testAccommodationV2ProductListServiceWithFilter(
 		},
 	}
 	resp, err := distributorBot.AccommodationProductListServiceV2.AccommodationProductList(
-		requestContext(ctx, &metadata.Metadata{
-			RecipientCMAccount: supplierBot.CMAccountAddress().Hex(),
-		}),
+		requestContext(ctx, supplierBot.CMAccountAddress()),
 		req,
 	)
 	require.NoError(t, err)
@@ -160,9 +155,7 @@ func testAccommodationV2ProductInfoService(
 		},
 	}
 	resp, err := distributorBot.AccommodationProductInfoServiceV2.AccommodationProductInfo(
-		requestContext(ctx, &metadata.Metadata{
-			RecipientCMAccount: supplierBot.CMAccountAddress().Hex(),
-		}),
+		requestContext(ctx, supplierBot.CMAccountAddress()),
 		req,
 	)
 	require.NoError(t, err)
@@ -217,9 +210,7 @@ func testAccommodationV2SearchServiceWithoutCurrency(
 		}},
 	}
 	resp, err := distributorBot.AccommodationSearchServiceV2.AccommodationSearch(
-		requestContext(ctx, &metadata.Metadata{
-			RecipientCMAccount: supplierBot.CMAccountAddress().Hex(),
-		}),
+		requestContext(ctx, supplierBot.CMAccountAddress()),
 		req,
 	)
 	require.NoError(t, err)
@@ -251,9 +242,7 @@ func testAccommodationV2SearchServiceWithoutTravelPeriod(
 		}},
 	}
 	resp, err := distributorBot.AccommodationSearchServiceV2.AccommodationSearch(
-		requestContext(ctx, &metadata.Metadata{
-			RecipientCMAccount: supplierBot.CMAccountAddress().Hex(),
-		}),
+		requestContext(ctx, supplierBot.CMAccountAddress()),
 		req,
 	)
 	require.NoError(t, err)
@@ -293,9 +282,7 @@ func testAccommodationV2SearchServiceTravelPeriodOutOfBounds(
 		}},
 	}
 	resp, err := distributorBot.AccommodationSearchServiceV2.AccommodationSearch(
-		requestContext(ctx, &metadata.Metadata{
-			RecipientCMAccount: supplierBot.CMAccountAddress().Hex(),
-		}),
+		requestContext(ctx, supplierBot.CMAccountAddress()),
 		req,
 	)
 	require.NoError(t, err)
@@ -335,9 +322,7 @@ func testAccommodationV2SearchServiceTravelPeriodReversed(
 		}},
 	}
 	resp, err := distributorBot.AccommodationSearchServiceV2.AccommodationSearch(
-		requestContext(ctx, &metadata.Metadata{
-			RecipientCMAccount: supplierBot.CMAccountAddress().Hex(),
-		}),
+		requestContext(ctx, supplierBot.CMAccountAddress()),
 		req,
 	)
 	require.NoError(t, err)
@@ -380,9 +365,7 @@ func testAccommodationV2SearchServiceWithTravelPeriod(
 		}},
 	}
 	resp, err := distributorBot.AccommodationSearchServiceV2.AccommodationSearch(
-		requestContext(ctx, &metadata.Metadata{
-			RecipientCMAccount: supplierBot.CMAccountAddress().Hex(),
-		}),
+		requestContext(ctx, supplierBot.CMAccountAddress()),
 		req,
 	)
 	require.NoError(t, err)
@@ -441,9 +424,7 @@ func testAccommodationV2ValidateV2(
 		},
 	}
 	resp, err := distributorBot.ValidationServiceV2.Validation(
-		requestContext(ctx, &metadata.Metadata{
-			RecipientCMAccount: supplierBot.CMAccountAddress().Hex(),
-		}),
+		requestContext(ctx, supplierBot.CMAccountAddress()),
 		req,
 	)
 	require.NoError(t, err)
@@ -491,9 +472,7 @@ func testAccommodationV2MintV2(
 		ValidationId: &typesv1.UUID{Value: validationID},
 	}
 	resp, err := distributorBot.MintServiceV2.Mint(
-		requestContext(ctx, &metadata.Metadata{
-			RecipientCMAccount: supplierBot.CMAccountAddress().Hex(),
-		}),
+		requestContext(ctx, supplierBot.CMAccountAddress()),
 		req,
 	)
 	require.NoError(t, err)

--- a/tests/e2e/tests/test_accommodation_v3.go
+++ b/tests/e2e/tests/test_accommodation_v3.go
@@ -18,7 +18,6 @@ import (
 	typesv3 "buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go/cmp/types/v3"
 	botGenerated "github.com/chain4travel/camino-messenger-bot/v11/internal/rpc/generated"
 	"github.com/chain4travel/camino-messenger-bot/v11/pkg/booking"
-	"github.com/chain4travel/camino-messenger-bot/v11/pkg/metadata"
 	"github.com/chain4travel/camino-messenger-bot/v11/pkg/price"
 	"github.com/chain4travel/camino-messenger-bot/v11/pp-mock/common"
 	"github.com/chain4travel/camino-messenger-bot/v11/tests/e2e/bot"
@@ -85,9 +84,7 @@ func testAccommodationV3ProductListService(
 		Header: &typesv1.RequestHeader{BaseHeader: &typesv1.Header{}},
 	}
 	resp, err := distributorBot.AccommodationProductListServiceV3.AccommodationProductList(
-		requestContext(ctx, &metadata.Metadata{
-			RecipientCMAccount: supplierBot.CMAccountAddress().Hex(),
-		}),
+		requestContext(ctx, supplierBot.CMAccountAddress()),
 		req,
 	)
 	require.NoError(t, err)
@@ -126,9 +123,7 @@ func testAccommodationV3ProductListServiceWithFilter(
 		},
 	}
 	resp, err := distributorBot.AccommodationProductListServiceV3.AccommodationProductList(
-		requestContext(ctx, &metadata.Metadata{
-			RecipientCMAccount: supplierBot.CMAccountAddress().Hex(),
-		}),
+		requestContext(ctx, supplierBot.CMAccountAddress()),
 		req,
 	)
 	require.NoError(t, err)
@@ -162,9 +157,7 @@ func testAccommodationV3ProductInfoService(
 		},
 	}
 	resp, err := distributorBot.AccommodationProductInfoServiceV3.AccommodationProductInfo(
-		requestContext(ctx, &metadata.Metadata{
-			RecipientCMAccount: supplierBot.CMAccountAddress().Hex(),
-		}),
+		requestContext(ctx, supplierBot.CMAccountAddress()),
 		req,
 	)
 	require.NoError(t, err)
@@ -219,9 +212,7 @@ func testAccommodationV3SearchServiceWithoutCurrency(
 		}},
 	}
 	resp, err := distributorBot.AccommodationSearchServiceV3.AccommodationSearch(
-		requestContext(ctx, &metadata.Metadata{
-			RecipientCMAccount: supplierBot.CMAccountAddress().Hex(),
-		}),
+		requestContext(ctx, supplierBot.CMAccountAddress()),
 		req,
 	)
 	require.NoError(t, err)
@@ -253,9 +244,7 @@ func testAccommodationV3SearchServiceWithoutTravelPeriod(
 		}},
 	}
 	resp, err := distributorBot.AccommodationSearchServiceV3.AccommodationSearch(
-		requestContext(ctx, &metadata.Metadata{
-			RecipientCMAccount: supplierBot.CMAccountAddress().Hex(),
-		}),
+		requestContext(ctx, supplierBot.CMAccountAddress()),
 		req,
 	)
 	require.NoError(t, err)
@@ -295,9 +284,7 @@ func testAccommodationV3SearchServiceTravelPeriodOutOfBounds(
 		}},
 	}
 	resp, err := distributorBot.AccommodationSearchServiceV3.AccommodationSearch(
-		requestContext(ctx, &metadata.Metadata{
-			RecipientCMAccount: supplierBot.CMAccountAddress().Hex(),
-		}),
+		requestContext(ctx, supplierBot.CMAccountAddress()),
 		req,
 	)
 	require.NoError(t, err)
@@ -337,9 +324,7 @@ func testAccommodationV3SearchServiceTravelPeriodReversed(
 		}},
 	}
 	resp, err := distributorBot.AccommodationSearchServiceV3.AccommodationSearch(
-		requestContext(ctx, &metadata.Metadata{
-			RecipientCMAccount: supplierBot.CMAccountAddress().Hex(),
-		}),
+		requestContext(ctx, supplierBot.CMAccountAddress()),
 		req,
 	)
 	require.NoError(t, err)
@@ -382,9 +367,7 @@ func testAccommodationV3SearchServiceWithTravelPeriod(
 		}},
 	}
 	resp, err := distributorBot.AccommodationSearchServiceV3.AccommodationSearch(
-		requestContext(ctx, &metadata.Metadata{
-			RecipientCMAccount: supplierBot.CMAccountAddress().Hex(),
-		}),
+		requestContext(ctx, supplierBot.CMAccountAddress()),
 		req,
 	)
 	require.NoError(t, err)
@@ -443,9 +426,7 @@ func testAccommodationV3ValidateV2(
 		},
 	}
 	resp, err := distributorBot.ValidationServiceV2.Validation(
-		requestContext(ctx, &metadata.Metadata{
-			RecipientCMAccount: supplierBot.CMAccountAddress().Hex(),
-		}),
+		requestContext(ctx, supplierBot.CMAccountAddress()),
 		req,
 	)
 	require.NoError(t, err)
@@ -494,9 +475,7 @@ func testAccommodationV3MintV2(
 		ValidationId: &typesv1.UUID{Value: validationID},
 	}
 	resp, err := distributorBot.MintServiceV2.Mint(
-		requestContext(ctx, &metadata.Metadata{
-			RecipientCMAccount: supplierBot.CMAccountAddress().Hex(),
-		}),
+		requestContext(ctx, supplierBot.CMAccountAddress()),
 		req,
 	)
 	require.NoError(t, err)

--- a/tests/e2e/tests/test_bot_sanity.go
+++ b/tests/e2e/tests/test_bot_sanity.go
@@ -12,7 +12,6 @@ import (
 	typesv1 "buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go/cmp/types/v1"
 	botGenerated "github.com/chain4travel/camino-messenger-bot/v11/internal/rpc/generated"
 	cmaccounts "github.com/chain4travel/camino-messenger-bot/v11/pkg/cm_accounts"
-	"github.com/chain4travel/camino-messenger-bot/v11/pkg/metadata"
 	"github.com/chain4travel/camino-messenger-bot/v11/tests/e2e/blockchain"
 	"github.com/chain4travel/camino-messenger-bot/v11/tests/e2e/bot"
 	partnerplugin "github.com/chain4travel/camino-messenger-bot/v11/tests/e2e/partner_plugin"
@@ -132,9 +131,7 @@ func testBotSanitySendCommonRequest(ctx context.Context, pingMessage string, dis
 		Timestamp:   timestamppb.Now(),
 	}
 	_, err := distributorBot.PingServiceV1.Ping(
-		requestContext(ctx, &metadata.Metadata{
-			RecipientCMAccount: supplierBot.CMAccountAddress().Hex(),
-		}),
+		requestContext(ctx, supplierBot.CMAccountAddress()),
 		req,
 	)
 	return err

--- a/tests/e2e/tests/test_cancellation_v1.go
+++ b/tests/e2e/tests/test_cancellation_v1.go
@@ -15,7 +15,6 @@ import (
 	typesv1 "buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go/cmp/types/v1"
 	typesv3 "buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go/cmp/types/v3"
 	botGenerated "github.com/chain4travel/camino-messenger-bot/v11/internal/rpc/generated"
-	"github.com/chain4travel/camino-messenger-bot/v11/pkg/metadata"
 	"github.com/chain4travel/camino-messenger-bot/v11/pkg/price"
 	"github.com/chain4travel/camino-messenger-bot/v11/pp-mock/common"
 	cancellation_handlers "github.com/chain4travel/camino-messenger-bot/v11/pp-mock/handlers/cancellation/v1"
@@ -109,9 +108,7 @@ func testAccommodationV3MintV3(
 		ValidationId: &typesv1.UUID{Value: validationID},
 	}
 	resp, err := distributorBot.MintServiceV3.Mint(
-		requestContext(ctx, &metadata.Metadata{
-			RecipientCMAccount: supplierBot.CMAccountAddress().Hex(),
-		}),
+		requestContext(ctx, supplierBot.CMAccountAddress()),
 		req,
 	)
 	require.NoError(t, err)
@@ -354,9 +351,7 @@ func testCheckCancellationV1(
 		Reason:  cancellationv1.CancellationReason_CANCELLATION_REASON_AMENITY_REQUIREMENT_CHANGE,
 	}
 	resp, err := distributorBot.CheckCancellationServiceV1.CheckCancellation(
-		requestContext(ctx, &metadata.Metadata{
-			RecipientCMAccount: supplierBot.CMAccountAddress().Hex(),
-		}),
+		requestContext(ctx, supplierBot.CMAccountAddress()),
 		req,
 	)
 	require.NoError(t, err)

--- a/tests/e2e/tests/test_mint_v2.go
+++ b/tests/e2e/tests/test_mint_v2.go
@@ -11,7 +11,6 @@ import (
 	notificationv2 "buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go/cmp/services/notification/v2"
 	typesv1 "buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go/cmp/types/v1"
 	botGenerated "github.com/chain4travel/camino-messenger-bot/v11/internal/rpc/generated"
-	"github.com/chain4travel/camino-messenger-bot/v11/pkg/metadata"
 	"github.com/chain4travel/camino-messenger-bot/v11/pp-mock/proto/pb/events"
 	"github.com/chain4travel/camino-messenger-bot/v11/tests/e2e/bot"
 	partnerplugin "github.com/chain4travel/camino-messenger-bot/v11/tests/e2e/partner_plugin"
@@ -106,9 +105,7 @@ func testMintV2MintV2ExpectedError(
 		ValidationId: &typesv1.UUID{Value: validationID},
 	}
 	resp, err := distributorBot.MintServiceV2.Mint(
-		requestContext(ctx, &metadata.Metadata{
-			RecipientCMAccount: supplierBot.CMAccountAddress().Hex(),
-		}),
+		requestContext(ctx, supplierBot.CMAccountAddress()),
 		req,
 	)
 	require.NoError(t, err)

--- a/tests/e2e/tests/test_ping.go
+++ b/tests/e2e/tests/test_ping.go
@@ -11,7 +11,6 @@ import (
 	pingv1 "buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go/cmp/services/ping/v1"
 	typesv1 "buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go/cmp/types/v1"
 	botGenerated "github.com/chain4travel/camino-messenger-bot/v11/internal/rpc/generated"
-	"github.com/chain4travel/camino-messenger-bot/v11/pkg/metadata"
 	"github.com/chain4travel/camino-messenger-bot/v11/tests/e2e/bot"
 	partnerplugin "github.com/chain4travel/camino-messenger-bot/v11/tests/e2e/partner_plugin"
 	"github.com/stretchr/testify/require"
@@ -44,9 +43,7 @@ func testPingV1Service(ctx context.Context, t *testing.T, tt *Test, distributorB
 		Timestamp:   timestamppb.Now(),
 	}
 	resp, err := distributorBot.PingServiceV1.Ping(
-		requestContext(ctx, &metadata.Metadata{
-			RecipientCMAccount: supplierBot.CMAccountAddress().Hex(),
-		}),
+		requestContext(ctx, supplierBot.CMAccountAddress()),
 		req,
 	)
 

--- a/tests/e2e/tests/test_transport_v3.go
+++ b/tests/e2e/tests/test_transport_v3.go
@@ -18,7 +18,6 @@ import (
 	typesv3 "buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go/cmp/types/v3"
 	botGenerated "github.com/chain4travel/camino-messenger-bot/v11/internal/rpc/generated"
 	"github.com/chain4travel/camino-messenger-bot/v11/pkg/booking"
-	"github.com/chain4travel/camino-messenger-bot/v11/pkg/metadata"
 	"github.com/chain4travel/camino-messenger-bot/v11/pkg/price"
 	"github.com/chain4travel/camino-messenger-bot/v11/pp-mock/common"
 	"github.com/chain4travel/camino-messenger-bot/v11/tests/e2e/bot"
@@ -89,9 +88,7 @@ func testTransportV3ProductListService(
 		Header: &typesv1.RequestHeader{BaseHeader: &typesv1.Header{}},
 	}
 	resp, err := distributorBot.TransportProductListServiceV3.TransportProductList(
-		requestContext(ctx, &metadata.Metadata{
-			RecipientCMAccount: supplierBot.CMAccountAddress().Hex(),
-		}),
+		requestContext(ctx, supplierBot.CMAccountAddress()),
 		req,
 	)
 	require.NoError(t, err)
@@ -148,9 +145,7 @@ func testTransportV3ProductListServiceWithFilter(
 		},
 	}
 	resp, err := distributorBot.TransportProductListServiceV3.TransportProductList(
-		requestContext(ctx, &metadata.Metadata{
-			RecipientCMAccount: supplierBot.CMAccountAddress().Hex(),
-		}),
+		requestContext(ctx, supplierBot.CMAccountAddress()),
 		req,
 	)
 	require.NoError(t, err)
@@ -189,9 +184,7 @@ func testTransportV3SearchServiceWithoutQuery(
 		Queries: []*transportv3.TransportSearchQuery{},
 	}
 	resp, err := distributorBot.TransportSearchServiceV3.TransportSearch(
-		requestContext(ctx, &metadata.Metadata{
-			RecipientCMAccount: supplierBot.CMAccountAddress().Hex(),
-		}),
+		requestContext(ctx, supplierBot.CMAccountAddress()),
 		req,
 	)
 	require.NoError(t, err)
@@ -276,9 +269,7 @@ func testTransportV3SearchServiceTravelDatesReversed(
 		},
 	}
 	resp, err := distributorBot.TransportSearchServiceV3.TransportSearch(
-		requestContext(ctx, &metadata.Metadata{
-			RecipientCMAccount: supplierBot.CMAccountAddress().Hex(),
-		}),
+		requestContext(ctx, supplierBot.CMAccountAddress()),
 		req,
 	)
 	require.NoError(t, err)
@@ -362,9 +353,7 @@ func testTransportV3SearchServiceTravelDatesWrong(
 		},
 	}
 	resp, err := distributorBot.TransportSearchServiceV3.TransportSearch(
-		requestContext(ctx, &metadata.Metadata{
-			RecipientCMAccount: supplierBot.CMAccountAddress().Hex(),
-		}),
+		requestContext(ctx, supplierBot.CMAccountAddress()),
 		req,
 	)
 	require.NoError(t, err)
@@ -455,9 +444,7 @@ func testTransportV3SearchServiceTravelWithoutArrivalDate(
 	}
 
 	resp, err := distributorBot.TransportSearchServiceV3.TransportSearch(
-		requestContext(ctx, &metadata.Metadata{
-			RecipientCMAccount: supplierBot.CMAccountAddress().Hex(),
-		}),
+		requestContext(ctx, supplierBot.CMAccountAddress()),
 		req,
 	)
 	require.NoError(t, err)
@@ -557,9 +544,7 @@ func testTransportV3SearchServiceWithoutArrivalLocation(
 		},
 	}
 	resp, err := distributorBot.TransportSearchServiceV3.TransportSearch(
-		requestContext(ctx, &metadata.Metadata{
-			RecipientCMAccount: supplierBot.CMAccountAddress().Hex(),
-		}),
+		requestContext(ctx, supplierBot.CMAccountAddress()),
 		req,
 	)
 	require.NoError(t, err)
@@ -654,9 +639,7 @@ func testTransportV3SearchServiceWithFilters(
 		},
 	}
 	resp, err := distributorBot.TransportSearchServiceV3.TransportSearch(
-		requestContext(ctx, &metadata.Metadata{
-			RecipientCMAccount: supplierBot.CMAccountAddress().Hex(),
-		}),
+		requestContext(ctx, supplierBot.CMAccountAddress()),
 		req,
 	)
 	require.NoError(t, err)
@@ -714,9 +697,7 @@ func testTransportV3ValidateV2(
 		},
 	}
 	resp, err := distributorBot.ValidationServiceV2.Validation(
-		requestContext(ctx, &metadata.Metadata{
-			RecipientCMAccount: supplierBot.CMAccountAddress().Hex(),
-		}),
+		requestContext(ctx, supplierBot.CMAccountAddress()),
 		req,
 	)
 	require.NoError(t, err)
@@ -765,9 +746,7 @@ func testTransportV3MintV2(
 		ValidationId: &typesv1.UUID{Value: validationID},
 	}
 	resp, err := distributorBot.MintServiceV2.Mint(
-		requestContext(ctx, &metadata.Metadata{
-			RecipientCMAccount: supplierBot.CMAccountAddress().Hex(),
-		}),
+		requestContext(ctx, supplierBot.CMAccountAddress()),
 		req,
 	)
 	require.NoError(t, err)

--- a/tests/e2e/tests/utils.go
+++ b/tests/e2e/tests/utils.go
@@ -12,7 +12,7 @@ import (
 
 	typesv2 "buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go/cmp/types/v2"
 	"github.com/chain4travel/camino-messenger-bot/v11/pkg/booking"
-	messageMetadata "github.com/chain4travel/camino-messenger-bot/v11/pkg/metadata"
+	"github.com/chain4travel/camino-messenger-bot/v11/pkg/metadata"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
@@ -28,8 +28,10 @@ const (
 	Distributor
 )
 
-func requestContext(ctx context.Context, metadata *messageMetadata.Metadata) context.Context {
-	return grpcMetadata.NewOutgoingContext(ctx, metadata.ToGrpcMD())
+func requestContext(ctx context.Context, recipientCMAccount common.Address) context.Context {
+	return grpcMetadata.NewOutgoingContext(ctx, grpcMetadata.Pairs(
+		metadata.KeyRecipientCMAccount, recipientCMAccount.Hex(),
+	))
 }
 
 // Gets the current function name including the whole package path


### PR DESCRIPTION
Previously, bot had one metadata structure for all layers: be it external grpc request, matrix events, core or partner plugin grpc.
But amount of required to transport data was very different on each layer. It will get even worse, when messages structure will be split into private and public parts with upcoming e2e encryption.
This PR does some preparation in cleaning up metadata usage.