### PR TITLE
Extending tests README.MD to cover macOS and goLand

### DIFF
--- a/examples/debug-launch-configs/goland_e2e.xml
+++ b/examples/debug-launch-configs/goland_e2e.xml
@@ -1,0 +1,19 @@
+<component name="ProjectRunConfigurationManager">
+    <configuration default="false" name="e2e" type="GoTestRunConfiguration" factoryName="Go Test">
+        <module name="camino-messenger-bot" />
+        <working_directory value="$PROJECT_DIR$" />
+        <go_parameters value="-tags=e2e" />
+        <parameters value="-test.parallel=4 -node=$PROJECT_DIR$/build/dependencies/caminogo/build/caminogo -matrix=$PROJECT_DIR$/build/dependencies/camino-conduit/build/camino-conduit -asb=$PROJECT_DIR$/build/dependencies/camino-matrix-app-service/build/camino-matrix-app-service/ -partner-plugin=$PROJECT_DIR$/build/pp-mock -cmb=$PROJECT_DIR$/build/camino-messenger-bot -tests-data-dir=/tmp/cmb-e2e --debug" />
+        <!-- envs for macOS:-->
+        <envs>
+            <env name="CGO_CFLAGS" value="-I/opt/homebrew/include" />
+            <env name="CGO_LDFLAGS" value="-L/opt/homebrew/lib" />
+        </envs>
+        <kind value="FILE" />
+        <package value="github.com/chain4travel/camino-messenger-bot/v12/tests/e2e" />
+        <directory value="$PROJECT_DIR$" />
+        <filePath value="$PROJECT_DIR$/tests/e2e/e2e_test.go" />
+        <framework value="gotest" />
+        <method v="2" />
+    </configuration>
+</component>

--- a/examples/debug-launch-configs/vs_code_launch.json
+++ b/examples/debug-launch-configs/vs_code_launch.json
@@ -26,7 +26,7 @@
 				"-cmb=${workspaceFolder}/build/camino-messenger-bot", // path to cmb binary
 				"-tests-data-dir=/tmp/cmb-e2e", // path to e2e tests data directory
 				"--filter=PingV1,TransportV3", // run specific tests. Will run all tests if not specified or empty
-				"--debug" // enables verbouse debug logging (including rpc requests and responses)
+				"--debug" // enables verbose debug logging (including rpc requests and responses)
 			]
 		}
 	]

--- a/examples/debug-launch-configs/vs_code_launch.json
+++ b/examples/debug-launch-configs/vs_code_launch.json
@@ -18,12 +18,15 @@
 				// "-existing-network-node-uri=http://127.0.0.1:19651", // local node endpoint, if need to use pre-existing local network
 				// "-existing-network-admin-key=PrivateKey-vmRQiZeXEXYMyJhEiqdC2z5JhuDbxL8ix9UVvjgMu2Er1NepE",
 				"-node=${workspaceFolder}/build/dependencies/caminogo/caminogo-v1.1.0/caminogo", // path to caminogo binary
+        		// "-node=${workspaceFolder}/build/dependencies/caminogo/build/caminogo", // path to caminogo binary if build locally
 				"-matrix=${workspaceFolder}/build/dependencies/camino-conduit/camino-conduit-v1.0.0/camino-conduit", // path to conduit binary
+				//"-matrix=${workspaceFolder}/build/dependencies/camino-conduit/build/camino-conduit", // path to conduit binary if build locally
+				// "-asb=${workspaceFolder}/build/dependencies/camino-matrix-app-service/build/camino-matrix-app-service/" // path to camino-matrix-app-service if built locally
 				"-partner-plugin=${workspaceFolder}/build/pp-mock", // path to partner-plugin binary
 				"-cmb=${workspaceFolder}/build/camino-messenger-bot", // path to cmb binary
 				"-tests-data-dir=/tmp/cmb-e2e", // path to e2e tests data directory
-				"-filter=PingV1,TransportV3", // run specific tests. Will run all tests if not specified or empty
-				"-debug" // enables verbouse debug logging (including rpc requests and responses)
+				"--filter=PingV1,TransportV3", // run specific tests. Will run all tests if not specified or empty
+				"--debug" // enables verbouse debug logging (including rpc requests and responses)
 			]
 		}
 	]

--- a/tests/e2e/README.MD
+++ b/tests/e2e/README.MD
@@ -10,12 +10,12 @@
 ### Dependencies
 
 #### Linux
-```
+```sh
 sudo apt install libclang-dev build-essential
 ```
 
 #### macOS
-```
+```sh
 brew install rust
 brew install llvm
 ```

--- a/tests/e2e/README.MD
+++ b/tests/e2e/README.MD
@@ -9,12 +9,12 @@
 
 ### Dependencies
 
-### Linux
+#### Linux
 ```
 sudo apt install libclang-dev build-essential
 ```
 
-### MacOS
+#### macOS
 ```
 brew install rust
 brew install llvm
@@ -40,7 +40,7 @@ or to download from the dev branch
 ```sh
 ./scripts/e2e.sh --clean --debug --caminogo "dev" --camino-conduit "dev" --asb "dev"
 ```
-Different dependencies might require different go versions or otherwise will fail to build. In this case, manually delete the dependency from `build/depencexies` folder, use gvm to adjust the version and re-run the script with just the dependency.
+Different dependencies might require different go versions or otherwise will fail to build. In this case, manually delete the dependency from `build/dependencies` folder, use gvm to adjust the version and re-run the script with just the dependency.
 ```
 gvm use go1.20
 ./scripts/e2e.sh --debug --caminogo "dev"
@@ -82,6 +82,6 @@ Example runConfiguration .xml file can be found [here](../../examples/debug-laun
 
 ## Troubleshooting
 The logs of tests are stored inside `/tmp/cmb-e2e` folder. 
-```
+```sh
 find /tmp/cmb-e2e -name "node-*.log" 2>/dev/null
 ```

--- a/tests/e2e/README.MD
+++ b/tests/e2e/README.MD
@@ -7,6 +7,19 @@
 
 ## Running tests
 
+### Dependencies
+
+### Linux
+```
+sudo apt install libclang-dev build-essential
+```
+
+### MacOS
+```
+brew install rust
+brew install llvm
+```
+
 ### Running from terminal
 
 The e2e.sh script does:
@@ -17,7 +30,24 @@ The e2e.sh script does:
 Usage:
 
 ```sh
-./scripts/e2e.sh [--clean] [--debug] [--filter "TESTNAME"] [--caminogo "CAMINOGO_VERSION"] [--camino-conduit "CAMINO_CONDUIT_VERSION"]
+./scripts/e2e.sh [--clean] [--debug] [--filter "TESTNAME"] [--caminogo "CAMINOGO_VERSION"] [--camino-conduit "CAMINO_CONDUIT_VERSION"] [--asb "ASB_VERSION"]
+```
+e.g.
+```sh
+./scripts/e2e.sh --clean --debug --caminogo "latest" --camino-conduit "latest" --asb "latest"
+```
+or to download from the dev branch
+```sh
+./scripts/e2e.sh --clean --debug --caminogo "dev" --camino-conduit "dev" --asb "dev"
+```
+Different dependencies might require different go versions or otherwise will fail to build. In this case, manually delete the dependency from `build/depencexies` folder, use gvm to adjust the version and re-run the script with just the dependency.
+```
+gvm use go1.20
+./scripts/e2e.sh --debug --caminogo "dev"
+```
+```
+gvm use go1.25
+./scripts/e2e.sh --debug --asb "dev"
 ```
 
 Flags (All optional):
@@ -27,7 +57,7 @@ Flags (All optional):
 * `--filter` Comma-separated list of top-level test names to execute instead of all e.g. "PingV1,AccommodationV3".
 * `--caminogo` Overrides the version to download; if unspecified, the latest version will be used.
 * `--camino-conduit` Overrides the version to download; if unspecified, the latest version will be used.
-
+* `--asb` Overrides the version to download; if unspecified, the latest version will be used.
 ### Running from VS Code
 
 For VS Code to work correctly with e2e, following settings must be added because of build constraints:
@@ -42,3 +72,16 @@ For VS Code to work correctly with e2e, following settings must be added because
 ```
 
 Example launch json debug config can be found [here](../../examples/debug-launch-configs/vs_code_launch.json).
+
+
+### Running from GoLand
+
+
+Example runConfiguration .xml file can be found [here](../../examples/debug-launch-configs/goland_e2e.xml)
+
+
+## Troubleshooting
+The logs of tests are stored inside `/tmp/cmb-e2e` folder. 
+```
+find /tmp/cmb-e2e -name "node-*.log" 2>/dev/null
+```


### PR DESCRIPTION
- added config file for running tests in debug mode from GoLand
- added required dependencies on macOS
- added Troubleshooting section