### PR TITLE
Expand instructions for macOS users; submodule configuration; olm configuration; gvm recommendation

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -168,6 +168,7 @@ Below are instructions for installing the `olm` library for Linux (Debian and Ub
 >  ```zsh
 > export PATH="/usr/bin:$PATH"
 > ```
+> Add the `export` line to your `~/.bashrc` (and put `source ~/.bashrc` in your `.bash_profile`) or `~/.zshrc` to make it permanent.
 
 1. **Update Homebrew:**
 
@@ -184,10 +185,13 @@ Below are instructions for installing the `olm` library for Linux (Debian and Ub
    brew install libolm
    ```
 3. **Install GNU grep**
+
+   MacOS ships with BSD `grep`, which does not support the `-P` flag required by the build scripts. Install GNU grep and add it to your PATH:
    ```bash
    brew install grep
    export PATH="/opt/homebrew/opt/grep/libexec/gnubin:$PATH"
    ```
+   Add the `export` line to your `~/.bashrc` (and put `source ~/.bashrc` in your `.bash_profile`) or `~/.zshrc` to make it permanent.
 
 ## Build
 
@@ -208,17 +212,22 @@ export CGO_CFLAGS="-I/opt/homebrew/include"
 export CGO_LDFLAGS="-L/opt/homebrew/lib"
 ./scripts/build.sh
 ```
+or run
+```bash
+set -a && source homebrew.env && set +a && ./scripts/build.sh
+```
+
 ##### Intel Macs
 ```bash
 export CGO_CFLAGS="-I/usr/local/include"
 export CGO_LDFLAGS="-L/usr/local/lib"
 ./scripts/build.sh
 ```
-
 or run
 ```bash
-set -a && source homebrew.env && set +a && ./scripts/build.sh
+set -a && source intel.env && set +a && ./scripts/build.sh
 ```
+
 ## Run
 
 ### Configuration

--- a/README.MD
+++ b/README.MD
@@ -10,6 +10,12 @@ Camino-Messenger-Bot is designed to facilitate communication through various mes
 
    Currently, the only concrete implementation is the `matrix-messenger`, which utilizes the [Mautrix Golang SDK](https://github.com/mautrix/go) for the Matrix client. Note that the `mautrix` dependency requires the `olm` C library during both build time and runtime.
 
+   To update camino-matrix-go submodule run:
+
+   ```bash
+   git submodule update --init --recursive
+   ```
+
 2. **Message Processor**
 
    - The Message Processor utilizes the Messenger to receive and process messages.
@@ -106,7 +112,7 @@ yarn hardhat account role:grant --role WITHDRAWER_ROLE --cm-account <0xCMAccount
 yarn hardhat account service:add --cm-account <0xCMAccount-address> --private-key <0xstatic-private-key-of-the-cm-account-wallet>  --service-name cmp.services.ping.v1.PingService --fee 1 --network columbus
 ```
 
-> [!IMPORTANT]  
+> [!IMPORTANT]
 > **After adding or removing the service(s)** it is necessary to **restart the bot**.
 
 
@@ -157,6 +163,9 @@ Below are instructions for installing the `olm` library for Linux (Debian and Ub
 
 #### macOS
 
+> [!IMPORTANT]
+> We recommend using **bash** terminal on macOS so that grep command is available to build.sh script.
+
 1. **Update Homebrew:**
 
    ```bash
@@ -175,10 +184,33 @@ Below are instructions for installing the `olm` library for Linux (Debian and Ub
 ## Build
 
 Use the provided build script to build the application. This will create a binary in the `./build` directory.
-Minimum required go version is 1.24
+Minimum required go version is written in [go.mod](go.mod)
+
+We recommend not using global go installation but rather installing [gvm](https://github.com/moovweb/gvm) for easier go version management. After installing go, run the following command
 
 ```bash
 ./scripts/build.sh
+```
+### Troubleshooting
+
+If on macOs you are getting
+```
+camino-matrix-go/crypto/olm/verification.go:6:11: fatal error: 'olm/olm.h' file not found
+    6 |  #include <olm/olm.h>
+      |           ^~~~~~~~~~~
+1 error generated.
+```
+
+It requires editing beginning of the file [camino-matrix-go/crypto/olm/account.go](camino-matrix-go/crypto/olm/account.go) :
+```go
+//go:build !goolm
+
+package olm
+
+// #cgo CFLAGS: -I/opt/homebrew/include
+// #cgo LDFLAGS: -L/opt/homebrew/lib -lolm -lstdc++
+// #include <olm/olm.h>
+import "C"
 ```
 
 ## Run

--- a/README.MD
+++ b/README.MD
@@ -146,11 +146,11 @@ The repository includes examples demonstrating the setup of gRPC servers and cli
 ### Operating systems Support
 > [!Note]
 > - Linux - Supported on **Ubuntu/Debian Linux** systems
-> - macOs - Only on **Apple Silicon** chip, on Intel chip it is not supported
+> - macOS - Only on **Apple Silicon** chip, on Intel chip it is not supported
 > - Windows - Not supported
 ### Install required `olm` library
 
-Below are instructions for installing the `olm` library for Linux (Debian and Ubuntu) and masOS (Apple Silicon):
+Below are instructions for installing the `olm` library for Linux (Debian and Ubuntu) and macOS (Apple Silicon):
 
 #### Linux (Debian/Ubuntu)
 

--- a/README.MD
+++ b/README.MD
@@ -165,7 +165,7 @@ Below are instructions for installing the `olm` library for Linux (Debian and Ub
 
 > [!IMPORTANT]
 >  Esure **grep** is available to your terminal by either opting for bash terminal or you might have to adjust $PATH in .zshrc
->  ```
+>  ```zsh
 > export PATH="/usr/bin:$PATH"
 > ```
 
@@ -191,31 +191,24 @@ Minimum required go version is written in [go.mod](go.mod)
 
 We recommend not using global go installation but rather installing [gvm](https://github.com/moovweb/gvm) for easier go version management. After installing go, run the following command
 
+#### Linux
 ```bash
 ./scripts/build.sh
 ```
-### Troubleshooting
 
-If on macOs you are getting
+#### macOS
+##### Apple Silicon Macs
+```bash
+export CGO_CFLAGS="-I/opt/homebrew/include"
+export CGO_LDFLAGS="-L/opt/homebrew/lib"
+./scripts/build.sh
 ```
-camino-matrix-go/crypto/olm/verification.go:6:11: fatal error: 'olm/olm.h' file not found
-    6 |  #include <olm/olm.h>
-      |           ^~~~~~~~~~~
-1 error generated.
+##### Intel Macs
+```bash
+export CGO_CFLAGS="-I/usr/local/include"
+export CGO_LDFLAGS="-L/usr/local/lib"
+./scripts/build.sh
 ```
-
-It requires editing beginning of the file [camino-matrix-go/crypto/olm/account.go](camino-matrix-go/crypto/olm/account.go) :
-```go
-//go:build !goolm
-
-package olm
-
-// #cgo CFLAGS: -I/opt/homebrew/include
-// #cgo LDFLAGS: -L/opt/homebrew/lib -lolm -lstdc++
-// #include <olm/olm.h>
-import "C"
-```
-
 ## Run
 
 ### Configuration

--- a/README.MD
+++ b/README.MD
@@ -143,10 +143,14 @@ The repository includes examples demonstrating the setup of gRPC servers and cli
 > If docker-compose.yml is used, please check volumes. The configuration filepath should be `cmb-config/config.yaml`. An example can be copied over from examples/config/ and modified.
 
 ## Getting Started
-
+### Operating systems Support
+> [!Note]
+> - Linux - Supported on **Ubuntu/Debian Linux** systems
+> - macOs - Only on **Apple Silicon** chip, on Intel chip it is not supported
+> - Windows - Not supported
 ### Install required `olm` library
 
-Below are instructions for installing the `olm` library for Linux (Debian and Ubuntu) and macOS:
+Below are instructions for installing the `olm` library for Linux (Debian and Ubuntu) and masOS (Apple Silicon):
 
 #### Linux (Debian/Ubuntu)
 
@@ -161,7 +165,7 @@ Below are instructions for installing the `olm` library for Linux (Debian and Ub
    sudo apt install -y libolm-dev
    ```
 
-#### macOS
+#### macOS (Apple Silicon)
 
 1. **Update Homebrew:**
 
@@ -193,12 +197,12 @@ Minimum required go version is written in [go.mod](go.mod)
 
 We recommend not using global go installation but rather installing [gvm](https://github.com/moovweb/gvm) for easier go version management. After installing go, run the following command
 
-#### Linux
+#### Linux (Debian/Ubuntu)
 ```bash
 ./scripts/build.sh
 ```
 
-#### macOS
+#### macOS (Apple Silicon)
 
 ```bash
 export CGO_CFLAGS="-I/opt/homebrew/include"

--- a/README.MD
+++ b/README.MD
@@ -189,7 +189,7 @@ Below are instructions for installing the `olm` library for Linux (Debian and Ub
    MacOS ships with BSD `grep`, which does not support the `-P` flag required by the build scripts. Install GNU grep and add it to your PATH:
    ```bash
    brew install grep
-   export PATH="/opt/homebrew/opt/grep/libexec/gnubin:$PATH"
+  export PATH="$(brew --prefix)/opt/grep/libexec/gnubin:$PATH"
    ```
    Add the `export` line to your `~/.bashrc` (and put `source ~/.bashrc` in your `.bash_profile`) or `~/.zshrc` to make it permanent.
 

--- a/README.MD
+++ b/README.MD
@@ -164,7 +164,10 @@ Below are instructions for installing the `olm` library for Linux (Debian and Ub
 #### macOS
 
 > [!IMPORTANT]
-> We recommend using **bash** terminal on macOS so that grep command is available to build.sh script.
+>  Esure **grep** is available to your terminal by either opting for bash terminal or you might have to adjust $PATH in .zshrc
+>  ```
+> export PATH="/usr/bin:$PATH"
+> ```
 
 1. **Update Homebrew:**
 

--- a/README.MD
+++ b/README.MD
@@ -163,13 +163,6 @@ Below are instructions for installing the `olm` library for Linux (Debian and Ub
 
 #### macOS
 
-> [!IMPORTANT]
->  Either opt for a **bash** terminal or you might have to adjust $PATH in .zshrc
->  ```zsh
-> export PATH="/usr/bin:$PATH"
-> ```
-> Add the `export` line to your `~/.bashrc` (and put `source ~/.bashrc` in your `.bash_profile`) or `~/.zshrc` to make it permanent.
-
 1. **Update Homebrew:**
 
    ```bash

--- a/README.MD
+++ b/README.MD
@@ -164,7 +164,7 @@ Below are instructions for installing the `olm` library for Linux (Debian and Ub
 #### macOS
 
 > [!IMPORTANT]
->  Either opt for a *bash* terminal or you might have to adjust $PATH in .zshrc
+>  Either opt for a **bash** terminal or you might have to adjust $PATH in .zshrc
 >  ```zsh
 > export PATH="/usr/bin:$PATH"
 > ```
@@ -182,6 +182,11 @@ Below are instructions for installing the `olm` library for Linux (Debian and Ub
 2. **Install libolm:**
    ```bash
    brew install libolm
+   ```
+3. **Install GNU grep**
+   ```bash
+   brew install grep
+   export PATH="/opt/homebrew/opt/grep/libexec/gnubin:$PATH"
    ```
 
 ## Build
@@ -208,6 +213,11 @@ export CGO_LDFLAGS="-L/opt/homebrew/lib"
 export CGO_CFLAGS="-I/usr/local/include"
 export CGO_LDFLAGS="-L/usr/local/lib"
 ./scripts/build.sh
+```
+
+or run
+```bash
+set -a && source homebrew.env && set +a && ./scripts/build.sh
 ```
 ## Run
 

--- a/README.MD
+++ b/README.MD
@@ -182,7 +182,7 @@ Below are instructions for installing the `olm` library for Linux (Debian and Ub
    MacOS ships with BSD `grep`, which does not support the `-P` flag required by the build scripts. Install GNU grep and add it to your PATH:
    ```bash
    brew install grep
-  export PATH="$(brew --prefix)/opt/grep/libexec/gnubin:$PATH"
+   export PATH="$(brew --prefix)/opt/grep/libexec/gnubin:$PATH"
    ```
    Add the `export` line to your `~/.bashrc` (and put `source ~/.bashrc` in your `.bash_profile`) or `~/.zshrc` to make it permanent.
 
@@ -199,7 +199,7 @@ We recommend not using global go installation but rather installing [gvm](https:
 ```
 
 #### macOS
-#### Apple Silicon Macs
+
 ```bash
 export CGO_CFLAGS="-I/opt/homebrew/include"
 export CGO_LDFLAGS="-L/opt/homebrew/lib"
@@ -208,17 +208,6 @@ export CGO_LDFLAGS="-L/opt/homebrew/lib"
 or run
 ```bash
 set -a && source homebrew.env && set +a && ./scripts/build.sh
-```
-
-#### Intel Macs
-```bash
-export CGO_CFLAGS="-I/usr/local/include"
-export CGO_LDFLAGS="-L/usr/local/lib"
-./scripts/build.sh
-```
-or run
-```bash
-set -a && source intel.env && set +a && ./scripts/build.sh
 ```
 
 ## Run

--- a/README.MD
+++ b/README.MD
@@ -206,7 +206,7 @@ We recommend not using global go installation but rather installing [gvm](https:
 ```
 
 #### macOS
-##### Apple Silicon Macs
+#### Apple Silicon Macs
 ```bash
 export CGO_CFLAGS="-I/opt/homebrew/include"
 export CGO_LDFLAGS="-L/opt/homebrew/lib"
@@ -217,7 +217,7 @@ or run
 set -a && source homebrew.env && set +a && ./scripts/build.sh
 ```
 
-##### Intel Macs
+#### Intel Macs
 ```bash
 export CGO_CFLAGS="-I/usr/local/include"
 export CGO_LDFLAGS="-L/usr/local/lib"

--- a/README.MD
+++ b/README.MD
@@ -164,7 +164,7 @@ Below are instructions for installing the `olm` library for Linux (Debian and Ub
 #### macOS
 
 > [!IMPORTANT]
->  Esure **grep** is available to your terminal by either opting for bash terminal or you might have to adjust $PATH in .zshrc
+>  Either opt for a *bash* terminal or you might have to adjust $PATH in .zshrc
 >  ```zsh
 > export PATH="/usr/bin:$PATH"
 > ```

--- a/homebrew.env
+++ b/homebrew.env
@@ -1,6 +1,3 @@
 ## Apple Silicon Macs
 CGO_CFLAGS="-I/opt/homebrew/include"
 CGO_LDFLAGS="-L/opt/homebrew/lib"
-## Intel Macs
-# CGO_CFLAGS="-I/usr/local/include"
-# CGO_LDFLAGS="-L/usr/local/lib"

--- a/homebrew.env
+++ b/homebrew.env
@@ -1,0 +1,6 @@
+## Apple Silicon Macs
+CGO_CFLAGS="-I/opt/homebrew/include"
+CGO_LDFLAGS="-L/opt/homebrew/lib"
+## Intel Macs
+# CGO_CFLAGS="-I/usr/local/include"
+# CGO_LDFLAGS="-L/usr/local/lib"

--- a/intel.env
+++ b/intel.env
@@ -1,0 +1,3 @@
+## Intel Macs
+CGO_CFLAGS="-I/usr/local/include"
+CGO_LDFLAGS="-L/usr/local/lib"

--- a/intel.env
+++ b/intel.env
@@ -1,3 +1,0 @@
-## Intel Macs
-CGO_CFLAGS="-I/usr/local/include"
-CGO_LDFLAGS="-L/usr/local/lib"


### PR DESCRIPTION
Expands instructions for:
- macOS users (olm lib, bash terminal, GNU grep, env variables)
- Submodule configuration
- gvm recommendation