### PR TITLE
Matrix eventContent: verify chunk index

### DIFF
--- a/internal/matrix/messenger/messages.go
+++ b/internal/matrix/messenger/messages.go
@@ -49,7 +49,7 @@ func (m *messenger) SendMessage(ctx context.Context, msg *messaging.EncodedSigne
 	}
 
 	messageEvent := matrix.SignedMessageEventContent{
-		MessageChunkEventContent: matrix.MessageChunkEventContent{
+		ChunkData: matrix.ChunkData{
 			MessageID: messageID,
 			Data:      msg.ChunkedEncodedMessage[0],
 		},
@@ -63,9 +63,11 @@ func (m *messenger) SendMessage(ctx context.Context, msg *messaging.EncodedSigne
 		chunkEvents = make([]matrix.MessageChunkEventContent, 0, len(msg.ChunkedEncodedMessage)-1)
 		for i, chunk := range msg.ChunkedEncodedMessage[1:] {
 			chunkEvents = append(chunkEvents, matrix.MessageChunkEventContent{
-				MessageID:  messageID,
-				ChunkIndex: conversion.MustIntToUInt32(i + 1),
-				Data:       chunk,
+				ChunkData: matrix.ChunkData{
+					MessageID:  messageID,
+					ChunkIndex: conversion.MustIntToUInt32(i + 1),
+					Data:       chunk,
+				},
 			})
 		}
 	}
@@ -202,7 +204,7 @@ func (m *messenger) addMessageFirstChunk(eventContent *matrix.SignedMessageEvent
 	message.chunksCount = eventContent.ChunksCount
 	message.fromCMAccount = eventContent.NetworkFeeCheque.FromCMAccount
 
-	return m.addMessageChunk(message, &eventContent.MessageChunkEventContent)
+	return m.addMessageChunk(message, &eventContent.ChunkData)
 }
 
 func (m *messenger) addMessageNextChunk(eventContent *matrix.MessageChunkEventContent) (*chunkedMessage, bool) {
@@ -215,20 +217,20 @@ func (m *messenger) addMessageNextChunk(eventContent *matrix.MessageChunkEventCo
 		m.chunkedMessages[eventContent.MessageID] = message
 	}
 
-	return m.addMessageChunk(message, eventContent)
+	return m.addMessageChunk(message, &eventContent.ChunkData)
 }
 
-func (m *messenger) addMessageChunk(message *chunkedMessage, eventContent *matrix.MessageChunkEventContent) (*chunkedMessage, bool) {
+func (m *messenger) addMessageChunk(message *chunkedMessage, chunkData *matrix.ChunkData) (*chunkedMessage, bool) {
 	message.chunks = append(message.chunks, messageChunk{
-		index: eventContent.ChunkIndex,
-		data:  eventContent.Data,
+		index: chunkData.ChunkIndex,
+		data:  chunkData.Data,
 	})
 
 	if message.chunksCount == 0 || conversion.MustIntToUInt32(len(message.chunks)) < message.chunksCount {
 		return nil, false
 	}
 
-	delete(m.chunkedMessages, eventContent.MessageID)
+	delete(m.chunkedMessages, chunkData.MessageID)
 
 	return message, true
 }

--- a/internal/matrix/messenger/messages.go
+++ b/internal/matrix/messenger/messages.go
@@ -64,10 +64,10 @@ func (m *messenger) SendMessage(ctx context.Context, msg *messaging.EncodedSigne
 		for i, chunk := range msg.ChunkedEncodedMessage[1:] {
 			chunkEvents = append(chunkEvents, matrix.MessageChunkEventContent{
 				ChunkData: matrix.ChunkData{
-					MessageID:  messageID,
-					ChunkIndex: conversion.MustIntToUInt32(i + 1),
-					Data:       chunk,
+					MessageID: messageID,
+					Data:      chunk,
 				},
+				ChunkIndex: conversion.MustIntToUInt32(i + 1),
 			})
 		}
 	}
@@ -204,7 +204,7 @@ func (m *messenger) addMessageFirstChunk(eventContent *matrix.SignedMessageEvent
 	message.chunksCount = eventContent.ChunksCount
 	message.fromCMAccount = eventContent.NetworkFeeCheque.FromCMAccount
 
-	return m.addMessageChunk(message, &eventContent.ChunkData)
+	return m.addMessageChunk(message, &eventContent.ChunkData, 0)
 }
 
 func (m *messenger) addMessageNextChunk(eventContent *matrix.MessageChunkEventContent) (*chunkedMessage, bool) {
@@ -217,12 +217,12 @@ func (m *messenger) addMessageNextChunk(eventContent *matrix.MessageChunkEventCo
 		m.chunkedMessages[eventContent.MessageID] = message
 	}
 
-	return m.addMessageChunk(message, &eventContent.ChunkData)
+	return m.addMessageChunk(message, &eventContent.ChunkData, eventContent.ChunkIndex)
 }
 
-func (m *messenger) addMessageChunk(message *chunkedMessage, chunkData *matrix.ChunkData) (*chunkedMessage, bool) {
+func (m *messenger) addMessageChunk(message *chunkedMessage, chunkData *matrix.ChunkData, chunkIndex uint32) (*chunkedMessage, bool) {
 	message.chunks = append(message.chunks, messageChunk{
-		index: chunkData.ChunkIndex,
+		index: chunkIndex,
 		data:  chunkData.Data,
 	})
 

--- a/internal/matrix/messenger/messages_test.go
+++ b/internal/matrix/messenger/messages_test.go
@@ -235,10 +235,10 @@ func TestTryCompleteMessage(t *testing.T) {
 		"Chunk is first": {
 			msgEventContent: &matrix.MessageChunkEventContent{
 				ChunkData: matrix.ChunkData{
-					MessageID:  messageID,
-					Data:       []byte("chunk1"),
-					ChunkIndex: 1,
+					MessageID: messageID,
+					Data:      []byte("chunk1"),
 				},
+				ChunkIndex: 1,
 			},
 			expectedChunkedMessages: map[string]*chunkedMessage{
 				messageID: {
@@ -251,10 +251,10 @@ func TestTryCompleteMessage(t *testing.T) {
 		"Chunk is second": {
 			msgEventContent: &matrix.MessageChunkEventContent{
 				ChunkData: matrix.ChunkData{
-					MessageID:  messageID,
-					Data:       []byte("chunk2"),
-					ChunkIndex: 2,
+					MessageID: messageID,
+					Data:      []byte("chunk2"),
 				},
+				ChunkIndex: 2,
 			},
 			existingChunkedMessages: map[string]*chunkedMessage{
 				messageID: {
@@ -275,10 +275,10 @@ func TestTryCompleteMessage(t *testing.T) {
 		"Chunk is last": {
 			msgEventContent: &matrix.MessageChunkEventContent{
 				ChunkData: matrix.ChunkData{
-					MessageID:  messageID,
-					Data:       []byte("chunk1"),
-					ChunkIndex: 1,
+					MessageID: messageID,
+					Data:      []byte("chunk1"),
 				},
+				ChunkIndex: 1,
 			},
 			existingChunkedMessages: map[string]*chunkedMessage{
 				messageID: {

--- a/internal/matrix/messenger/messages_test.go
+++ b/internal/matrix/messenger/messages_test.go
@@ -66,7 +66,7 @@ func TestTryCompleteMessageWithFirstChunk(t *testing.T) {
 	}{
 		"Single-chunk message": {
 			msgEventContent: &matrix.SignedMessageEventContent{
-				MessageChunkEventContent: matrix.MessageChunkEventContent{
+				ChunkData: matrix.ChunkData{
 					MessageID: messageID,
 					Data:      []byte("single chunk data"),
 				},
@@ -85,7 +85,7 @@ func TestTryCompleteMessageWithFirstChunk(t *testing.T) {
 		},
 		"First chunk is actually first": {
 			msgEventContent: &matrix.SignedMessageEventContent{
-				MessageChunkEventContent: matrix.MessageChunkEventContent{
+				ChunkData: matrix.ChunkData{
 					MessageID: messageID,
 					Data:      []byte("chunk0"),
 				},
@@ -106,7 +106,7 @@ func TestTryCompleteMessageWithFirstChunk(t *testing.T) {
 		},
 		"First chunk is second": {
 			msgEventContent: &matrix.SignedMessageEventContent{
-				MessageChunkEventContent: matrix.MessageChunkEventContent{
+				ChunkData: matrix.ChunkData{
 					MessageID: messageID,
 					Data:      []byte("chunk0"),
 				},
@@ -135,7 +135,7 @@ func TestTryCompleteMessageWithFirstChunk(t *testing.T) {
 		},
 		"First chunk is last": {
 			msgEventContent: &matrix.SignedMessageEventContent{
-				MessageChunkEventContent: matrix.MessageChunkEventContent{
+				ChunkData: matrix.ChunkData{
 					MessageID: messageID,
 					Data:      []byte("chunk0"),
 				},
@@ -234,9 +234,11 @@ func TestTryCompleteMessage(t *testing.T) {
 	}{
 		"Chunk is first": {
 			msgEventContent: &matrix.MessageChunkEventContent{
-				MessageID:  messageID,
-				Data:       []byte("chunk1"),
-				ChunkIndex: 1,
+				ChunkData: matrix.ChunkData{
+					MessageID:  messageID,
+					Data:       []byte("chunk1"),
+					ChunkIndex: 1,
+				},
 			},
 			expectedChunkedMessages: map[string]*chunkedMessage{
 				messageID: {
@@ -248,9 +250,11 @@ func TestTryCompleteMessage(t *testing.T) {
 		},
 		"Chunk is second": {
 			msgEventContent: &matrix.MessageChunkEventContent{
-				MessageID:  messageID,
-				Data:       []byte("chunk2"),
-				ChunkIndex: 2,
+				ChunkData: matrix.ChunkData{
+					MessageID:  messageID,
+					Data:       []byte("chunk2"),
+					ChunkIndex: 2,
+				},
 			},
 			existingChunkedMessages: map[string]*chunkedMessage{
 				messageID: {
@@ -270,9 +274,11 @@ func TestTryCompleteMessage(t *testing.T) {
 		},
 		"Chunk is last": {
 			msgEventContent: &matrix.MessageChunkEventContent{
-				MessageID:  messageID,
-				Data:       []byte("chunk1"),
-				ChunkIndex: 1,
+				ChunkData: matrix.ChunkData{
+					MessageID:  messageID,
+					Data:       []byte("chunk1"),
+					ChunkIndex: 1,
+				},
 			},
 			existingChunkedMessages: map[string]*chunkedMessage{
 				messageID: {

--- a/pkg/matrix/events.go
+++ b/pkg/matrix/events.go
@@ -28,6 +28,8 @@ func init() {
 
 type MessageChunkEventContent struct {
 	ChunkData
+
+	ChunkIndex uint32
 }
 
 func (e *MessageChunkEventContent) Verify() error {
@@ -49,16 +51,12 @@ func (e *SignedMessageEventContent) Verify() error {
 	if e.ChunksCount == 0 {
 		return ErrNoChunks
 	}
-	if e.ChunkIndex != 0 {
-		return ErrWrongChunkIndex
-	}
 	return e.ChunkData.Verify()
 }
 
 type ChunkData struct {
-	MessageID  string
-	ChunkIndex uint32 `json:"omitempty"`
-	Data       []byte
+	MessageID string
+	Data      []byte
 }
 
 func (c *ChunkData) Verify() error {

--- a/pkg/matrix/events.go
+++ b/pkg/matrix/events.go
@@ -15,9 +15,10 @@ var (
 	EventTypeSignedMessage = event.Type{Type: "m.room.c4t-signed-msg", Class: event.MessageEventType}
 	EventTypeMessageChunk  = event.Type{Type: "m.room.c4t-msg-chunk", Class: event.MessageEventType}
 
-	ErrNoChunks    = errors.New("zero chunks count")
-	ErrNoData      = errors.New("no data in message chunk")
-	ErrNoMessageID = errors.New("missing message ID")
+	ErrWrongChunkIndex = errors.New("wrong chunk index")
+	ErrNoChunks        = errors.New("zero chunks count")
+	ErrNoData          = errors.New("no data in message chunk")
+	ErrNoMessageID     = errors.New("missing message ID")
 )
 
 func init() {
@@ -26,32 +27,46 @@ func init() {
 }
 
 type MessageChunkEventContent struct {
-	MessageID  string `json:"message_id"`
-	ChunkIndex uint32 `json:"chunk_index,omitempty"`
-	Data       []byte `json:"data"`
+	ChunkData
 }
 
 func (e *MessageChunkEventContent) Verify() error {
-	if len(e.Data) == 0 {
-		return ErrNoData
+	if e.ChunkIndex == 0 {
+		return ErrWrongChunkIndex
 	}
-	if e.MessageID == "" {
-		return ErrNoMessageID
-	}
-	return nil
+	return e.ChunkData.Verify()
 }
 
 type SignedMessageEventContent struct {
-	MessageChunkEventContent
+	ChunkData
 
-	ChunksCount      uint32               `json:"chunks_count"`
-	Signature        []byte               `json:"signature"`
-	NetworkFeeCheque cheques.SignedCheque `json:"network_fee_cheque"`
+	ChunksCount      uint32
+	Signature        []byte
+	NetworkFeeCheque cheques.SignedCheque
 }
 
 func (e *SignedMessageEventContent) Verify() error {
 	if e.ChunksCount == 0 {
 		return ErrNoChunks
 	}
-	return e.MessageChunkEventContent.Verify()
+	if e.ChunkIndex != 0 {
+		return ErrWrongChunkIndex
+	}
+	return e.ChunkData.Verify()
+}
+
+type ChunkData struct {
+	MessageID  string
+	ChunkIndex uint32 `json:"omitempty"`
+	Data       []byte
+}
+
+func (c *ChunkData) Verify() error {
+	if len(c.Data) == 0 {
+		return ErrNoData
+	}
+	if c.MessageID == "" {
+		return ErrNoMessageID
+	}
+	return nil
 }


### PR DESCRIPTION
We have very clear value ranges for both type of events, so why not verify it instead of accepting bad events?
PR restructures events structures and adds necessary verification.