### PR TITLE
Support error response header v4

### DIFF
--- a/internal/common/response_header.go
+++ b/internal/common/response_header.go
@@ -5,6 +5,7 @@ package common
 
 import (
 	typesv1 "buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go/cmp/types/v1"
+	typesv4 "buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go/cmp/types/v4"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/reflect/protoreflect"
 )
@@ -32,6 +33,8 @@ func (h *responseHeaderHandler) AddError(response protoreflect.ProtoMessage, err
 	switch header := headerReflectValue.Message().Interface().(type) {
 	case *typesv1.ResponseHeader:
 		addErrorToResponseHeaderV1(header, errMessage)
+	case *typesv4.ResponseHeader:
+		addErrorToResponseHeaderV4(header, errMessage)
 	default:
 		h.logger.Errorf("failed add error to response header: %v", errMessage)
 	}
@@ -42,5 +45,13 @@ func addErrorToResponseHeaderV1(header *typesv1.ResponseHeader, errMessage strin
 	header.Alerts = append(header.Alerts, &typesv1.Alert{
 		Message: errMessage,
 		Type:    typesv1.AlertType_ALERT_TYPE_ERROR,
+	})
+}
+
+func addErrorToResponseHeaderV4(header *typesv4.ResponseHeader, errMessage string) {
+	header.Status = typesv4.StatusType_STATUS_TYPE_FAILURE
+	header.Alerts = append(header.Alerts, &typesv4.Alert{
+		Message: errMessage,
+		Type:    typesv4.AlertType_ALERT_TYPE_ERROR,
 	})
 }


### PR DESCRIPTION
Required by all v4 responses. Otherwise bot will fail to add error to response.