### PR TITLE
Remove concurrent bots setup in e2e tests

### DIFF
--- a/tests/e2e/tests/test_accommodation_v2.go
+++ b/tests/e2e/tests/test_accommodation_v2.go
@@ -6,7 +6,6 @@ package tests
 import (
 	"context"
 	"math/big"
-	"sync"
 	"testing"
 	"time"
 
@@ -92,32 +91,20 @@ func (tt *TestAccommodationV2) prepare(ctx context.Context, t *testing.T) {
 		botGenerated.MintServiceV2,
 	))
 
-	wg := sync.WaitGroup{}
-
 	// bot with partnerPlugin and without rpc server (supplier)
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		tt.supplierPartnerPlugin = tt.CreatePartnerPlugin(ctx, t)
-		tt.supplierBot = tt.CreateBot(ctx, t, true, tt.supplierPartnerPlugin,
-			bot.WithServices([]bot.CMService{
-				{Name: botGenerated.AccommodationProductListServiceV2, Fee: 100},
-				{Name: botGenerated.AccommodationProductInfoServiceV2, Fee: 110},
-				{Name: botGenerated.AccommodationSearchServiceV2, Fee: 120},
-				{Name: botGenerated.ValidationServiceV2, Fee: 130},
-				{Name: botGenerated.MintServiceV2, Fee: 140},
-			}),
-		)
-	}()
+	tt.supplierPartnerPlugin = tt.CreatePartnerPlugin(ctx, t)
+	tt.supplierBot = tt.CreateBot(ctx, t, true, tt.supplierPartnerPlugin,
+		bot.WithServices([]bot.CMService{
+			{Name: botGenerated.AccommodationProductListServiceV2, Fee: 100},
+			{Name: botGenerated.AccommodationProductInfoServiceV2, Fee: 110},
+			{Name: botGenerated.AccommodationSearchServiceV2, Fee: 120},
+			{Name: botGenerated.ValidationServiceV2, Fee: 130},
+			{Name: botGenerated.MintServiceV2, Fee: 140},
+		}),
+	)
 
 	// bot without partnerPlugin and with rpc server (distributor)
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		tt.distributorBot = tt.CreateBot(ctx, t, true, nil)
-	}()
-
-	wg.Wait()
+	tt.distributorBot = tt.CreateBot(ctx, t, true, nil)
 }
 
 // Simple product list request which shall return all properties. Checking if all are present

--- a/tests/e2e/tests/test_accommodation_v3.go
+++ b/tests/e2e/tests/test_accommodation_v3.go
@@ -6,7 +6,6 @@ package tests
 import (
 	"context"
 	"math/big"
-	"sync"
 	"testing"
 	"time"
 
@@ -94,32 +93,20 @@ func (tt *TestAccommodationV3) prepare(ctx context.Context, t *testing.T) {
 		botGenerated.MintServiceV2,
 	))
 
-	wg := sync.WaitGroup{}
-
 	// bot with partnerPlugin and without rpc server (supplier)
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		tt.supplierPartnerPlugin = tt.CreatePartnerPlugin(ctx, t)
-		tt.supplierBot = tt.CreateBot(ctx, t, true, tt.supplierPartnerPlugin,
-			bot.WithServices([]bot.CMService{
-				{Name: botGenerated.AccommodationProductListServiceV3, Fee: 100},
-				{Name: botGenerated.AccommodationProductInfoServiceV3, Fee: 110},
-				{Name: botGenerated.AccommodationSearchServiceV3, Fee: 120},
-				{Name: botGenerated.ValidationServiceV2, Fee: 130},
-				{Name: botGenerated.MintServiceV2, Fee: 140},
-			}),
-		)
-	}()
+	tt.supplierPartnerPlugin = tt.CreatePartnerPlugin(ctx, t)
+	tt.supplierBot = tt.CreateBot(ctx, t, true, tt.supplierPartnerPlugin,
+		bot.WithServices([]bot.CMService{
+			{Name: botGenerated.AccommodationProductListServiceV3, Fee: 100},
+			{Name: botGenerated.AccommodationProductInfoServiceV3, Fee: 110},
+			{Name: botGenerated.AccommodationSearchServiceV3, Fee: 120},
+			{Name: botGenerated.ValidationServiceV2, Fee: 130},
+			{Name: botGenerated.MintServiceV2, Fee: 140},
+		}),
+	)
 
 	// bot without partnerPlugin and with rpc server (distributor)
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		tt.distributorBot = tt.CreateBot(ctx, t, true, nil)
-	}()
-
-	wg.Wait()
+	tt.distributorBot = tt.CreateBot(ctx, t, true, nil)
 }
 
 // Simple product list request which shall return all properties. Checking if all are present

--- a/tests/e2e/tests/test_activity_v2.go
+++ b/tests/e2e/tests/test_activity_v2.go
@@ -6,7 +6,6 @@ package tests
 import (
 	"context"
 	"math/big"
-	"sync"
 	"testing"
 	"time"
 
@@ -94,32 +93,20 @@ func (tt *TestActivityV2) prepare(ctx context.Context, t *testing.T) {
 		botGenerated.MintServiceV2,
 	))
 
-	wg := sync.WaitGroup{}
-
 	// bot with partnerPlugin and without rpc server (supplier)
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		tt.supplierPartnerPlugin = tt.CreatePartnerPlugin(ctx, t)
-		tt.supplierBot = tt.CreateBot(ctx, t, true, tt.supplierPartnerPlugin,
-			bot.WithServices([]bot.CMService{
-				{Name: botGenerated.ActivityProductListServiceV2, Fee: 100},
-				{Name: botGenerated.ActivityProductInfoServiceV2, Fee: 110},
-				{Name: botGenerated.ActivitySearchServiceV2, Fee: 120},
-				{Name: botGenerated.ValidationServiceV2, Fee: 130},
-				{Name: botGenerated.MintServiceV2, Fee: 140},
-			}),
-		)
-	}()
+	tt.supplierPartnerPlugin = tt.CreatePartnerPlugin(ctx, t)
+	tt.supplierBot = tt.CreateBot(ctx, t, true, tt.supplierPartnerPlugin,
+		bot.WithServices([]bot.CMService{
+			{Name: botGenerated.ActivityProductListServiceV2, Fee: 100},
+			{Name: botGenerated.ActivityProductInfoServiceV2, Fee: 110},
+			{Name: botGenerated.ActivitySearchServiceV2, Fee: 120},
+			{Name: botGenerated.ValidationServiceV2, Fee: 130},
+			{Name: botGenerated.MintServiceV2, Fee: 140},
+		}),
+	)
 
 	// bot without partnerPlugin and with rpc server (distributor)
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		tt.distributorBot = tt.CreateBot(ctx, t, true, nil)
-	}()
-
-	wg.Wait()
+	tt.distributorBot = tt.CreateBot(ctx, t, true, nil)
 }
 
 // Simple product list request which shall return all activities. Checking if all are present

--- a/tests/e2e/tests/test_activity_v3.go
+++ b/tests/e2e/tests/test_activity_v3.go
@@ -6,7 +6,6 @@ package tests
 import (
 	"context"
 	"math/big"
-	"sync"
 	"testing"
 	"time"
 
@@ -95,32 +94,20 @@ func (tt *TestActivityV3) prepare(ctx context.Context, t *testing.T) {
 		botGenerated.MintServiceV2,
 	))
 
-	wg := sync.WaitGroup{}
-
 	// bot with partnerPlugin and without rpc server (supplier)
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		tt.supplierPartnerPlugin = tt.CreatePartnerPlugin(ctx, t)
-		tt.supplierBot = tt.CreateBot(ctx, t, true, tt.supplierPartnerPlugin,
-			bot.WithServices([]bot.CMService{
-				{Name: botGenerated.ActivityProductListServiceV3, Fee: 100},
-				{Name: botGenerated.ActivityProductInfoServiceV3, Fee: 110},
-				{Name: botGenerated.ActivitySearchServiceV3, Fee: 120},
-				{Name: botGenerated.ValidationServiceV2, Fee: 130},
-				{Name: botGenerated.MintServiceV2, Fee: 140},
-			}),
-		)
-	}()
+	tt.supplierPartnerPlugin = tt.CreatePartnerPlugin(ctx, t)
+	tt.supplierBot = tt.CreateBot(ctx, t, true, tt.supplierPartnerPlugin,
+		bot.WithServices([]bot.CMService{
+			{Name: botGenerated.ActivityProductListServiceV3, Fee: 100},
+			{Name: botGenerated.ActivityProductInfoServiceV3, Fee: 110},
+			{Name: botGenerated.ActivitySearchServiceV3, Fee: 120},
+			{Name: botGenerated.ValidationServiceV2, Fee: 130},
+			{Name: botGenerated.MintServiceV2, Fee: 140},
+		}),
+	)
 
 	// bot without partnerPlugin and with rpc server (distributor)
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		tt.distributorBot = tt.CreateBot(ctx, t, true, nil)
-	}()
-
-	wg.Wait()
+	tt.distributorBot = tt.CreateBot(ctx, t, true, nil)
 }
 
 // Simple product list request which shall return all activities. Checking if all are present

--- a/tests/e2e/tests/test_bot_sanity.go
+++ b/tests/e2e/tests/test_bot_sanity.go
@@ -5,7 +5,6 @@ package tests
 
 import (
 	"context"
-	"sync"
 	"testing"
 	"time"
 
@@ -104,53 +103,33 @@ func (tt *TestBotSanity) prepareAfterCMManagerRegisterServices(ctx context.Conte
 		botGenerated.MintServiceV3,
 	))
 
-	wg := sync.WaitGroup{}
-
 	// This bot does actually have the CM-Account and prefunding of the owner
 	// But only the bot registration is missing in the CM-Account
 	// With that the distributor bot should not be able to find the supplier bot
 	// and fail with an error in a later test
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		tt.supplierBotUnregistered = tt.CreateBot(ctx, t, false, tt.supplierPartnerPlugin,
-			bot.WithServices([]bot.CMService{{Name: botGenerated.PingServiceV1, Fee: 100}}),
-			bot.WithSkips(&bot.Skip{BotRegistration: true}),
-		)
-	}()
+	tt.supplierBotUnregistered = tt.CreateBot(ctx, t, false, tt.supplierPartnerPlugin,
+		bot.WithServices([]bot.CMService{{Name: botGenerated.PingServiceV1, Fee: 100}}),
+		bot.WithSkips(&bot.Skip{BotRegistration: true}),
+	)
 
 	// This bot does actually have the CM-Account and prefunding of the owner
 	// and is also registered in the CM-Account **BUT** the service registration
 	// is missing - this is checked by the bot but results only in a warning
 	// inside of the logs. We can later use this bot to check if the distributor
 	// bot acts correctly by rejecting this supplier bot as the required service is missing
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		tt.supplierBotNoServices = tt.CreateBot(ctx, t, false, tt.supplierPartnerPlugin,
-			bot.WithServices([]bot.CMService{{Name: botGenerated.PingServiceV1, Fee: 100}}),
-			bot.WithSkips(&bot.Skip{ServiceRegistration: true}),
-		)
-	}()
+	tt.supplierBotNoServices = tt.CreateBot(ctx, t, false, tt.supplierPartnerPlugin,
+		bot.WithServices([]bot.CMService{{Name: botGenerated.PingServiceV1, Fee: 100}}),
+		bot.WithSkips(&bot.Skip{ServiceRegistration: true}),
+	)
 
 	// All good here - just a different service used which should then
 	// fail in the later test
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		tt.supplierBotDifferentServices = tt.CreateBot(ctx, t, false, tt.supplierPartnerPlugin,
-			bot.WithServices([]bot.CMService{{Name: botGenerated.MintServiceV3, Fee: 100}}),
-		)
-	}()
+	tt.supplierBotDifferentServices = tt.CreateBot(ctx, t, false, tt.supplierPartnerPlugin,
+		bot.WithServices([]bot.CMService{{Name: botGenerated.MintServiceV3, Fee: 100}}),
+	)
 
 	// bot without partnerPlugin and with rpc server (distributor)
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		tt.distributorBot = tt.CreateBot(ctx, t, true, nil)
-	}()
-
-	wg.Wait()
+	tt.distributorBot = tt.CreateBot(ctx, t, true, nil)
 }
 
 func testBotSanitySendCommonRequest(ctx context.Context, pingMessage string, distributorBot *bot.Bot, supplierBot *bot.Bot) error {

--- a/tests/e2e/tests/test_cancellation_v1.go
+++ b/tests/e2e/tests/test_cancellation_v1.go
@@ -6,7 +6,6 @@ package tests
 import (
 	"context"
 	"math/big"
-	"sync"
 	"testing"
 	"time"
 
@@ -77,38 +76,26 @@ func (tt *TestCancellationV1) prepare(ctx context.Context, t *testing.T) {
 		botGenerated.CheckCancellationServiceV1,
 	))
 
-	wg := sync.WaitGroup{}
+	var err error
 
 	// supplier bot
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		tt.supplierPartnerPlugin = tt.CreatePartnerPlugin(ctx, t)
-		tt.supplierBot = tt.CreateBot(ctx, t, true, tt.supplierPartnerPlugin,
-			bot.WithServices([]bot.CMService{
-				{Name: botGenerated.AccommodationSearchServiceV3, Fee: 120},
-				{Name: botGenerated.ValidationServiceV3, Fee: 130},
-				{Name: botGenerated.MintServiceV3, Fee: 140},
-				{Name: botGenerated.CheckCancellationServiceV1, Fee: 150},
-			}),
-		)
-		var err error
-		tt.supplierPPEventStream, err = tt.supplierPartnerPlugin.SubscribeForEvents(ctx)
-		require.NoError(t, err)
-	}()
+	tt.supplierPartnerPlugin = tt.CreatePartnerPlugin(ctx, t)
+	tt.supplierBot = tt.CreateBot(ctx, t, true, tt.supplierPartnerPlugin,
+		bot.WithServices([]bot.CMService{
+			{Name: botGenerated.AccommodationSearchServiceV3, Fee: 120},
+			{Name: botGenerated.ValidationServiceV3, Fee: 130},
+			{Name: botGenerated.MintServiceV3, Fee: 140},
+			{Name: botGenerated.CheckCancellationServiceV1, Fee: 150},
+		}),
+	)
+	tt.supplierPPEventStream, err = tt.supplierPartnerPlugin.SubscribeForEvents(ctx)
+	require.NoError(t, err)
 
 	// distributor bot
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		tt.distributorPartnerPlugin = tt.CreatePartnerPlugin(ctx, t)
-		tt.distributorBot = tt.CreateBot(ctx, t, true, tt.distributorPartnerPlugin)
-		var err error
-		tt.distributorPPEventStream, err = tt.distributorPartnerPlugin.SubscribeForEvents(ctx)
-		require.NoError(t, err)
-	}()
-
-	wg.Wait()
+	tt.distributorPartnerPlugin = tt.CreatePartnerPlugin(ctx, t)
+	tt.distributorBot = tt.CreateBot(ctx, t, true, tt.distributorPartnerPlugin)
+	tt.distributorPPEventStream, err = tt.distributorPartnerPlugin.SubscribeForEvents(ctx)
+	require.NoError(t, err)
 }
 
 func (tt *TestCancellationV1) testCancellationV1DistributorInitiatesBasic(ctx context.Context, t *testing.T) {

--- a/tests/e2e/tests/test_mint_v2.go
+++ b/tests/e2e/tests/test_mint_v2.go
@@ -5,7 +5,6 @@ package tests
 
 import (
 	"context"
-	"sync"
 	"testing"
 
 	bookv2 "buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go/cmp/services/book/v2"
@@ -66,45 +65,29 @@ func (tt *TestMintV2) prepare(ctx context.Context, t *testing.T) {
 		botGenerated.MintServiceV2,
 	))
 
-	wg := sync.WaitGroup{}
-
 	// bot with partnerPlugin and without rpc server (supplier)
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		tt.supplierPartnerPlugin = tt.CreatePartnerPlugin(ctx, t)
-		tt.supplierBot = tt.CreateBot(ctx, t, true, tt.supplierPartnerPlugin,
-			bot.WithServices([]bot.CMService{
-				{Name: botGenerated.AccommodationSearchServiceV3, Fee: 120},
-				{Name: botGenerated.ValidationServiceV2, Fee: 130},
-				{Name: botGenerated.MintServiceV2, Fee: 140},
-			}),
-		)
+	tt.supplierPartnerPlugin = tt.CreatePartnerPlugin(ctx, t)
+	tt.supplierBot = tt.CreateBot(ctx, t, true, tt.supplierPartnerPlugin,
+		bot.WithServices([]bot.CMService{
+			{Name: botGenerated.AccommodationSearchServiceV3, Fee: 120},
+			{Name: botGenerated.ValidationServiceV2, Fee: 130},
+			{Name: botGenerated.MintServiceV2, Fee: 140},
+		}),
+	)
 
-		var err error
-		tt.supplierPPEventStream, err = tt.supplierPartnerPlugin.SubscribeForEvents(ctx)
-		require.NoError(t, err)
-	}()
+	var err error
+	tt.supplierPPEventStream, err = tt.supplierPartnerPlugin.SubscribeForEvents(ctx)
+	require.NoError(t, err)
 
 	// bot without partnerPlugin and with rpc server (distributor)
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		tt.distributorBot = tt.CreateBot(ctx, t, true, nil)
-	}()
+	tt.distributorBot = tt.CreateBot(ctx, t, true, nil)
 
 	// bot without partnerPlugin and with rpc server (distributor) but with the
 	// catch, that the bot account does not have funds to pay for the fees when
 	// trying to buy the booking token.
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		tt.distributorBotWithoutFunds = tt.CreateBot(ctx, t, true, nil,
-			bot.WithSkips(&bot.Skip{PrefundBot: true}),
-		)
-	}()
-
-	wg.Wait()
+	tt.distributorBotWithoutFunds = tt.CreateBot(ctx, t, true, nil,
+		bot.WithSkips(&bot.Skip{PrefundBot: true}),
+	)
 }
 
 func (tt *TestMintV2) testMintV2FullWorkflow(ctx context.Context, t *testing.T) {

--- a/tests/e2e/tests/test_periodic_cash_in.go
+++ b/tests/e2e/tests/test_periodic_cash_in.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"math/big"
-	"sync"
 	"testing"
 	"time"
 
@@ -67,30 +66,18 @@ func (tt *TestCashIn) prepare(ctx context.Context, t *testing.T) {
 
 	tt.pingFee = 5_000_000_000_000_000
 
-	wg := sync.WaitGroup{}
-
 	// bot with partnerPlugin and without rpc server (supplier)
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		tt.supplierPartnerPlugin = tt.CreatePartnerPlugin(ctx, t)
-		tt.supplierBot = tt.CreateBot(ctx, t, true, tt.supplierPartnerPlugin,
-			bot.WithServices([]bot.CMService{{Name: botGenerated.PingServiceV1, Fee: tt.pingFee}}),
-			bot.WithCashInPeriod(tt.cashInPeriodSeconds), // cash-in every 10 seconds
-		)
-	}()
+	tt.supplierPartnerPlugin = tt.CreatePartnerPlugin(ctx, t)
+	tt.supplierBot = tt.CreateBot(ctx, t, true, tt.supplierPartnerPlugin,
+		bot.WithServices([]bot.CMService{{Name: botGenerated.PingServiceV1, Fee: tt.pingFee}}),
+		bot.WithCashInPeriod(tt.cashInPeriodSeconds), // cash-in every 10 seconds
+	)
 
 	// bot without partnerPlugin and with rpc server (distributor)
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		tt.distributorBot = tt.CreateBot(ctx, t, true, nil,
-			// has nothing to cash in, so we'll just check that nothing unexpected happens
-			bot.WithCashInPeriod(tt.cashInPeriodSeconds), // cash-in every 10 seconds
-		)
-	}()
-
-	wg.Wait()
+	tt.distributorBot = tt.CreateBot(ctx, t, true, nil,
+		// has nothing to cash in, so we'll just check that nothing unexpected happens
+		bot.WithCashInPeriod(tt.cashInPeriodSeconds), // cash-in every 10 seconds
+	)
 }
 
 func (tt *TestCashIn) testPeriodicCashInWithPingV1(ctx context.Context, t *testing.T) {

--- a/tests/e2e/tests/test_ping_v1.go
+++ b/tests/e2e/tests/test_ping_v1.go
@@ -6,7 +6,6 @@ package tests
 import (
 	"context"
 	"fmt"
-	"sync"
 	"testing"
 
 	pingv1 "buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go/cmp/services/ping/v1"
@@ -51,26 +50,14 @@ func (tt *TestPingV1) Run(t *testing.T) {
 func (tt *TestPingV1) prepare(ctx context.Context, t *testing.T) {
 	require.NoError(t, tt.CaminoNetwork.Client.RegisterCMServices(ctx, botGenerated.PingServiceV1))
 
-	wg := sync.WaitGroup{}
-
 	// bot with partnerPlugin and without rpc server (supplier)
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		tt.supplierPartnerPlugin = tt.CreatePartnerPlugin(ctx, t)
-		tt.supplierBot = tt.CreateBot(ctx, t, true, tt.supplierPartnerPlugin,
-			bot.WithServices([]bot.CMService{{Name: botGenerated.PingServiceV1, Fee: 100}}),
-		)
-	}()
+	tt.supplierPartnerPlugin = tt.CreatePartnerPlugin(ctx, t)
+	tt.supplierBot = tt.CreateBot(ctx, t, true, tt.supplierPartnerPlugin,
+		bot.WithServices([]bot.CMService{{Name: botGenerated.PingServiceV1, Fee: 100}}),
+	)
 
 	// bot without partnerPlugin and with rpc server (distributor)
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		tt.distributorBot = tt.CreateBot(ctx, t, true, nil)
-	}()
-
-	wg.Wait()
+	tt.distributorBot = tt.CreateBot(ctx, t, true, nil)
 }
 
 func (tt *TestPingV1) testPingV1Service(ctx context.Context, t *testing.T) {

--- a/tests/e2e/tests/test_seat_map_v4.go
+++ b/tests/e2e/tests/test_seat_map_v4.go
@@ -5,7 +5,6 @@ package tests
 
 import (
 	"context"
-	"sync"
 	"testing"
 
 	seatmapv4 "buf.build/gen/go/chain4travel/camino-messenger-protocol/protocolbuffers/go/cmp/services/seat_map/v4"
@@ -96,37 +95,25 @@ func (tt *TestSeatMapV4) prepare(ctx context.Context, t *testing.T) {
 		botGenerated.SeatMapAvailabilityServiceV4,
 	))
 
-	wg := sync.WaitGroup{}
-
 	// bot with partnerPlugin and without rpc server (supplier)
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		tt.supplierPartnerPlugin = tt.CreatePartnerPlugin(ctx, t)
-		tt.supplierBot = tt.CreateBot(ctx, t, true, tt.supplierPartnerPlugin,
-			bot.WithServices([]bot.CMService{
-				{Name: botGenerated.TransportProductListServiceV3, Fee: 100},
-				{Name: botGenerated.TransportSearchServiceV3, Fee: 110},
-				{Name: botGenerated.ActivitySearchServiceV3, Fee: 120},
-				{Name: botGenerated.ValidationServiceV3, Fee: 130},
-				{Name: botGenerated.MintServiceV3, Fee: 140},
-				{Name: botGenerated.SeatMapServiceV4, Fee: 150},
-				{Name: botGenerated.SeatMapAvailabilityServiceV4, Fee: 160},
-			}),
-		)
-		var err error
-		tt.supplierPPEventStream, err = tt.supplierPartnerPlugin.SubscribeForEvents(ctx)
-		require.NoError(t, err)
-	}()
+	tt.supplierPartnerPlugin = tt.CreatePartnerPlugin(ctx, t)
+	tt.supplierBot = tt.CreateBot(ctx, t, true, tt.supplierPartnerPlugin,
+		bot.WithServices([]bot.CMService{
+			{Name: botGenerated.TransportProductListServiceV3, Fee: 100},
+			{Name: botGenerated.TransportSearchServiceV3, Fee: 110},
+			{Name: botGenerated.ActivitySearchServiceV3, Fee: 120},
+			{Name: botGenerated.ValidationServiceV3, Fee: 130},
+			{Name: botGenerated.MintServiceV3, Fee: 140},
+			{Name: botGenerated.SeatMapServiceV4, Fee: 150},
+			{Name: botGenerated.SeatMapAvailabilityServiceV4, Fee: 160},
+		}),
+	)
+	var err error
+	tt.supplierPPEventStream, err = tt.supplierPartnerPlugin.SubscribeForEvents(ctx)
+	require.NoError(t, err)
 
 	// bot without partnerPlugin and with rpc server (distributor)
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		tt.distributorBot = tt.CreateBot(ctx, t, true, nil)
-	}()
-
-	wg.Wait()
+	tt.distributorBot = tt.CreateBot(ctx, t, true, nil)
 }
 
 func (tt *TestSeatMapV4) testSeatMapAvailabilityV4WithSearchID(ctx context.Context, t *testing.T, searchID string, expectedSeatMapInventory *typesv4.SeatMapInventory) {

--- a/tests/e2e/tests/test_transport_v3.go
+++ b/tests/e2e/tests/test_transport_v3.go
@@ -6,7 +6,6 @@ package tests
 import (
 	"context"
 	"math/big"
-	"sync"
 	"testing"
 	"time"
 
@@ -95,31 +94,19 @@ func (tt *TestTransportV3) prepare(ctx context.Context, t *testing.T) {
 		botGenerated.MintServiceV2,
 	))
 
-	wg := sync.WaitGroup{}
-
 	// bot with partnerPlugin and without rpc server (supplier)
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		tt.supplierPartnerPlugin = tt.CreatePartnerPlugin(ctx, t)
-		tt.supplierBot = tt.CreateBot(ctx, t, true, tt.supplierPartnerPlugin,
-			bot.WithServices([]bot.CMService{
-				{Name: botGenerated.TransportProductListServiceV3, Fee: 100},
-				{Name: botGenerated.TransportSearchServiceV3, Fee: 120},
-				{Name: botGenerated.ValidationServiceV2, Fee: 130},
-				{Name: botGenerated.MintServiceV2, Fee: 140},
-			}),
-		)
-	}()
+	tt.supplierPartnerPlugin = tt.CreatePartnerPlugin(ctx, t)
+	tt.supplierBot = tt.CreateBot(ctx, t, true, tt.supplierPartnerPlugin,
+		bot.WithServices([]bot.CMService{
+			{Name: botGenerated.TransportProductListServiceV3, Fee: 100},
+			{Name: botGenerated.TransportSearchServiceV3, Fee: 120},
+			{Name: botGenerated.ValidationServiceV2, Fee: 130},
+			{Name: botGenerated.MintServiceV2, Fee: 140},
+		}),
+	)
 
 	// bot without partnerPlugin and with rpc server (distributor)
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		tt.distributorBot = tt.CreateBot(ctx, t, true, nil)
-	}()
-
-	wg.Wait()
+	tt.distributorBot = tt.CreateBot(ctx, t, true, nil)
 }
 
 // Product list request with a modification filter set. It should only return one fitting result.


### PR DESCRIPTION
Tests are doing concurrent bots setup and this can sometimes fail because of nonces.
Each bot creates cm account and does some number of sequential txs using network admin key to create and fund CM account. We have nonce-tracking system in place to allow sending multiple txs at once for same address, but since there are parallel bots setup, parallel txs can arrive in any order and mismatch blockchain nonce expectations resulting in txs failure.

Removing this concurrent setup will add a few seconds to each test, but it is necessary step for now to maintain stable tests results. We can revisit this issue later with some keys pool implementation that will have minted nullUSD (erc-20 that is used for cheque fees) during CM contracts setup and CAM funds from genesis.