### PR TITLE
Make e2e tests bots setup in parallel

### DIFF
--- a/cmd/camino_messenger_bot.go
+++ b/cmd/camino_messenger_bot.go
@@ -5,6 +5,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os/signal"
 	"syscall"
@@ -83,6 +84,11 @@ func rootFunc(cmd *cobra.Command, _ []string) error {
 
 	app, err := app.NewApp(ctx, cfg, logger)
 	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			// if context is canceled, it means that the app was stopped by a signal
+			return nil
+		}
+
 		logger.Error(err)
 		return err
 	}

--- a/tests/e2e/blockchain/client.go
+++ b/tests/e2e/blockchain/client.go
@@ -83,7 +83,7 @@ type Client struct {
 	adminContract               *contracts.CaminoAdmin
 
 	nonces      map[common.Address]uint64
-	noncesMutex sync.RWMutex
+	noncesMutex sync.Mutex
 }
 
 func (c *Client) ETHClient() *ethclient.Client {

--- a/tests/e2e/blockchain/client.go
+++ b/tests/e2e/blockchain/client.go
@@ -11,6 +11,7 @@ import (
 	"math/big"
 	"regexp"
 	"strings"
+	"sync"
 
 	e2ecommon "github.com/chain4travel/camino-messenger-bot/v11/tests/e2e/common"
 	"github.com/chain4travel/camino-messenger-contracts/go/contracts/bookingtoken"
@@ -65,6 +66,7 @@ func newClient(
 		prefundedKeys: prefundedKeys,
 		adminKey:      adminKey,
 		adminContract: adminContract,
+		nonces:        make(map[common.Address]uint64),
 	}, nil
 }
 
@@ -79,6 +81,9 @@ type Client struct {
 	cmAccountManager            *cmaccountmanager.Cmaccountmanager
 	BookingToken                *bookingtoken.Bookingtoken
 	adminContract               *contracts.CaminoAdmin
+
+	nonces      map[common.Address]uint64
+	noncesMutex sync.RWMutex
 }
 
 func (c *Client) ETHClient() *ethclient.Client {
@@ -301,9 +306,15 @@ func (c *Client) SetKYC(ctx context.Context, account common.Address, isKYCVerifi
 }
 
 func (c *Client) transactor(ctx context.Context, key *ecdsa.PrivateKey, value *big.Int) (*bind.TransactOpts, error) {
+	nonce, err := c.nextNonce(ctx, crypto.PubkeyToAddress(key.PublicKey))
+	if err != nil {
+		return nil, fmt.Errorf("failed to get nonce: %w", err)
+	}
+
 	transactor, err := bind.NewKeyedTransactorWithChainID(key, c.ethChainID)
 	transactor.Context = ctx
 	transactor.Value = value
+	transactor.Nonce = new(big.Int).SetUint64(nonce)
 	return transactor, err
 }
 
@@ -345,14 +356,18 @@ func (c *Client) prepareAdmin(ctx context.Context) error {
 
 // TODO @evlekht we can use some kind of snapshotting to skip the process of deploying SCs if we'll use persistent network
 func (c *Client) prepareCMBContracts(ctx context.Context) error {
+	c.noncesMutex.Lock()
+	defer c.noncesMutex.Unlock()
+
 	adminAddress := crypto.PubkeyToAddress(c.adminKey.PublicKey)
 
 	// prepare contracts, will be done in 4 blocks
-	var err error
-	transactor, err := c.transactor(ctx, c.adminKey, common.Big0)
+
+	transactor, err := bind.NewKeyedTransactorWithChainID(c.adminKey, c.ethChainID)
 	if err != nil {
-		return fmt.Errorf("failed to create default transactor: %w", err)
+		return fmt.Errorf("failed to create transactor: %w", err)
 	}
+	transactor.Context = ctx
 
 	// prepare CM Account Manager proxy initialization data
 
@@ -552,5 +567,29 @@ func (c *Client) prepareCMBContracts(ctx context.Context) error {
 
 	c.bookingTokenContractAddress = bookingTokenProxyAddress
 
+	nonce, err := c.ethClient.PendingNonceAt(ctx, adminAddress)
+	if err != nil {
+		return fmt.Errorf("failed to get nonce for admin address: %w", err)
+	}
+	c.nonces[adminAddress] = nonce
+
 	return nil
+}
+
+func (c *Client) nextNonce(ctx context.Context, addr common.Address) (uint64, error) {
+	c.noncesMutex.Lock()
+	defer c.noncesMutex.Unlock()
+
+	nonce, ok := c.nonces[addr]
+	if !ok {
+		var err error
+		nonce, err = c.ethClient.PendingNonceAt(ctx, addr)
+		if err != nil {
+			return 0, fmt.Errorf("failed to get nonce for address %s: %w", addr.Hex(), err)
+		}
+	}
+
+	c.nonces[addr] = nonce + 1
+
+	return nonce, nil
 }

--- a/tests/e2e/blockchain/client.go
+++ b/tests/e2e/blockchain/client.go
@@ -251,7 +251,7 @@ func (c *Client) Transfer(
 		return fmt.Errorf("failed to suggest gas price: %w", err)
 	}
 
-	nonce, err := c.ethClient.PendingNonceAt(ctx, crypto.PubkeyToAddress(from.PublicKey))
+	nonce, err := c.nextNonce(ctx, crypto.PubkeyToAddress(from.PublicKey))
 	if err != nil {
 		return fmt.Errorf("failed to get nonce: %w", err)
 	}

--- a/tests/e2e/bot/bot.go
+++ b/tests/e2e/bot/bot.go
@@ -64,6 +64,10 @@ func (b *Bot) Start(ctx context.Context) (chan error, error) {
 	b.mutex.Lock()
 	defer b.mutex.Unlock()
 
+	return b.start(ctx)
+}
+
+func (b *Bot) start(ctx context.Context) (chan error, error) {
 	// Prepare log file for bot
 
 	logFile, err := os.OpenFile(b.logPath, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o600)
@@ -133,6 +137,10 @@ func (b *Bot) Stop(ctx context.Context) error {
 	b.mutex.Lock()
 	defer b.mutex.Unlock()
 
+	return b.stop(ctx)
+}
+
+func (b *Bot) stop(ctx context.Context) error {
 	g := errgroup.Group{}
 	processStopped := make(chan struct{})
 	pid := b.pid
@@ -190,11 +198,11 @@ func (b *Bot) Restart(ctx context.Context) (chan error, error) {
 
 	oldPID := b.pid
 
-	if err := b.Stop(ctx); err != nil {
+	if err := b.stop(ctx); err != nil {
 		return nil, err
 	}
 
-	errChan, err := b.Start(ctx)
+	errChan, err := b.start(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to start bot (old pid %d, new pid %d): %w", oldPID, b.pid, err)
 	}

--- a/tests/e2e/bot/bot.go
+++ b/tests/e2e/bot/bot.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"sync"
 	"time"
 
 	"go.uber.org/zap"
@@ -52,12 +53,16 @@ type Bot struct {
 	configPath          string
 	logPath             string
 	rpcConnectionString string
+	mutex               sync.Mutex
 
 	*rpcClient
 }
 
 func (b *Bot) Start(ctx context.Context) (chan error, error) {
 	// Prepare log file for bot
+
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
 
 	logFile, err := os.OpenFile(b.logPath, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o600)
 	if err != nil {
@@ -123,6 +128,9 @@ func (b *Bot) Stop(ctx context.Context) error {
 		return nil
 	}
 
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
+
 	g := errgroup.Group{}
 	processStopped := make(chan struct{})
 	pid := b.pid
@@ -173,6 +181,9 @@ func (b *Bot) Stop(ctx context.Context) error {
 }
 
 func (b *Bot) Restart(ctx context.Context) (chan error, error) {
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
+
 	b.logger.Debugf("Restarting bot (pid %d)", b.pid)
 
 	oldPID := b.pid

--- a/tests/e2e/bot/bot.go
+++ b/tests/e2e/bot/bot.go
@@ -11,17 +11,17 @@ import (
 	"sync"
 	"time"
 
+	"github.com/chain4travel/camino-messenger-bot/v11/internal/rpc/server"
+	"github.com/chain4travel/camino-messenger-bot/v11/proto/pb/readiness"
+	"github.com/chain4travel/camino-messenger-bot/v11/tests/e2e/bot/generated"
+	"github.com/chain4travel/camino-messenger-bot/v11/tests/e2e/process"
+
+	"github.com/ethereum/go-ethereum/common"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/protobuf/types/known/emptypb"
-
-	"github.com/chain4travel/camino-messenger-bot/v11/internal/rpc/server"
-	"github.com/chain4travel/camino-messenger-bot/v11/proto/pb/readiness"
-	"github.com/chain4travel/camino-messenger-bot/v11/tests/e2e/bot/generated"
-	"github.com/chain4travel/camino-messenger-bot/v11/tests/e2e/process"
-	"github.com/ethereum/go-ethereum/common"
 )
 
 const requestTickerInterval = 500 * time.Millisecond
@@ -45,24 +45,26 @@ func newBot(
 }
 
 type Bot struct {
-	logger              *zap.SugaredLogger
-	pid                 int
+	logger *zap.SugaredLogger
+	mutex  sync.Mutex
+
 	cmAccountAddress    common.Address
-	logFile             *os.File
 	binPath             string
 	configPath          string
 	logPath             string
 	rpcConnectionString string
-	mutex               sync.Mutex
+
+	pid     int
+	logFile *os.File
 
 	*rpcClient
 }
 
 func (b *Bot) Start(ctx context.Context) (chan error, error) {
-	// Prepare log file for bot
-
 	b.mutex.Lock()
 	defer b.mutex.Unlock()
+
+	// Prepare log file for bot
 
 	logFile, err := os.OpenFile(b.logPath, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o600)
 	if err != nil {

--- a/tests/e2e/bot/factory.go
+++ b/tests/e2e/bot/factory.go
@@ -49,7 +49,6 @@ func NewFactory(
 	}
 }
 
-// Not safe for concurrent use.
 type Factory struct {
 	logger                 *zap.SugaredLogger
 	resourceManagerSession *resources.Session
@@ -243,6 +242,9 @@ func (f *Factory) CreateBot(
 }
 
 func (f *Factory) StopBots(ctx context.Context) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
 	var errs []error
 	errsMx := sync.Mutex{}
 	wg := sync.WaitGroup{}

--- a/tests/e2e/bot/factory.go
+++ b/tests/e2e/bot/factory.go
@@ -15,16 +15,16 @@ import (
 	"strconv"
 	"sync"
 
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/crypto"
-	"go.uber.org/zap"
-
 	"github.com/chain4travel/camino-messenger-bot/v11/config"
 	"github.com/chain4travel/camino-messenger-bot/v11/tests/e2e/blockchain"
 	e2eCommon "github.com/chain4travel/camino-messenger-bot/v11/tests/e2e/common"
 	"github.com/chain4travel/camino-messenger-bot/v11/tests/e2e/matrix"
 	partnerplugin "github.com/chain4travel/camino-messenger-bot/v11/tests/e2e/partner_plugin"
 	"github.com/chain4travel/camino-messenger-bot/v11/tests/e2e/resources"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"go.uber.org/zap"
 )
 
 const CashInPeriodSeconds = 3600 // 1h
@@ -197,7 +197,7 @@ func (f *Factory) CreateBot(
 		ResponseTimeout:                     30000,                 // 30s
 		PartnerPlugin: config.PartnerPluginConfig{
 			Enabled:     partnerPlugin != nil,
-			Host:        partnerPlugin.Host(),
+			Host:        partnerPlugin.RPCClientConnectionString(),
 			Unencrypted: true,
 		},
 		RPCServer: config.RPCServerConfig{

--- a/tests/e2e/bot/factory.go
+++ b/tests/e2e/bot/factory.go
@@ -58,6 +58,7 @@ type Factory struct {
 	networkClient          *blockchain.Client
 	matrix                 *matrix.ConduitServer
 	asb                    *matrix.AppService
+	mutex                  sync.Mutex
 	bots                   []*Bot
 }
 
@@ -110,7 +111,7 @@ func (f *Factory) CreateBot(
 	enableRPCServer bool,
 	partnerPlugin *partnerplugin.PartnerPlugin,
 	opts ...Option,
-) (*Bot, chan error, error) {
+) (*Bot, error) {
 	options := &options{
 		skips:               &Skip{},
 		cashInPeriodSeconds: CashInPeriodSeconds, // 1h
@@ -121,12 +122,12 @@ func (f *Factory) CreateBot(
 
 	cmAccountOwnerKey, err := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to generate key: %w", err)
+		return nil, fmt.Errorf("failed to generate key: %w", err)
 	}
 
 	botKey, err := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to generate key: %w", err)
+		return nil, fmt.Errorf("failed to generate key: %w", err)
 	}
 
 	var cmAccountAddress common.Address
@@ -135,24 +136,24 @@ func (f *Factory) CreateBot(
 		cmAccountOwnerAddress := crypto.PubkeyToAddress(cmAccountOwnerKey.PublicKey)
 		cmAccountAddress, _, err = f.networkClient.CreateCMAccount(ctx, cmAccountOwnerKey)
 		if err != nil {
-			return nil, nil, fmt.Errorf("failed to create CM account: %w", err)
+			return nil, fmt.Errorf("failed to create CM account: %w", err)
 		}
 
 		if !options.skips.PrefundOwner {
 			if err := f.networkClient.Transfer(ctx, f.networkClient.PrefundedKeys()[0], cmAccountOwnerAddress, e2eCommon.DefaultCMAccountOwnerFunds); err != nil {
-				return nil, nil, fmt.Errorf("failed to transfer funds to cm account owner: %w", err)
+				return nil, fmt.Errorf("failed to transfer funds to cm account owner: %w", err)
 			}
 
 			if !options.skips.BotRegistration {
 				if err := f.networkClient.AddBotToCMAccount(ctx, cmAccountAddress, cmAccountOwnerKey, botAddr); err != nil {
-					return nil, nil, fmt.Errorf("failed to add bot to CM account: %w", err)
+					return nil, fmt.Errorf("failed to add bot to CM account: %w", err)
 				}
 			}
 
 			if !options.skips.ServiceRegistration {
 				for _, service := range options.services {
 					if err := f.networkClient.AddCMService(ctx, cmAccountAddress, cmAccountOwnerKey, service.Name, service.Fee); err != nil {
-						return nil, nil, fmt.Errorf("failed to add %s service to CM account: %w", service.Name, err)
+						return nil, fmt.Errorf("failed to add %s service to CM account: %w", service.Name, err)
 					}
 				}
 			}
@@ -160,7 +161,7 @@ func (f *Factory) CreateBot(
 
 		if !options.skips.PrefundBot {
 			if err := f.networkClient.Transfer(ctx, f.networkClient.PrefundedKeys()[0], botAddr, e2eCommon.DefaultCMAccountOwnerFunds); err != nil {
-				return nil, nil, fmt.Errorf("failed to transfer funds to bot: %w", err)
+				return nil, fmt.Errorf("failed to transfer funds to bot: %w", err)
 			}
 		}
 	}
@@ -171,9 +172,12 @@ func (f *Factory) CreateBot(
 	if enableRPCServer {
 		port, err = f.resourceManagerSession.GetNetworkPort()
 		if err != nil {
-			return nil, nil, fmt.Errorf("failed to get free port: %w", err)
+			return nil, fmt.Errorf("failed to get free port: %w", err)
 		}
 	}
+
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
 
 	botDir := path.Join(f.dir, strconv.Itoa(len(f.bots)))
 
@@ -208,24 +212,22 @@ func (f *Factory) CreateBot(
 	}
 
 	if err := os.RemoveAll(botDir); err != nil {
-		return nil, nil, fmt.Errorf("failed to remove bot data dir: %w", err)
+		return nil, fmt.Errorf("failed to remove bot data dir: %w", err)
 	}
 
 	if err := os.MkdirAll(botDir, 0o755); err != nil {
-		return nil, nil, fmt.Errorf("failed to create bot data dir: %w", err)
+		return nil, fmt.Errorf("failed to create bot data dir: %w", err)
 	}
 
 	configPath := path.Join(botDir, "config.yaml")
 	if err := e2eCommon.WriteYAMLConfig(config, configPath); err != nil {
-		return nil, nil, fmt.Errorf("failed to write bot config file: %w", err)
+		return nil, fmt.Errorf("failed to write bot config file: %w", err)
 	}
 
 	rpcClientConnectionString := ""
 	if config.RPCServer.Enabled {
 		rpcClientConnectionString = fmt.Sprintf("localhost:%d", config.RPCServer.Port) // rpc client connection string
 	}
-
-	// Start bot
 
 	bot := newBot(
 		f.logger,
@@ -237,12 +239,7 @@ func (f *Factory) CreateBot(
 	)
 	f.bots = append(f.bots, bot)
 
-	errChan, err := bot.Start(ctx)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to start bot: %w", err)
-	}
-
-	return bot, errChan, nil
+	return bot, nil
 }
 
 func (f *Factory) StopBots(ctx context.Context) error {

--- a/tests/e2e/partner_plugin/factory.go
+++ b/tests/e2e/partner_plugin/factory.go
@@ -47,10 +47,6 @@ type Factory struct {
 	partnerPlugins         []*PartnerPlugin
 }
 
-func (f *Factory) PartnerPluginsCount() int {
-	return len(f.partnerPlugins)
-}
-
 func (f *Factory) CreatePartnerPlugin(ctx context.Context) (*PartnerPlugin, chan error, error) {
 	port, err := f.resourceManagerSession.GetNetworkPort()
 	if err != nil {

--- a/tests/e2e/partner_plugin/factory.go
+++ b/tests/e2e/partner_plugin/factory.go
@@ -7,21 +7,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net/url"
 	"os"
-	"os/exec"
 	"path"
 	"sync"
 
-	"go.uber.org/zap"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
-
-	"buf.build/gen/go/chain4travel/camino-messenger-protocol/grpc/go/cmp/services/ping/v1/pingv1grpc"
-	"github.com/chain4travel/camino-messenger-bot/v11/pp-mock/proto/pb/events"
-	ppmock "github.com/chain4travel/camino-messenger-bot/v11/pp-mock/server"
-	"github.com/chain4travel/camino-messenger-bot/v11/tests/e2e/process"
 	"github.com/chain4travel/camino-messenger-bot/v11/tests/e2e/resources"
+
+	"go.uber.org/zap"
 )
 
 func NewFactory(
@@ -47,74 +39,25 @@ type Factory struct {
 	partnerPlugins         []*PartnerPlugin
 }
 
-func (f *Factory) CreatePartnerPlugin(ctx context.Context) (*PartnerPlugin, chan error, error) {
+func (f *Factory) CreatePartnerPlugin() (*PartnerPlugin, error) {
+	if err := os.MkdirAll(f.dir, 0o755); err != nil {
+		return nil, fmt.Errorf("failed to create pp-mock directory: %w", err)
+	}
+
 	port, err := f.resourceManagerSession.GetNetworkPort()
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to get free port: %w", err)
+		return nil, fmt.Errorf("failed to get free port: %w", err)
 	}
 
-	host := fmt.Sprintf("localhost:%d", port)
-
-	clientConnection, err := grpc.NewClient(host, grpc.WithTransportCredentials(insecure.NewCredentials()))
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create grpc client: %w", err)
-	}
-
-	hostURL, err := url.Parse(fmt.Sprintf("gprc://%s", host))
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to parse host url: %w", err)
-	}
-
-	cmd := exec.Command(f.binPath) //nolint:gosec // this is a partner plugin mock binary, not some injection.
-	cmd.Env = append(cmd.Env,
-		fmt.Sprintf("%s=%d", ppmock.EnvKeyPort, port),
-		fmt.Sprintf("%s=true", ppmock.EnvKeyEventsEnabled),
-		fmt.Sprintf("%s=true", ppmock.EnvE2ETestMode),
+	pp := newPartnerPlugin(
+		f.logger,
+		f.binPath,
+		port,
+		path.Join(f.dir, fmt.Sprintf("partner-plugin-%d.log", port)),
 	)
-
-	if err := os.MkdirAll(f.dir, 0o755); err != nil {
-		return nil, nil, fmt.Errorf("failed to create pp-mock directory: %w", err)
-	}
-	logFileName := path.Join(f.dir, fmt.Sprintf("partner-plugin-%d.log", port))
-	logFile, err := os.OpenFile(logFileName, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o600)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to open pp-mock log file: %w", err)
-	}
-
-	cmd.Stdout = logFile
-	cmd.Stderr = logFile
-
-	if err := cmd.Start(); err != nil {
-		return nil, nil, fmt.Errorf("failed to start partner-plugin (%d): %w", cmd.Process.Pid, err)
-	}
-
-	pp := &PartnerPlugin{
-		logger:       f.logger,
-		pid:          cmd.Process.Pid,
-		host:         hostURL,
-		pingClient:   pingv1grpc.NewPingServiceClient(clientConnection),
-		eventsClient: events.NewEventsServiceClient(clientConnection),
-		logFile:      logFile,
-	}
-
-	if err := pp.awaitReady(ctx); err != nil {
-		return pp, nil, fmt.Errorf("failed to wait for partner-plugin to be ready: %w", err)
-	}
-
-	f.logger.Debugf("Partner-plugin (pid %d) started", cmd.Process.Pid)
-
 	f.partnerPlugins = append(f.partnerPlugins, pp)
 
-	errChan := make(chan error)
-	go func() {
-		err := <-process.ListenForProcessError(cmd)
-		if err != nil {
-			errChan <- fmt.Errorf("partner-plugin (pid %d) failed: %w", pp.pid, err)
-		}
-		close(errChan)
-	}()
-
-	return pp, errChan, nil
+	return pp, nil
 }
 
 func (f *Factory) StopPartnerPlugins(ctx context.Context) error {

--- a/tests/e2e/partner_plugin/factory.go
+++ b/tests/e2e/partner_plugin/factory.go
@@ -30,12 +30,12 @@ func NewFactory(
 	}
 }
 
-// Not safe for concurrent use.
 type Factory struct {
 	logger                 *zap.SugaredLogger
 	resourceManagerSession *resources.Session
 	dir                    string
 	binPath                string
+	mutex                  sync.Mutex
 	partnerPlugins         []*PartnerPlugin
 }
 
@@ -55,12 +55,19 @@ func (f *Factory) CreatePartnerPlugin() (*PartnerPlugin, error) {
 		port,
 		path.Join(f.dir, fmt.Sprintf("partner-plugin-%d.log", port)),
 	)
+
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
 	f.partnerPlugins = append(f.partnerPlugins, pp)
 
 	return pp, nil
 }
 
 func (f *Factory) StopPartnerPlugins(ctx context.Context) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
 	var errs []error
 	errsMx := sync.Mutex{}
 	wg := sync.WaitGroup{}

--- a/tests/e2e/partner_plugin/partner_plugin.go
+++ b/tests/e2e/partner_plugin/partner_plugin.go
@@ -6,62 +6,135 @@ package partnerplugin
 import (
 	"context"
 	"fmt"
-	"net/url"
 	"os"
+	"os/exec"
+	"sync"
 	"time"
+
+	"github.com/chain4travel/camino-messenger-bot/v11/pp-mock/proto/pb/events"
+	ppmock "github.com/chain4travel/camino-messenger-bot/v11/pp-mock/server"
+	"github.com/chain4travel/camino-messenger-bot/v11/tests/e2e/process"
 
 	"buf.build/gen/go/chain4travel/camino-messenger-protocol/grpc/go/cmp/services/ping/v1/pingv1grpc"
 	pingv1 "buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go/cmp/services/ping/v1"
 	typesv1 "buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go/cmp/types/v1"
+
 	"github.com/ethereum/go-ethereum/common"
 	"go.uber.org/zap"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/protobuf/types/known/emptypb"
 	"google.golang.org/protobuf/types/known/timestamppb"
-
-	"github.com/chain4travel/camino-messenger-bot/v11/pp-mock/proto/pb/events"
-	"github.com/chain4travel/camino-messenger-bot/v11/tests/e2e/process"
 )
 
 const requestTickerInterval = 500 * time.Millisecond
 
 type PartnerPlugin struct {
-	logger       *zap.SugaredLogger
+	mutex  sync.Mutex
+	logger *zap.SugaredLogger
+
+	binPath             string
+	port                int32
+	logPath             string
+	rpcConnectionString string
+
 	pid          int
-	host         *url.URL
+	logFile      *os.File
 	pingClient   pingv1grpc.PingServiceClient
 	eventsClient events.EventsServiceClient
-	logFile      *os.File
 }
 
 func newPartnerPlugin(
 	logger *zap.SugaredLogger,
-	cmAccountAddress common.Address,
 	binPath string,
-	configPath string,
+	port int32,
 	logPath string,
-	rpcConnectionString string,
 ) *PartnerPlugin {
 	return &PartnerPlugin{
-		logger:       logger,
-		pid:          cmd.Process.Pid,
-		host:         hostURL,
-		pingClient:   pingv1grpc.NewPingServiceClient(clientConnection),
-		eventsClient: events.NewEventsServiceClient(clientConnection),
-		logFile:      logFile,
+		logger:              logger,
+		binPath:             binPath,
+		port:                port,
+		logPath:             logPath,
+		rpcConnectionString: fmt.Sprintf("localhost:%d", port),
 	}
 }
 
-func (pp *PartnerPlugin) Host() string {
+func (pp *PartnerPlugin) RPCClientConnectionString() string {
 	if pp == nil {
 		return ""
 	}
-	return pp.host.Host
+	return pp.rpcConnectionString
+}
+
+func (pp *PartnerPlugin) Start(ctx context.Context) (chan error, error) {
+	pp.mutex.Lock()
+	defer pp.mutex.Unlock()
+
+	// Prepare log file for partner-plugin
+
+	logFile, err := os.OpenFile(pp.logPath, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open partner-plugin log file: %w", err)
+	}
+	pp.logFile = logFile
+
+	// Prepare cmd and start partner-plugin process
+
+	cmd := exec.Command(pp.binPath) //nolint:gosec // this is a partner plugin binary, not some injection.
+	cmd.Env = append(cmd.Env,
+		fmt.Sprintf("%s=%d", ppmock.EnvKeyPort, pp.port),
+		fmt.Sprintf("%s=true", ppmock.EnvKeyEventsEnabled),
+		fmt.Sprintf("%s=true", ppmock.EnvE2ETestMode),
+	)
+	cmd.Stdout = pp.logFile
+	cmd.Stderr = pp.logFile
+
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("failed to start partner-plugin (%d): %w", cmd.Process.Pid, err)
+	}
+
+	pp.pid = cmd.Process.Pid
+
+	// Prepare RPC client
+
+	rpcClientConnection, err := grpc.NewClient(pp.rpcConnectionString, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create grpc client: %w", err)
+	}
+	pp.pingClient = pingv1grpc.NewPingServiceClient(rpcClientConnection)
+	pp.eventsClient = events.NewEventsServiceClient(rpcClientConnection)
+
+	// Await partner-plugin readiness if RPC client is set
+
+	if err := pp.awaitReady(ctx); err != nil {
+		return nil, fmt.Errorf("failed to wait for partner-plugin to be ready: %w", err)
+	}
+
+	// Await partner-plugin process error async
+
+	errChan := make(chan error)
+	go func() {
+		defer close(errChan)
+		err := <-process.ListenForProcessError(cmd)
+		if err != nil {
+			errChan <- fmt.Errorf("partner-plugin (pid %d) failed: %w", pp.pid, err)
+		}
+	}()
+
+	// Successfully started partner-plugin
+
+	pp.logger.Debugf("Partner-plugin (pid %d) started", cmd.Process.Pid)
+	return errChan, nil
 }
 
 func (pp *PartnerPlugin) Stop(ctx context.Context) error {
 	if pp == nil {
 		return nil
 	}
+
+	pp.mutex.Lock()
+	defer pp.mutex.Unlock()
+
 	if err := process.StopProcess(ctx, pp.pid); err != nil {
 		return fmt.Errorf("failed to stop partner plugin process with pid %d: %w", pp.pid, err)
 	}
@@ -73,6 +146,9 @@ func (pp *PartnerPlugin) Stop(ctx context.Context) error {
 }
 
 func (pp *PartnerPlugin) SubscribeForEvents(ctx context.Context) (events.EventsService_SubscribeClient, error) {
+	pp.mutex.Lock()
+	defer pp.mutex.Unlock()
+
 	return pp.eventsClient.Subscribe(ctx, &emptypb.Empty{})
 }
 

--- a/tests/e2e/partner_plugin/partner_plugin.go
+++ b/tests/e2e/partner_plugin/partner_plugin.go
@@ -33,6 +33,24 @@ type PartnerPlugin struct {
 	logFile      *os.File
 }
 
+func newPartnerPlugin(
+	logger *zap.SugaredLogger,
+	cmAccountAddress common.Address,
+	binPath string,
+	configPath string,
+	logPath string,
+	rpcConnectionString string,
+) *PartnerPlugin {
+	return &PartnerPlugin{
+		logger:       logger,
+		pid:          cmd.Process.Pid,
+		host:         hostURL,
+		pingClient:   pingv1grpc.NewPingServiceClient(clientConnection),
+		eventsClient: events.NewEventsServiceClient(clientConnection),
+		logFile:      logFile,
+	}
+}
+
 func (pp *PartnerPlugin) Host() string {
 	if pp == nil {
 		return ""

--- a/tests/e2e/resources/manager.go
+++ b/tests/e2e/resources/manager.go
@@ -70,8 +70,8 @@ func (m *Manager) NewSession() *Session {
 	}
 }
 
-// Not safe for concurrent use.
 type Session struct {
+	mutex       sync.Mutex
 	manager     *Manager
 	lockedPorts []int32
 }
@@ -81,11 +81,18 @@ func (s *Session) GetNetworkPort() (int32, error) {
 	if err != nil {
 		return 0, err
 	}
+
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
 	s.lockedPorts = append(s.lockedPorts, port)
 	return port, nil
 }
 
 func (s *Session) ReleaseResources() {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
 	for _, port := range s.lockedPorts {
 		s.manager.releaseNetworkPort(port)
 	}

--- a/tests/e2e/suite/environment.go
+++ b/tests/e2e/suite/environment.go
@@ -115,6 +115,7 @@ func (e *Environment) CreatePartnerPlugin(
 	t *testing.T,
 ) *partnerplugin.PartnerPlugin {
 	t.Helper()
+
 	partnerPlugin, err := e.partnerPluginFactory.CreatePartnerPlugin()
 	require.NoError(t, err)
 

--- a/tests/e2e/suite/environment.go
+++ b/tests/e2e/suite/environment.go
@@ -115,8 +115,12 @@ func (e *Environment) CreatePartnerPlugin(
 	t *testing.T,
 ) *partnerplugin.PartnerPlugin {
 	t.Helper()
-	partnerPlugin, errChan, err := e.partnerPluginFactory.CreatePartnerPlugin(ctx)
+	partnerPlugin, err := e.partnerPluginFactory.CreatePartnerPlugin()
 	require.NoError(t, err)
+
+	errChan, err := partnerPlugin.Start(ctx)
+	require.NoError(t, err)
+
 	common.ExpectNoErrorAsync(t, errChan)
 	return partnerPlugin
 }

--- a/tests/e2e/suite/environment.go
+++ b/tests/e2e/suite/environment.go
@@ -26,7 +26,6 @@ import (
 	"github.com/chain4travel/camino-messenger-bot/v11/tests/e2e/resources"
 )
 
-// Not safe for concurrent use.
 type Environment struct {
 	// used by tests; we don't bother to abstract it for safety, because its tests and we expect tests to not modify those fields
 	Logger        *zap.SugaredLogger
@@ -52,8 +51,13 @@ func (e *Environment) CreateBot(
 	opts ...bot.Option,
 ) *bot.Bot {
 	t.Helper()
-	bot, errChan, err := e.botFactory.CreateBot(ctx, enableRPCServer, partnerPlugin, opts...)
+
+	bot, err := e.botFactory.CreateBot(ctx, enableRPCServer, partnerPlugin, opts...)
 	require.NoError(t, err)
+
+	errChan, err := bot.Start(ctx)
+	require.NoError(t, err)
+
 	common.ExpectNoErrorAsync(t, errChan)
 	return bot
 }
@@ -64,8 +68,14 @@ func (e *Environment) CreateBotWithError(
 	partnerPlugin *partnerplugin.PartnerPlugin,
 	opts ...bot.Option,
 ) error {
-	_, _, err := e.botFactory.CreateBot(ctx, enableRPCServer, partnerPlugin, opts...)
-	return err
+	bot, err := e.botFactory.CreateBot(ctx, enableRPCServer, partnerPlugin, opts...)
+	if err != nil {
+		return fmt.Errorf("failed to create bot: %w", err)
+	}
+	if _, err := bot.Start(ctx); err != nil {
+		return fmt.Errorf("failed to start bot: %w", err)
+	}
+	return nil
 }
 
 func (e *Environment) CreateBotAwaitError(
@@ -78,8 +88,13 @@ func (e *Environment) CreateBotAwaitError(
 	opts ...bot.Option,
 ) {
 	t.Helper()
-	_, errChan, err := e.botFactory.CreateBot(ctx, enableRPCServer, partnerPlugin, opts...)
+
+	bot, err := e.botFactory.CreateBot(ctx, enableRPCServer, partnerPlugin, opts...)
 	require.NoError(t, err)
+
+	errChan, err := bot.Start(ctx)
+	require.NoError(t, err)
+
 	common.AwaitError(t, errChan, errorContains, timeout)
 }
 

--- a/tests/e2e/tests/test_accommodation_v2.go
+++ b/tests/e2e/tests/test_accommodation_v2.go
@@ -6,6 +6,7 @@ package tests
 import (
 	"context"
 	"math/big"
+	"sync"
 	"testing"
 	"time"
 
@@ -91,21 +92,32 @@ func (tt *TestAccommodationV2) prepare(ctx context.Context, t *testing.T) {
 		botGenerated.MintServiceV2,
 	))
 
-	tt.supplierPartnerPlugin = tt.CreatePartnerPlugin(ctx, t)
+	wg := sync.WaitGroup{}
 
 	// bot with partnerPlugin and without rpc server (supplier)
-	tt.supplierBot = tt.CreateBot(ctx, t, true, tt.supplierPartnerPlugin,
-		bot.WithServices([]bot.CMService{
-			{Name: botGenerated.AccommodationProductListServiceV2, Fee: 100},
-			{Name: botGenerated.AccommodationProductInfoServiceV2, Fee: 110},
-			{Name: botGenerated.AccommodationSearchServiceV2, Fee: 120},
-			{Name: botGenerated.ValidationServiceV2, Fee: 130},
-			{Name: botGenerated.MintServiceV2, Fee: 140},
-		}),
-	)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		tt.supplierPartnerPlugin = tt.CreatePartnerPlugin(ctx, t)
+		tt.supplierBot = tt.CreateBot(ctx, t, true, tt.supplierPartnerPlugin,
+			bot.WithServices([]bot.CMService{
+				{Name: botGenerated.AccommodationProductListServiceV2, Fee: 100},
+				{Name: botGenerated.AccommodationProductInfoServiceV2, Fee: 110},
+				{Name: botGenerated.AccommodationSearchServiceV2, Fee: 120},
+				{Name: botGenerated.ValidationServiceV2, Fee: 130},
+				{Name: botGenerated.MintServiceV2, Fee: 140},
+			}),
+		)
+	}()
 
 	// bot without partnerPlugin and with rpc server (distributor)
-	tt.distributorBot = tt.CreateBot(ctx, t, true, nil)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		tt.distributorBot = tt.CreateBot(ctx, t, true, nil)
+	}()
+
+	wg.Wait()
 }
 
 // Simple product list request which shall return all properties. Checking if all are present

--- a/tests/e2e/tests/test_accommodation_v3.go
+++ b/tests/e2e/tests/test_accommodation_v3.go
@@ -6,6 +6,7 @@ package tests
 import (
 	"context"
 	"math/big"
+	"sync"
 	"testing"
 	"time"
 
@@ -93,21 +94,32 @@ func (tt *TestAccommodationV3) prepare(ctx context.Context, t *testing.T) {
 		botGenerated.MintServiceV2,
 	))
 
-	tt.supplierPartnerPlugin = tt.CreatePartnerPlugin(ctx, t)
+	wg := sync.WaitGroup{}
 
 	// bot with partnerPlugin and without rpc server (supplier)
-	tt.supplierBot = tt.CreateBot(ctx, t, true, tt.supplierPartnerPlugin,
-		bot.WithServices([]bot.CMService{
-			{Name: botGenerated.AccommodationProductListServiceV3, Fee: 100},
-			{Name: botGenerated.AccommodationProductInfoServiceV3, Fee: 110},
-			{Name: botGenerated.AccommodationSearchServiceV3, Fee: 120},
-			{Name: botGenerated.ValidationServiceV2, Fee: 130},
-			{Name: botGenerated.MintServiceV2, Fee: 140},
-		}),
-	)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		tt.supplierPartnerPlugin = tt.CreatePartnerPlugin(ctx, t)
+		tt.supplierBot = tt.CreateBot(ctx, t, true, tt.supplierPartnerPlugin,
+			bot.WithServices([]bot.CMService{
+				{Name: botGenerated.AccommodationProductListServiceV3, Fee: 100},
+				{Name: botGenerated.AccommodationProductInfoServiceV3, Fee: 110},
+				{Name: botGenerated.AccommodationSearchServiceV3, Fee: 120},
+				{Name: botGenerated.ValidationServiceV2, Fee: 130},
+				{Name: botGenerated.MintServiceV2, Fee: 140},
+			}),
+		)
+	}()
 
 	// bot without partnerPlugin and with rpc server (distributor)
-	tt.distributorBot = tt.CreateBot(ctx, t, true, nil)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		tt.distributorBot = tt.CreateBot(ctx, t, true, nil)
+	}()
+
+	wg.Wait()
 }
 
 // Simple product list request which shall return all properties. Checking if all are present

--- a/tests/e2e/tests/test_activity_v1.go
+++ b/tests/e2e/tests/test_activity_v1.go
@@ -6,6 +6,7 @@ package tests
 import (
 	"context"
 	"math/big"
+	"sync"
 	"testing"
 	"time"
 
@@ -92,21 +93,32 @@ func (tt *TestActivityV1) prepare(ctx context.Context, t *testing.T) {
 		botGenerated.MintServiceV2,
 	))
 
-	tt.supplierPartnerPlugin = tt.CreatePartnerPlugin(ctx, t)
+	wg := sync.WaitGroup{}
 
 	// bot with partnerPlugin and without rpc server (supplier)
-	tt.supplierBot = tt.CreateBot(ctx, t, true, tt.supplierPartnerPlugin,
-		bot.WithServices([]bot.CMService{
-			{Name: botGenerated.ActivityProductListServiceV1, Fee: 100},
-			{Name: botGenerated.ActivityProductInfoServiceV1, Fee: 110},
-			{Name: botGenerated.ActivitySearchServiceV1, Fee: 120},
-			{Name: botGenerated.ValidationServiceV2, Fee: 130},
-			{Name: botGenerated.MintServiceV2, Fee: 140},
-		}),
-	)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		tt.supplierPartnerPlugin = tt.CreatePartnerPlugin(ctx, t)
+		tt.supplierBot = tt.CreateBot(ctx, t, true, tt.supplierPartnerPlugin,
+			bot.WithServices([]bot.CMService{
+				{Name: botGenerated.ActivityProductListServiceV1, Fee: 100},
+				{Name: botGenerated.ActivityProductInfoServiceV1, Fee: 110},
+				{Name: botGenerated.ActivitySearchServiceV1, Fee: 120},
+				{Name: botGenerated.ValidationServiceV2, Fee: 130},
+				{Name: botGenerated.MintServiceV2, Fee: 140},
+			}),
+		)
+	}()
 
 	// bot without partnerPlugin and with rpc server (distributor)
-	tt.distributorBot = tt.CreateBot(ctx, t, true, nil)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		tt.distributorBot = tt.CreateBot(ctx, t, true, nil)
+	}()
+
+	wg.Wait()
 }
 
 // Simple product list request which shall return all activities. Checking if all are present

--- a/tests/e2e/tests/test_activity_v2.go
+++ b/tests/e2e/tests/test_activity_v2.go
@@ -6,6 +6,7 @@ package tests
 import (
 	"context"
 	"math/big"
+	"sync"
 	"testing"
 	"time"
 
@@ -93,21 +94,32 @@ func (tt *TestActivityV2) prepare(ctx context.Context, t *testing.T) {
 		botGenerated.MintServiceV2,
 	))
 
-	tt.supplierPartnerPlugin = tt.CreatePartnerPlugin(ctx, t)
+	wg := sync.WaitGroup{}
 
 	// bot with partnerPlugin and without rpc server (supplier)
-	tt.supplierBot = tt.CreateBot(ctx, t, true, tt.supplierPartnerPlugin,
-		bot.WithServices([]bot.CMService{
-			{Name: botGenerated.ActivityProductListServiceV2, Fee: 100},
-			{Name: botGenerated.ActivityProductInfoServiceV2, Fee: 110},
-			{Name: botGenerated.ActivitySearchServiceV2, Fee: 120},
-			{Name: botGenerated.ValidationServiceV2, Fee: 130},
-			{Name: botGenerated.MintServiceV2, Fee: 140},
-		}),
-	)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		tt.supplierPartnerPlugin = tt.CreatePartnerPlugin(ctx, t)
+		tt.supplierBot = tt.CreateBot(ctx, t, true, tt.supplierPartnerPlugin,
+			bot.WithServices([]bot.CMService{
+				{Name: botGenerated.ActivityProductListServiceV2, Fee: 100},
+				{Name: botGenerated.ActivityProductInfoServiceV2, Fee: 110},
+				{Name: botGenerated.ActivitySearchServiceV2, Fee: 120},
+				{Name: botGenerated.ValidationServiceV2, Fee: 130},
+				{Name: botGenerated.MintServiceV2, Fee: 140},
+			}),
+		)
+	}()
 
 	// bot without partnerPlugin and with rpc server (distributor)
-	tt.distributorBot = tt.CreateBot(ctx, t, true, nil)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		tt.distributorBot = tt.CreateBot(ctx, t, true, nil)
+	}()
+
+	wg.Wait()
 }
 
 // Simple product list request which shall return all activities. Checking if all are present

--- a/tests/e2e/tests/test_activity_v3.go
+++ b/tests/e2e/tests/test_activity_v3.go
@@ -6,6 +6,7 @@ package tests
 import (
 	"context"
 	"math/big"
+	"sync"
 	"testing"
 	"time"
 
@@ -94,21 +95,32 @@ func (tt *TestActivityV3) prepare(ctx context.Context, t *testing.T) {
 		botGenerated.MintServiceV2,
 	))
 
-	tt.supplierPartnerPlugin = tt.CreatePartnerPlugin(ctx, t)
+	wg := sync.WaitGroup{}
 
 	// bot with partnerPlugin and without rpc server (supplier)
-	tt.supplierBot = tt.CreateBot(ctx, t, true, tt.supplierPartnerPlugin,
-		bot.WithServices([]bot.CMService{
-			{Name: botGenerated.ActivityProductListServiceV3, Fee: 100},
-			{Name: botGenerated.ActivityProductInfoServiceV3, Fee: 110},
-			{Name: botGenerated.ActivitySearchServiceV3, Fee: 120},
-			{Name: botGenerated.ValidationServiceV2, Fee: 130},
-			{Name: botGenerated.MintServiceV2, Fee: 140},
-		}),
-	)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		tt.supplierPartnerPlugin = tt.CreatePartnerPlugin(ctx, t)
+		tt.supplierBot = tt.CreateBot(ctx, t, true, tt.supplierPartnerPlugin,
+			bot.WithServices([]bot.CMService{
+				{Name: botGenerated.ActivityProductListServiceV3, Fee: 100},
+				{Name: botGenerated.ActivityProductInfoServiceV3, Fee: 110},
+				{Name: botGenerated.ActivitySearchServiceV3, Fee: 120},
+				{Name: botGenerated.ValidationServiceV2, Fee: 130},
+				{Name: botGenerated.MintServiceV2, Fee: 140},
+			}),
+		)
+	}()
 
 	// bot without partnerPlugin and with rpc server (distributor)
-	tt.distributorBot = tt.CreateBot(ctx, t, true, nil)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		tt.distributorBot = tt.CreateBot(ctx, t, true, nil)
+	}()
+
+	wg.Wait()
 }
 
 // Simple product list request which shall return all activities. Checking if all are present

--- a/tests/e2e/tests/test_bot_sanity.go
+++ b/tests/e2e/tests/test_bot_sanity.go
@@ -5,6 +5,7 @@ package tests
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -103,33 +104,53 @@ func (tt *TestBotSanity) prepareAfterCMManagerRegisterServices(ctx context.Conte
 		botGenerated.MintServiceV3,
 	))
 
+	wg := sync.WaitGroup{}
+
 	// This bot does actually have the CM-Account and prefunding of the owner
 	// But only the bot registration is missing in the CM-Account
 	// With that the distributor bot should not be able to find the supplier bot
 	// and fail with an error in a later test
-	tt.supplierBotUnregistered = tt.CreateBot(ctx, t, false, tt.supplierPartnerPlugin,
-		bot.WithServices([]bot.CMService{{Name: botGenerated.PingServiceV1, Fee: 100}}),
-		bot.WithSkips(&bot.Skip{BotRegistration: true}),
-	)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		tt.supplierBotUnregistered = tt.CreateBot(ctx, t, false, tt.supplierPartnerPlugin,
+			bot.WithServices([]bot.CMService{{Name: botGenerated.PingServiceV1, Fee: 100}}),
+			bot.WithSkips(&bot.Skip{BotRegistration: true}),
+		)
+	}()
 
 	// This bot does actually have the CM-Account and prefunding of the owner
 	// and is also registered in the CM-Account **BUT** the service registration
 	// is missing - this is checked by the bot but results only in a warning
 	// inside of the logs. We can later use this bot to check if the distributor
 	// bot acts correctly by rejecting this supplier bot as the required service is missing
-	tt.supplierBotNoServices = tt.CreateBot(ctx, t, false, tt.supplierPartnerPlugin,
-		bot.WithServices([]bot.CMService{{Name: botGenerated.PingServiceV1, Fee: 100}}),
-		bot.WithSkips(&bot.Skip{ServiceRegistration: true}),
-	)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		tt.supplierBotNoServices = tt.CreateBot(ctx, t, false, tt.supplierPartnerPlugin,
+			bot.WithServices([]bot.CMService{{Name: botGenerated.PingServiceV1, Fee: 100}}),
+			bot.WithSkips(&bot.Skip{ServiceRegistration: true}),
+		)
+	}()
 
 	// All good here - just a different service used which should then
 	// fail in the later test
-	tt.supplierBotDifferentServices = tt.CreateBot(ctx, t, false, tt.supplierPartnerPlugin,
-		bot.WithServices([]bot.CMService{{Name: botGenerated.MintServiceV3, Fee: 100}}),
-	)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		tt.supplierBotDifferentServices = tt.CreateBot(ctx, t, false, tt.supplierPartnerPlugin,
+			bot.WithServices([]bot.CMService{{Name: botGenerated.MintServiceV3, Fee: 100}}),
+		)
+	}()
 
 	// bot without partnerPlugin and with rpc server (distributor)
-	tt.distributorBot = tt.CreateBot(ctx, t, true, nil)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		tt.distributorBot = tt.CreateBot(ctx, t, true, nil)
+	}()
+
+	wg.Wait()
 }
 
 func testBotSanitySendCommonRequest(ctx context.Context, pingMessage string, distributorBot *bot.Bot, supplierBot *bot.Bot) error {

--- a/tests/e2e/tests/test_cancellation_v1.go
+++ b/tests/e2e/tests/test_cancellation_v1.go
@@ -6,6 +6,7 @@ package tests
 import (
 	"context"
 	"math/big"
+	"sync"
 	"testing"
 	"time"
 
@@ -76,28 +77,38 @@ func (tt *TestCancellationV1) prepare(ctx context.Context, t *testing.T) {
 		botGenerated.CheckCancellationServiceV1,
 	))
 
-	tt.supplierPartnerPlugin = tt.CreatePartnerPlugin(ctx, t)
+	wg := sync.WaitGroup{}
 
-	// bot with partnerPlugin and without rpc server (supplier)
-	tt.supplierBot = tt.CreateBot(ctx, t, true, tt.supplierPartnerPlugin,
-		bot.WithServices([]bot.CMService{
-			{Name: botGenerated.AccommodationSearchServiceV3, Fee: 120},
-			{Name: botGenerated.ValidationServiceV2, Fee: 130},
-			{Name: botGenerated.MintServiceV3, Fee: 140},
-			{Name: botGenerated.CheckCancellationServiceV1, Fee: 150},
-		}),
-	)
+	// supplier bot
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		tt.supplierPartnerPlugin = tt.CreatePartnerPlugin(ctx, t)
+		tt.supplierBot = tt.CreateBot(ctx, t, true, tt.supplierPartnerPlugin,
+			bot.WithServices([]bot.CMService{
+				{Name: botGenerated.AccommodationSearchServiceV3, Fee: 120},
+				{Name: botGenerated.ValidationServiceV2, Fee: 130},
+				{Name: botGenerated.MintServiceV3, Fee: 140},
+				{Name: botGenerated.CheckCancellationServiceV1, Fee: 150},
+			}),
+		)
+		var err error
+		tt.supplierPPEventStream, err = tt.supplierPartnerPlugin.SubscribeForEvents(ctx)
+		require.NoError(t, err)
+	}()
 
-	tt.distributorPartnerPlugin = tt.CreatePartnerPlugin(ctx, t)
+	// distributor bot
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		tt.distributorPartnerPlugin = tt.CreatePartnerPlugin(ctx, t)
+		tt.distributorBot = tt.CreateBot(ctx, t, true, tt.distributorPartnerPlugin)
+		var err error
+		tt.distributorPPEventStream, err = tt.distributorPartnerPlugin.SubscribeForEvents(ctx)
+		require.NoError(t, err)
+	}()
 
-	// bot without partnerPlugin and with rpc server (distributor)
-	tt.distributorBot = tt.CreateBot(ctx, t, true, tt.distributorPartnerPlugin)
-
-	var err error
-	tt.supplierPPEventStream, err = tt.supplierPartnerPlugin.SubscribeForEvents(ctx)
-	require.NoError(t, err)
-	tt.distributorPPEventStream, err = tt.distributorPartnerPlugin.SubscribeForEvents(ctx)
-	require.NoError(t, err)
+	wg.Wait()
 }
 
 func (tt *TestCancellationV1) testCancellationV1DistributorInitiatesBasic(ctx context.Context, t *testing.T) {

--- a/tests/e2e/tests/test_mint_v2.go
+++ b/tests/e2e/tests/test_mint_v2.go
@@ -5,6 +5,7 @@ package tests
 
 import (
 	"context"
+	"sync"
 	"testing"
 
 	bookv2 "buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go/cmp/services/book/v2"
@@ -65,30 +66,45 @@ func (tt *TestMintV2) prepare(ctx context.Context, t *testing.T) {
 		botGenerated.MintServiceV2,
 	))
 
-	tt.supplierPartnerPlugin = tt.CreatePartnerPlugin(ctx, t)
+	wg := sync.WaitGroup{}
 
 	// bot with partnerPlugin and without rpc server (supplier)
-	tt.supplierBot = tt.CreateBot(ctx, t, true, tt.supplierPartnerPlugin,
-		bot.WithServices([]bot.CMService{
-			{Name: botGenerated.AccommodationSearchServiceV3, Fee: 120},
-			{Name: botGenerated.ValidationServiceV2, Fee: 130},
-			{Name: botGenerated.MintServiceV2, Fee: 140},
-		}),
-	)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		tt.supplierPartnerPlugin = tt.CreatePartnerPlugin(ctx, t)
+		tt.supplierBot = tt.CreateBot(ctx, t, true, tt.supplierPartnerPlugin,
+			bot.WithServices([]bot.CMService{
+				{Name: botGenerated.AccommodationSearchServiceV3, Fee: 120},
+				{Name: botGenerated.ValidationServiceV2, Fee: 130},
+				{Name: botGenerated.MintServiceV2, Fee: 140},
+			}),
+		)
+
+		var err error
+		tt.supplierPPEventStream, err = tt.supplierPartnerPlugin.SubscribeForEvents(ctx)
+		require.NoError(t, err)
+	}()
 
 	// bot without partnerPlugin and with rpc server (distributor)
-	tt.distributorBot = tt.CreateBot(ctx, t, true, nil)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		tt.distributorBot = tt.CreateBot(ctx, t, true, nil)
+	}()
 
 	// bot without partnerPlugin and with rpc server (distributor) but with the
 	// catch, that the bot account does not have funds to pay for the fees when
 	// trying to buy the booking token.
-	tt.distributorBotWithoutFunds = tt.CreateBot(ctx, t, true, nil,
-		bot.WithSkips(&bot.Skip{PrefundBot: true}),
-	)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		tt.distributorBotWithoutFunds = tt.CreateBot(ctx, t, true, nil,
+			bot.WithSkips(&bot.Skip{PrefundBot: true}),
+		)
+	}()
 
-	var err error
-	tt.supplierPPEventStream, err = tt.supplierPartnerPlugin.SubscribeForEvents(ctx)
-	require.NoError(t, err)
+	wg.Wait()
 }
 
 func (tt *TestMintV2) testMintV2FullWorkflow(ctx context.Context, t *testing.T) {

--- a/tests/e2e/tests/test_periodic_cash_in.go
+++ b/tests/e2e/tests/test_periodic_cash_in.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"math/big"
+	"sync"
 	"testing"
 	"time"
 
@@ -64,21 +65,32 @@ func (tt *TestCashIn) prepare(ctx context.Context, t *testing.T) {
 	// Register all the services needed for the tests
 	require.NoError(t, tt.CaminoNetwork.Client.RegisterCMServices(ctx, botGenerated.PingServiceV1))
 
-	tt.supplierPartnerPlugin = tt.CreatePartnerPlugin(ctx, t)
-
 	tt.pingFee = 5_000_000_000_000_000
 
+	wg := sync.WaitGroup{}
+
 	// bot with partnerPlugin and without rpc server (supplier)
-	tt.supplierBot = tt.CreateBot(ctx, t, true, tt.supplierPartnerPlugin,
-		bot.WithServices([]bot.CMService{{Name: botGenerated.PingServiceV1, Fee: tt.pingFee}}),
-		bot.WithCashInPeriod(tt.cashInPeriodSeconds), // cash-in every 10 seconds
-	)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		tt.supplierPartnerPlugin = tt.CreatePartnerPlugin(ctx, t)
+		tt.supplierBot = tt.CreateBot(ctx, t, true, tt.supplierPartnerPlugin,
+			bot.WithServices([]bot.CMService{{Name: botGenerated.PingServiceV1, Fee: tt.pingFee}}),
+			bot.WithCashInPeriod(tt.cashInPeriodSeconds), // cash-in every 10 seconds
+		)
+	}()
 
 	// bot without partnerPlugin and with rpc server (distributor)
-	tt.distributorBot = tt.CreateBot(ctx, t, true, nil,
-		// has nothing to cash in, so we'll just check that nothing unexpected happens
-		bot.WithCashInPeriod(tt.cashInPeriodSeconds), // cash-in every 10 seconds
-	)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		tt.distributorBot = tt.CreateBot(ctx, t, true, nil,
+			// has nothing to cash in, so we'll just check that nothing unexpected happens
+			bot.WithCashInPeriod(tt.cashInPeriodSeconds), // cash-in every 10 seconds
+		)
+	}()
+
+	wg.Wait()
 }
 
 func (tt *TestCashIn) testPeriodicCashInWithPingV1(ctx context.Context, t *testing.T) {

--- a/tests/e2e/tests/test_ping.go
+++ b/tests/e2e/tests/test_ping.go
@@ -6,6 +6,7 @@ package tests
 import (
 	"context"
 	"fmt"
+	"sync"
 	"testing"
 
 	pingv1 "buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go/cmp/services/ping/v1"
@@ -50,15 +51,26 @@ func (tt *TestPingV1) Run(t *testing.T) {
 func (tt *TestPingV1) prepare(ctx context.Context, t *testing.T) {
 	require.NoError(t, tt.CaminoNetwork.Client.RegisterCMServices(ctx, botGenerated.PingServiceV1))
 
-	tt.supplierPartnerPlugin = tt.CreatePartnerPlugin(ctx, t)
+	wg := sync.WaitGroup{}
 
 	// bot with partnerPlugin and without rpc server (supplier)
-	tt.supplierBot = tt.CreateBot(ctx, t, true, tt.supplierPartnerPlugin,
-		bot.WithServices([]bot.CMService{{Name: botGenerated.PingServiceV1, Fee: 100}}),
-	)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		tt.supplierPartnerPlugin = tt.CreatePartnerPlugin(ctx, t)
+		tt.supplierBot = tt.CreateBot(ctx, t, true, tt.supplierPartnerPlugin,
+			bot.WithServices([]bot.CMService{{Name: botGenerated.PingServiceV1, Fee: 100}}),
+		)
+	}()
 
 	// bot without partnerPlugin and with rpc server (distributor)
-	tt.distributorBot = tt.CreateBot(ctx, t, true, nil)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		tt.distributorBot = tt.CreateBot(ctx, t, true, nil)
+	}()
+
+	wg.Wait()
 }
 
 func (tt *TestPingV1) testPingV1Service(ctx context.Context, t *testing.T) {

--- a/tests/e2e/tests/test_transport_v3.go
+++ b/tests/e2e/tests/test_transport_v3.go
@@ -6,6 +6,7 @@ package tests
 import (
 	"context"
 	"math/big"
+	"sync"
 	"testing"
 	"time"
 
@@ -94,20 +95,31 @@ func (tt *TestTransportV3) prepare(ctx context.Context, t *testing.T) {
 		botGenerated.MintServiceV2,
 	))
 
-	tt.supplierPartnerPlugin = tt.CreatePartnerPlugin(ctx, t)
+	wg := sync.WaitGroup{}
 
 	// bot with partnerPlugin and without rpc server (supplier)
-	tt.supplierBot = tt.CreateBot(ctx, t, true, tt.supplierPartnerPlugin,
-		bot.WithServices([]bot.CMService{
-			{Name: botGenerated.TransportProductListServiceV3, Fee: 100},
-			{Name: botGenerated.TransportSearchServiceV3, Fee: 120},
-			{Name: botGenerated.ValidationServiceV2, Fee: 130},
-			{Name: botGenerated.MintServiceV2, Fee: 140},
-		}),
-	)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		tt.supplierPartnerPlugin = tt.CreatePartnerPlugin(ctx, t)
+		tt.supplierBot = tt.CreateBot(ctx, t, true, tt.supplierPartnerPlugin,
+			bot.WithServices([]bot.CMService{
+				{Name: botGenerated.TransportProductListServiceV3, Fee: 100},
+				{Name: botGenerated.TransportSearchServiceV3, Fee: 120},
+				{Name: botGenerated.ValidationServiceV2, Fee: 130},
+				{Name: botGenerated.MintServiceV2, Fee: 140},
+			}),
+		)
+	}()
 
 	// bot without partnerPlugin and with rpc server (distributor)
-	tt.distributorBot = tt.CreateBot(ctx, t, true, nil)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		tt.distributorBot = tt.CreateBot(ctx, t, true, nil)
+	}()
+
+	wg.Wait()
 }
 
 // Simple product list request which shall return all properties. Checking if all are present


### PR DESCRIPTION
Update bot and partner plugin factories and network client to allow parallel execution.
Update existing e2e tests to setup bots in parallel